### PR TITLE
fix: close silent failure modes in multi-repo execution routing

### DIFF
--- a/swe_af/execution/coding_loop.py
+++ b/swe_af/execution/coding_loop.py
@@ -515,6 +515,16 @@ async def run_coding_loop(
     target_repo = issue.get("target_repo", "")
     ws_manifest_dict = dag_state.workspace_manifest  # dict | None
 
+    # Warn if multi-repo issue is missing worktree_path (falling back to primary repo)
+    if ws_manifest_dict and not issue.get("worktree_path"):
+        if note_fn:
+            note_fn(
+                f"WARNING: issue '{issue_name}' has no worktree_path in multi-repo mode. "
+                f"Falling back to primary repo: {dag_state.repo_path}. "
+                f"target_repo='{target_repo}'",
+                tags=["coding_loop", "warning", "multi_repo_fallback"],
+            )
+
     # Extract guidance — determines execution path
     guidance = issue.get("guidance") or {}
     needs_deeper_qa = guidance.get("needs_deeper_qa", False)


### PR DESCRIPTION
## Summary
- Adds warnings in worktree setup when `target_repo` is unknown or `git_init` is incomplete (was silently falling back to no isolation)
- Adds warning in coding loop when a multi-repo issue has no `worktree_path` (falling back to primary repo silently)
- Persists `worktree_path` and `branch_name` back to `dag_state.all_issues` after worktree enrichment so checkpoints are resume-safe
- Routes integration tests to the correct repo when all merged branches belong to a single repo
- Replanner-generated issues now inherit `target_repo` from their dependencies in multi-repo builds

## Context
Analysis of a live multi-repo execution revealed 6 silent failure modes where agents could be pointed at the wrong repo directory without any warning. These all stem from the same pattern: optional fields defaulting to the primary repo path when enrichment fails.

## Test plan
- [x] Multi-repo integration tests: 24/25 pass (1 pre-existing async plugin issue)
- [x] DAG executor + coding loop multi-repo tests: 41/41 pass
- [x] Full test suite: 687 passed, 39 failed — identical to parent branch (zero regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)