### PR TITLE
Honor SWE_DEFAULT_RUNTIME env var for the default runtime

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,12 @@ GH_TOKEN=ghp_...
 
 # --- Optional: Model configuration ---
 
+# Default runtime when callers don't pass a `runtime` in the request config.
+# Lets the deployer pick the runtime once instead of every caller threading
+# a config through. Falls back to claude_code if unset; an invalid value is
+# logged as a warning and ignored.
+# SWE_DEFAULT_RUNTIME=claude_code  # or: open_code
+
 # Runtime/model selection is configured via API request config (V2):
 # {
 #   "runtime": "claude_code" | "open_code",

--- a/README.md
+++ b/README.md
@@ -576,7 +576,7 @@ Pass `config` to `build` or `execute`. Full schema: [`swe_af/execution/schemas.p
 
 | Key                       | Default         | Description                                           |
 | ------------------------- | --------------- | ----------------------------------------------------- |
-| `runtime`                 | `"claude_code"` | Model runtime: `"claude_code"` or `"open_code"`       |
+| `runtime`                 | `"claude_code"` | Model runtime: `"claude_code"` or `"open_code"`. The default also honors the `SWE_DEFAULT_RUNTIME` env var when no `runtime` is passed in `config` — set it on the deployment so callers don't need to plumb a config through. |
 | `models`                  | `null`          | Flat role-model map (`default` + role keys below)     |
 | `max_coding_iterations`   | `5`             | Inner-loop retry budget                               |
 | `max_advisor_invocations` | `2`             | Middle-loop advisor budget                            |

--- a/swe_af/execution/schemas.py
+++ b/swe_af/execution/schemas.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+import os
 import re
 from enum import Enum
 from typing import Any, Literal
@@ -9,6 +11,7 @@ from typing import Any, Literal
 from pydantic import (
     BaseModel,
     ConfigDict,
+    Field,
     PrivateAttr,
     field_validator,
     model_validator,
@@ -520,6 +523,26 @@ def _runtime_to_provider(runtime: str) -> Literal["claude", "opencode"]:
     )
 
 
+def _default_runtime() -> Literal["claude_code", "open_code"]:
+    """Default runtime, honoring the ``SWE_DEFAULT_RUNTIME`` env var.
+
+    Lets the deployer pick the runtime without every caller having to pass
+    a config. Falls back to ``claude_code`` when unset; logs and falls back
+    when the env value isn't a valid runtime.
+    """
+    value = os.getenv("SWE_DEFAULT_RUNTIME", "").strip()
+    if not value:
+        return "claude_code"
+    if value in RUNTIME_VALUES:
+        return value  # type: ignore[return-value]
+    logging.getLogger(__name__).warning(
+        "SWE_DEFAULT_RUNTIME=%r is not one of %s; falling back to claude_code",
+        value,
+        RUNTIME_VALUES,
+    )
+    return "claude_code"
+
+
 def _legacy_hint_for_model_key(key: str) -> str:
     if key in _LEGACY_GROUP_EQUIVALENTS:
         return _LEGACY_GROUP_EQUIVALENTS[key]
@@ -624,7 +647,7 @@ class BuildConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    runtime: Literal["claude_code", "open_code"] = "claude_code"
+    runtime: Literal["claude_code", "open_code"] = Field(default_factory=_default_runtime)
     models: dict[str, str] | None = None
 
     max_review_iterations: int = 2
@@ -805,7 +828,7 @@ class ExecutionConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    runtime: Literal["claude_code", "open_code"] = "claude_code"
+    runtime: Literal["claude_code", "open_code"] = Field(default_factory=_default_runtime)
     models: dict[str, str] | None = None
     _resolved_models: dict[str, str] = PrivateAttr(default_factory=dict)
 

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import os
 import unittest
+from unittest import mock
 
 from swe_af.execution.schemas import (
     ALL_MODEL_FIELDS,
@@ -99,6 +101,39 @@ class TestBuildConfig(unittest.TestCase):
             BuildConfig(models={"planning": "opus"})
         self.assertIn("planning", str(ctx.exception))
         self.assertIn("models.pm", str(ctx.exception))
+
+
+class TestDefaultRuntimeFromEnv(unittest.TestCase):
+    """`SWE_DEFAULT_RUNTIME` lets the deployer pick runtime without callers
+    threading a config through. Callers that DO pass `runtime=...` win."""
+
+    def test_env_open_code_overrides_default(self) -> None:
+        with mock.patch.dict(os.environ, {"SWE_DEFAULT_RUNTIME": "open_code"}):
+            self.assertEqual(BuildConfig().runtime, "open_code")
+            self.assertEqual(ExecutionConfig().runtime, "open_code")
+
+    def test_env_claude_code_overrides_default(self) -> None:
+        with mock.patch.dict(os.environ, {"SWE_DEFAULT_RUNTIME": "claude_code"}):
+            self.assertEqual(BuildConfig().runtime, "claude_code")
+            self.assertEqual(ExecutionConfig().runtime, "claude_code")
+
+    def test_explicit_runtime_beats_env(self) -> None:
+        with mock.patch.dict(os.environ, {"SWE_DEFAULT_RUNTIME": "open_code"}):
+            self.assertEqual(BuildConfig(runtime="claude_code").runtime, "claude_code")
+            self.assertEqual(ExecutionConfig(runtime="claude_code").runtime, "claude_code")
+
+    def test_invalid_env_falls_back_to_claude_code(self) -> None:
+        with mock.patch.dict(os.environ, {"SWE_DEFAULT_RUNTIME": "bogus_runtime"}):
+            self.assertEqual(BuildConfig().runtime, "claude_code")
+
+    def test_unset_env_uses_claude_code(self) -> None:
+        env = {k: v for k, v in os.environ.items() if k != "SWE_DEFAULT_RUNTIME"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            self.assertEqual(BuildConfig().runtime, "claude_code")
+
+    def test_empty_env_uses_claude_code(self) -> None:
+        with mock.patch.dict(os.environ, {"SWE_DEFAULT_RUNTIME": ""}):
+            self.assertEqual(BuildConfig().runtime, "claude_code")
 
 
 class TestExecutionConfig(unittest.TestCase):


### PR DESCRIPTION
## Summary

`BuildConfig` and `ExecutionConfig` now read the default runtime from a new `SWE_DEFAULT_RUNTIME` env var when no `runtime` is passed in the request config. The deployer picks `claude_code` vs `open_code` once on the service rather than forcing every caller to thread a config through.

## Why

A caller that doesn't pass a config — which is the realistic case for cross-agent `app.call` invocations — falls through to `BuildConfig`'s hardcoded default of `claude_code`. On a deployment configured for OpenRouter (no `CLAUDE_CODE_OAUTH_TOKEN`, only `OPENROUTER_API_KEY`), the Claude Code harness exits with code 1 on its first invocation and the build fails as `Product manager failed to produce a valid PRD`.

This is exactly the failure mode documented under [`Product manager failed to produce a valid PRD with open_code runtime`](docs/deployment.md) — but the original cause for that diagnosis was an opencode CLI v1.4 compatibility issue, fixed in `agentfield 0.1.67+`. With that fix in place (we're at 0.1.72+), the *new* path to the same error message is: deployer wanted `open_code` but the runtime defaulted to `claude_code` because no caller knew to pass `runtime` in the config. This PR closes that gap.

## Behavior

- `SWE_DEFAULT_RUNTIME` unset / empty → `claude_code` (preserves current default).
- `SWE_DEFAULT_RUNTIME=open_code` or `SWE_DEFAULT_RUNTIME=claude_code` → that value becomes the default.
- Invalid value (e.g. `SWE_DEFAULT_RUNTIME=bogus`) → logged warning, falls back to `claude_code`.
- An explicit `runtime` in the request config still wins over the env var (callers retain full control).

Both `BuildConfig` and `ExecutionConfig` use the same env-driven default factory, so `to_execution_config_dict` round-trips correctly and a no-config call from `build()` produces an `ExecutionConfig` matching the env.

## Test plan

- [x] `tests/test_model_config.py::TestDefaultRuntimeFromEnv` — 6 new cases:
  - env=`open_code` overrides default for both configs
  - env=`claude_code` works
  - explicit `runtime=...` beats env
  - invalid env value falls back to `claude_code`
  - unset env uses `claude_code`
  - empty env uses `claude_code`
- [x] All existing 125 tests in `tests/test_model_config.py`, `tests/fast/test_schemas.py`, `tests/test_multi_repo_schemas.py` still pass.
- [ ] Deploy: set `SWE_DEFAULT_RUNTIME=open_code` on the SWE-AF Railway service; trigger a build; PRD step uses opencode + OpenRouter end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)