### PR TITLE
docs: add Railway template to Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ One click deploys SWE-AF + AgentField control plane + PostgreSQL. Set two enviro
 Once deployed, trigger a build:
 
 ```bash
-curl -X POST https://<your-app>.up.railway.app/api/v1/execute/async/swe-planner.build \
+curl -X POST https://<control-plane>.up.railway.app/api/v1/execute/async/swe-planner.build \
   -H "Content-Type: application/json" \
   -H "X-API-Key: this-is-a-secret" \
   -d '{"input": {"goal": "Add JWT auth", "repo_url": "https://github.com/user/my-repo"}}'


### PR DESCRIPTION
## Summary
- Adds a "Deploy with Railway (fastest)" subsection as the **first entry** in Quick Start
- Links to the published [`railway.com/deploy/swe-af`](https://railway.com/deploy/swe-af) template (deploys SWE-AF + AgentField control plane + PostgreSQL)
- Documents the two required env vars (`CLAUDE_CODE_OAUTH_TOKEN`, `GH_TOKEN`) and includes a trigger-build curl example
- Renames existing "1. Requirements" to "1. Requirements (local)" to clarify it's the manual path

## Test plan
- [ ] Verify Railway button SVG renders on GitHub
- [ ] Confirm deploy link resolves to https://railway.com/deploy/swe-af
- [ ] Check that existing Quick Start numbered steps still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)