### PR TITLE
chore(deps): bump agentfield to >=0.1.73

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Autonomous SWE agent node for AgentField"
 requires-python = ">=3.12"
 dependencies = [
-    "agentfield>=0.1.9",
+    "agentfield>=0.1.73",
     "pydantic>=2.0",
     # Compatibility pin: newer SDK builds have surfaced
     # "Unknown message type: rate_limit_event" during streaming.

--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -2,6 +2,6 @@
 #
 # Same runtime dependencies as requirements.txt.
 
-agentfield>=0.1.67
+agentfield>=0.1.73
 pydantic>=2.0
 claude-agent-sdk==0.1.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@
 #
 # Install: python -m pip install -r requirements.txt
 
-agentfield>=0.1.67
+agentfield>=0.1.73
 pydantic>=2.0
 claude-agent-sdk==0.1.20


### PR DESCRIPTION
## Summary

Pulls in the `OpenCodeProvider` stderr-error-detection fix released in `agentfield 0.1.73` (companion PR `Agent-Field/agentfield#525`).

Without this bump the Docker build keeps resolving to whatever older `agentfield` got cached when `0.1.67` was first pinned, so the SWE-AF model-prefix fix from #55 lands in production but the harness still silently swallows opencode `Model not found` / `AuthenticationError` / `APIError` cases that exit 0. Operators would once again see "Product manager failed to produce a valid PRD" with the migration prelude in stderr and no clue what's wrong.

## Changes

- `requirements-docker.txt` — `agentfield>=0.1.67` → `agentfield>=0.1.73`
- `requirements.txt` — same bump (bare-metal install path)
- `pyproject.toml` — was lagging at `agentfield>=0.1.9`, bumped to match

## Verified

`agentfield-0.1.73-py3-none-any.whl` ships both `_extract_opencode_error` and `_OPENCODE_STDERR_ERROR_PATTERNS`:

```bash
$ pip download agentfield==0.1.73 --no-deps
$ python -c "import zipfile, glob; w = glob.glob('agentfield-*.whl')[0]; \
  src = zipfile.ZipFile(w).read('agentfield/harness/providers/opencode.py').decode(); \
  print('fix present:', '_extract_opencode_error' in src)"
fix present: True
```

## Test plan

- [x] `pip download agentfield==0.1.73` succeeds and contains the fix.
- [ ] After merge: redeploy SWE-AF on Railway, re-trigger `github buddy implement` on `Agent-Field/github-buddy#22`, confirm any future opencode error surfaces with the actual cause in Railway logs (not buried under the SQLite migration prelude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)