### PR TITLE
feat: migrate planning agents to AgentField native .harness() (fixes #22)

### DIFF
--- a/swe_af/reasoners/pipeline.py
+++ b/swe_af/reasoners/pipeline.py
@@ -1,7 +1,7 @@
 """Internal reasoners for the SWE planning pipeline.
 
 Each reasoner wraps a single agent role (PM, Architect, Tech Lead, Sprint Planner)
-and uses AgentAI for actual AI execution. The @router.reasoner() decorator provides
+and uses router.harness() for actual AI execution. The @router.reasoner() decorator provides
 FastAPI endpoints, workflow DAG tracking, and observability via router.note().
 """
 

--- a/swe_af/reasoners/pipeline.py
+++ b/swe_af/reasoners/pipeline.py
@@ -14,8 +14,6 @@ from pathlib import Path
 
 from pydantic import BaseModel
 
-from swe_af.agent_ai import AgentAI, AgentAIConfig
-from swe_af.agent_ai.types import Tool
 from swe_af.execution.schemas import DEFAULT_AGENT_MAX_TURNS
 from swe_af.reasoners.schemas import (
     Architecture,
@@ -30,6 +28,7 @@ from . import router
 # ---------------------------------------------------------------------------
 # Pure helpers (NOT reasoners)
 # ---------------------------------------------------------------------------
+
 
 def _ensure_paths(base: str) -> dict[str, str]:
     """Create artifact directories under *base* and return a path map."""
@@ -89,9 +88,7 @@ def _compute_levels(issues: list[dict]) -> list[list[str]]:
     return levels
 
 
-def _validate_file_conflicts(
-    issues: list[dict], levels: list[list[str]]
-) -> list[dict]:
+def _validate_file_conflicts(issues: list[dict], levels: list[list[str]]) -> list[dict]:
     """Detect file conflicts between issues scheduled at the same parallel level.
 
     For each level, collects ``files_to_modify`` and ``files_to_create`` across
@@ -155,6 +152,7 @@ def _assign_sequence_numbers(issues: list[dict], levels: list[list[str]]) -> lis
 # Reasoners
 # ---------------------------------------------------------------------------
 
+
 @router.reasoner()
 async def run_product_manager(
     goal: str,
@@ -172,26 +170,19 @@ async def run_product_manager(
 
     base = os.path.join(os.path.abspath(repo_path), artifacts_dir)
     paths = _ensure_paths(base)
-    log_path = os.path.join(base, "logs", "product_manager.jsonl")
-
-    ai = AgentAI(AgentAIConfig(
-        model=model,
-        provider=ai_provider,
-        cwd=repo_path,
-        max_turns=max_turns,
-        allowed_tools=[Tool.READ, Tool.GLOB, Tool.GREP, Tool.BASH],
-        permission_mode=permission_mode or None,
-    ))
 
     from swe_af.prompts.product_manager import product_manager_prompts, pm_task_prompt  # noqa: PLC0415
     from swe_af.execution.schemas import WorkspaceManifest  # noqa: PLC0415
+
     system_prompt, _ = product_manager_prompts(
         goal=goal,
         repo_path=repo_path,
         prd_path=paths["prd"],
         additional_context=additional_context,
     )
-    ws_manifest = WorkspaceManifest(**workspace_manifest) if workspace_manifest else None
+    ws_manifest = (
+        WorkspaceManifest(**workspace_manifest) if workspace_manifest else None
+    )
     task_prompt = pm_task_prompt(
         goal=goal,
         repo_path=repo_path,
@@ -199,17 +190,23 @@ async def run_product_manager(
         additional_context=additional_context,
         workspace_manifest=ws_manifest,
     )
-    response = await ai.run(
-        task_prompt,
+    provider = "claude-code" if ai_provider == "claude" else ai_provider
+    result = await router.harness(
+        prompt=task_prompt,
+        schema=PRD,
+        provider=provider,
+        model=model,
+        max_turns=max_turns,
+        tools=["Read", "Glob", "Grep", "Bash"],
+        permission_mode=permission_mode or None,
         system_prompt=system_prompt,
-        output_schema=PRD,
-        log_file=log_path,
+        cwd=repo_path,
     )
-    if response.parsed is None:
+    if result.parsed is None:
         raise RuntimeError("Product manager failed to produce a valid PRD")
 
     router.note("PM complete", tags=["pm", "complete"])
-    return response.parsed.model_dump()
+    return result.parsed.model_dump()
 
 
 @router.reasoner()
@@ -229,20 +226,11 @@ async def run_architect(
 
     base = os.path.join(os.path.abspath(repo_path), artifacts_dir)
     paths = _ensure_paths(base)
-    log_path = os.path.join(base, "logs", "architect.jsonl")
-
-    ai = AgentAI(AgentAIConfig(
-        model=model,
-        provider=ai_provider,
-        cwd=repo_path,
-        max_turns=max_turns,
-        allowed_tools=[Tool.READ, Tool.WRITE, Tool.GLOB, Tool.GREP, Tool.BASH],
-        permission_mode=permission_mode or None,
-    ))
 
     prd_obj = PRD(**prd)
     from swe_af.prompts.architect import architect_prompts, architect_task_prompt  # noqa: PLC0415
     from swe_af.execution.schemas import WorkspaceManifest  # noqa: PLC0415
+
     system_prompt, _ = architect_prompts(
         prd=prd_obj,
         repo_path=repo_path,
@@ -250,7 +238,9 @@ async def run_architect(
         architecture_path=paths["architecture"],
         feedback=feedback or None,
     )
-    ws_manifest = WorkspaceManifest(**workspace_manifest) if workspace_manifest else None
+    ws_manifest = (
+        WorkspaceManifest(**workspace_manifest) if workspace_manifest else None
+    )
     task_prompt = architect_task_prompt(
         prd=prd_obj,
         repo_path=repo_path,
@@ -259,17 +249,23 @@ async def run_architect(
         feedback=feedback or None,
         workspace_manifest=ws_manifest,
     )
-    response = await ai.run(
-        task_prompt,
+    provider = "claude-code" if ai_provider == "claude" else ai_provider
+    result = await router.harness(
+        prompt=task_prompt,
+        schema=Architecture,
+        provider=provider,
+        model=model,
+        max_turns=max_turns,
+        tools=["Read", "Write", "Glob", "Grep", "Bash"],
+        permission_mode=permission_mode or None,
         system_prompt=system_prompt,
-        output_schema=Architecture,
-        log_file=log_path,
+        cwd=repo_path,
     )
-    if response.parsed is None:
+    if result.parsed is None:
         raise RuntimeError("Architect failed to produce a valid architecture")
 
     router.note("Architect complete", tags=["architect", "complete"])
-    return response.parsed.model_dump()
+    return result.parsed.model_dump()
 
 
 @router.reasoner()
@@ -289,41 +285,40 @@ async def run_tech_lead(
 
     base = os.path.join(os.path.abspath(repo_path), artifacts_dir)
     paths = _ensure_paths(base)
-    log_path = os.path.join(base, "logs", "tech_lead.jsonl")
-
-    ai = AgentAI(AgentAIConfig(
-        model=model,
-        provider=ai_provider,
-        cwd=repo_path,
-        max_turns=max_turns,
-        allowed_tools=[Tool.READ, Tool.GLOB, Tool.GREP],
-        permission_mode=permission_mode or None,
-    ))
 
     from swe_af.prompts.tech_lead import tech_lead_prompts, tech_lead_task_prompt  # noqa: PLC0415
     from swe_af.execution.schemas import WorkspaceManifest  # noqa: PLC0415
+
     system_prompt, _ = tech_lead_prompts(
         prd_path=paths["prd"],
         architecture_path=paths["architecture"],
         revision_number=revision_number,
     )
-    ws_manifest = WorkspaceManifest(**workspace_manifest) if workspace_manifest else None
+    ws_manifest = (
+        WorkspaceManifest(**workspace_manifest) if workspace_manifest else None
+    )
     task_prompt = tech_lead_task_prompt(
         prd_path=paths["prd"],
         architecture_path=paths["architecture"],
         revision_number=revision_number,
         workspace_manifest=ws_manifest,
     )
-    response = await ai.run(
-        task_prompt,
+    provider = "claude-code" if ai_provider == "claude" else ai_provider
+    result = await router.harness(
+        prompt=task_prompt,
+        schema=ReviewResult,
+        provider=provider,
+        model=model,
+        max_turns=max_turns,
+        tools=["Read", "Glob", "Grep"],
+        permission_mode=permission_mode or None,
         system_prompt=system_prompt,
-        output_schema=ReviewResult,
-        log_file=log_path,
+        cwd=repo_path,
     )
-    if response.parsed is None:
+    if result.parsed is None:
         raise RuntimeError("Tech lead failed to produce a valid review")
 
-    review = response.parsed.model_dump()
+    review = result.parsed.model_dump()
     review_json_path = os.path.join(base, "plan", "review.json")
     with open(review_json_path, "w") as f:
         json.dump(review, f, indent=2, default=str)
@@ -356,21 +351,15 @@ async def run_sprint_planner(
 
     base = os.path.join(os.path.abspath(repo_path), artifacts_dir)
     paths = _ensure_paths(base)
-    log_path = os.path.join(base, "logs", "sprint_planner.jsonl")
-
-    ai = AgentAI(AgentAIConfig(
-        model=model,
-        provider=ai_provider,
-        cwd=repo_path,
-        max_turns=max_turns,
-        allowed_tools=[Tool.READ, Tool.GLOB, Tool.GREP],
-        permission_mode=permission_mode or None,
-    ))
 
     prd_obj = PRD(**prd)
     arch_obj = Architecture(**architecture)
-    from swe_af.prompts.sprint_planner import sprint_planner_prompts, sprint_planner_task_prompt  # noqa: PLC0415
+    from swe_af.prompts.sprint_planner import (
+        sprint_planner_prompts,
+        sprint_planner_task_prompt,
+    )  # noqa: PLC0415
     from swe_af.execution.schemas import WorkspaceManifest  # noqa: PLC0415
+
     system_prompt, _ = sprint_planner_prompts(
         prd=prd_obj,
         architecture=arch_obj,
@@ -378,7 +367,9 @@ async def run_sprint_planner(
         prd_path=paths["prd"],
         architecture_path=paths["architecture"],
     )
-    ws_manifest = WorkspaceManifest(**workspace_manifest) if workspace_manifest else None
+    ws_manifest = (
+        WorkspaceManifest(**workspace_manifest) if workspace_manifest else None
+    )
     task_prompt = sprint_planner_task_prompt(
         goal=prd_obj.validated_description,
         prd=prd_obj,
@@ -388,17 +379,23 @@ async def run_sprint_planner(
         prd_path=paths["prd"],
         architecture_path=paths["architecture"],
     )
-    response = await ai.run(
-        task_prompt,
+    provider = "claude-code" if ai_provider == "claude" else ai_provider
+    result = await router.harness(
+        prompt=task_prompt,
+        schema=SprintPlanOutput,
+        provider=provider,
+        model=model,
+        max_turns=max_turns,
+        tools=["Read", "Glob", "Grep"],
+        permission_mode=permission_mode or None,
         system_prompt=system_prompt,
-        output_schema=SprintPlanOutput,
-        log_file=log_path,
+        cwd=repo_path,
     )
-    if response.parsed is None:
+    if result.parsed is None:
         raise RuntimeError("Sprint planner failed to produce valid issues")
 
     router.note("Sprint Planner complete", tags=["sprint_planner", "complete"])
     return {
-        "issues": [issue.model_dump() for issue in response.parsed.issues],
-        "rationale": response.parsed.rationale,
+        "issues": [issue.model_dump() for issue in result.parsed.issues],
+        "rationale": result.parsed.rationale,
     }


### PR DESCRIPTION
## Summary
Migrates all 4 planning agents in `swe_af/reasoners/pipeline.py` from custom `AgentAI` wrapper to AgentField native `router.harness()`.

## Changes
- **`run_product_manager`**: `AgentAI` → `router.harness()` with tools `["Read", "Glob", "Grep", "Bash"]`
- **`run_architect`**: `AgentAI` → `router.harness()` with tools `["Read", "Write", "Glob", "Grep", "Bash"]`
- **`run_tech_lead`**: `AgentAI` → `router.harness()` with tools `["Read", "Glob", "Grep"]`
- **`run_sprint_planner`**: `AgentAI` → `router.harness()` with tools `["Read", "Glob", "Grep"]`

## Details
- Removed `AgentAI`, `AgentAIConfig`, `Tool` imports
- Removed all `log_path`/`log_file=` parameters (not supported by `router.harness()`)
- Added provider mapping: `"claude"` → `"claude-code"`
- Preserved all error handling, fallback behavior, and `RuntimeError` raises
- Follows exact pattern from already-migrated `fast/planner.py`

Fixes #22