### PR TITLE
Document multi-repository workspace support

### DIFF
--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -100,6 +100,48 @@ curl -X POST http://localhost:8080/api/v1/execute/async/swe-planner.build \
 
 Available roles: `pm`, `architect`, `tech_lead`, `sprint_planner`, `coder`, `qa`, `code_reviewer`, `qa_synthesizer`, `replan`, `retry_advisor`, `issue_writer`, `issue_advisor`, `verifier`, `git`, `merger`, `integration_tester`
 
+## Multi-Repo Builds
+
+SWE-AF supports coordinated work across multiple repositories in a single build. Pass `config.repos` as an array of repository objects, each with a `repo_url` (or `repo_path`) and a `role`. Single-repo builds remain backward compatible—just use `repo_url` or `repo_path` at the top level.
+
+### Complete Example: Primary App + Dependency
+
+```bash
+curl -X POST http://localhost:8080/api/v1/execute/async/swe-planner.build \
+  -H "Content-Type: application/json" \
+  -d '{
+    "input": {
+      "goal": "Add JWT auth across API and shared-lib",
+      "config": {
+        "repos": [
+          {
+            "repo_url": "https://github.com/org/main-app",
+            "role": "primary"
+          },
+          {
+            "repo_url": "https://github.com/org/shared-lib",
+            "role": "dependency"
+          }
+        ],
+        "runtime": "claude_code",
+        "models": {
+          "default": "sonnet"
+        }
+      }
+    }
+  }'
+```
+
+**Repository roles:**
+- `primary`: The main application being built. Changes here drive the build; failures block progress.
+- `dependency`: Libraries or services that may be modified to support the primary repo. Failures are captured but don't block primary build progress.
+
+### Use Cases
+
+- **Primary App + Shared Libraries**: Coordinate changes between a web application and its shared utilities/SDK.
+- **Monorepo Sub-Projects**: Define multiple repos in a monorepo structure and orchestrate cross-package changes.
+- **Microservices**: When a feature spans an API service and a worker service, define roles to manage interdependencies.
+
 ## Requirements for open_code Runtime
 
 1. `opencode` CLI installed and in PATH


### PR DESCRIPTION
## Summary

- Added Multi-Repository Workspace Support section to README.md with use cases and configuration examples
- Updated docs/SKILL.md with Multi-Repo Builds section including curl examples with config.repos payload
- Documented config.repos array format with repo_url and role (primary/dependency) attributes
- Maintained backward compatibility with existing single repo_url configuration

## Changes

- **README.md** (+59 lines): New section documenting multi-repository workspace support with single-repo backward compatibility example and multi-repo configuration with curl payload
- **docs/SKILL.md** (+42 lines): New Multi-Repo Builds section with complete curl example showing config.repos payload and role descriptions

## Test Plan

- [x] Verify documentation is accurate and reflects the multi-repository support functionality
- [x] Confirm backward compatibility example shows single repo_url usage unchanged
- [x] Validate curl examples in both files have correct config.repos payload structure
- [x] Check that all role definitions (primary/dependency) are clearly explained
- [x] Ensure no code changes were introduced (documentation only)

🤖 Built with [AgentField SWE-AF](https://github.com/Agent-Field/SWE-AF)

🔌 Powered by [AgentField](https://github.com/Agent-Field/agentfield)