### PR TITLE
feat: post-PR CI gate — watch, legitimate-fix, promote to ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,6 +512,25 @@ Requirements:
 - `GH_TOKEN` in `.env` with `repo` scope
 - Repo access for that token
 
+### Post-PR CI gate
+
+After SWE-AF pushes the integration branch and opens a draft PR, it watches
+GitHub Actions on that PR until checks are conclusive. If they fail, a
+bounded fix-and-repush loop runs an agent that is explicitly forbidden from
+silencing tests (no `pytest.skip`, no `xfail`, no commenting tests out, no
+loosening assertions) — it must produce a legitimate fix in the production
+code and push a new commit. When CI is green, the PR is promoted from draft
+to ready-for-review via `gh pr ready`.
+
+Configuration on `BuildConfig`:
+
+| Field | Default | Purpose |
+|---|---|---|
+| `check_ci` | `true` | Run the post-PR CI gate. Set `false` to return immediately after the draft PR is created. |
+| `max_ci_fix_cycles` | `2` | Cap on watch → fix → repush iterations after the initial push. |
+| `ci_wait_seconds` | `1500` | Wall-clock cap per `gh pr checks` watch (25 min). |
+| `ci_poll_seconds` | `30` | Poll interval for `gh pr checks`. |
+
 ## API Reference
 
 <details>

--- a/swe_af/app.py
+++ b/swe_af/app.py
@@ -18,6 +18,7 @@ from swe_af.reasoners.pipeline import _assign_sequence_numbers, _compute_levels,
 from swe_af.reasoners.schemas import PlanResult, ReviewResult
 
 from agentfield import Agent
+from swe_af.execution.ci_gate import mark_pr_ready
 from swe_af.execution.envelope import unwrap_call_result as _unwrap
 from swe_af.execution.schemas import (
     BuildConfig,
@@ -167,6 +168,136 @@ async def _clone_repos(
         repos=repos,
         primary_repo_name=primary_repo_name,
     )
+
+
+async def _run_ci_gate(
+    *,
+    repo_path: str,
+    pr_number: int,
+    pr_url: str,
+    integration_branch: str,
+    base_branch: str,
+    cfg: BuildConfig,
+    resolved_models: dict,
+    goal: str,
+    completed_issues: list[dict],
+) -> dict:
+    """Watch CI on the freshly-pushed draft PR; fix-and-repush if it fails;
+    promote to ready-for-review when green.
+
+    Returns a summary dict the build can attach to its response. Bounded by
+    ``cfg.max_ci_fix_cycles`` and ``cfg.ci_wait_seconds`` per watch.
+    """
+    attempts: list[dict] = []
+    last_watch: dict | None = None
+
+    for cycle in range(cfg.max_ci_fix_cycles + 1):
+        app.note(
+            f"CI gate: watch cycle {cycle + 1} for PR #{pr_number}",
+            tags=["ci_gate", "watch"],
+        )
+        watch = _unwrap(await app.call(
+            f"{NODE_ID}.run_ci_watcher",
+            repo_path=repo_path,
+            pr_number=pr_number,
+            wait_seconds=cfg.ci_wait_seconds,
+            poll_seconds=cfg.ci_poll_seconds,
+        ), "run_ci_watcher")
+        last_watch = watch
+        status = watch.get("status", "error")
+
+        if status in ("passed", "no_checks"):
+            ok, msg = mark_pr_ready(repo_path=repo_path, pr_number=pr_number)
+            app.note(
+                f"CI gate: {status} → {msg}",
+                tags=["ci_gate", "ready" if ok else "ready_failed"],
+            )
+            return {
+                "final_status": "passed" if status == "passed" else "no_checks",
+                "promoted_to_ready": ok,
+                "promote_message": msg,
+                "fix_attempts": attempts,
+                "watch": watch,
+            }
+
+        if status in ("timed_out", "error"):
+            app.note(
+                f"CI gate: {status} — leaving PR in draft. {watch.get('summary', '')}",
+                tags=["ci_gate", status],
+            )
+            return {
+                "final_status": status,
+                "promoted_to_ready": False,
+                "promote_message": "",
+                "fix_attempts": attempts,
+                "watch": watch,
+            }
+
+        # status == "failed"
+        if cycle >= cfg.max_ci_fix_cycles:
+            app.note(
+                f"CI gate: exhausted {cfg.max_ci_fix_cycles} fix cycle(s) — "
+                "leaving PR in draft",
+                tags=["ci_gate", "exhausted"],
+            )
+            return {
+                "final_status": "failed_exhausted",
+                "promoted_to_ready": False,
+                "promote_message": "",
+                "fix_attempts": attempts,
+                "watch": watch,
+            }
+
+        failed_checks = watch.get("failed_checks", [])
+        app.note(
+            f"CI gate: fix attempt {cycle + 1}/{cfg.max_ci_fix_cycles} — "
+            f"{len(failed_checks)} failing check(s)",
+            tags=["ci_gate", "fix"],
+        )
+        fix = _unwrap(await app.call(
+            f"{NODE_ID}.run_ci_fixer",
+            repo_path=repo_path,
+            pr_number=pr_number,
+            pr_url=pr_url,
+            integration_branch=integration_branch,
+            base_branch=base_branch,
+            failed_checks=failed_checks,
+            iteration=cycle + 1,
+            max_iterations=cfg.max_ci_fix_cycles,
+            goal=goal,
+            completed_issues=completed_issues,
+            previous_attempts=attempts,
+            model=resolved_models.get("ci_fixer_model", resolved_models.get("coder_model", "")),
+            permission_mode=cfg.permission_mode,
+            ai_provider=cfg.ai_provider,
+        ), "run_ci_fixer")
+        attempts.append(fix)
+
+        if not fix.get("pushed"):
+            app.note(
+                f"CI gate: fixer did not push ({fix.get('summary', 'no summary')}) — "
+                "leaving PR in draft",
+                tags=["ci_gate", "fixer_no_push"],
+            )
+            return {
+                "final_status": "fixer_gave_up",
+                "promoted_to_ready": False,
+                "promote_message": "",
+                "fix_attempts": attempts,
+                "watch": watch,
+            }
+
+        # Pushed — loop back and watch again. GitHub may take a moment to
+        # register the new run; watcher's poll_seconds covers that.
+
+    # Loop fell through (shouldn't happen because the failed branch returns).
+    return {
+        "final_status": "loop_exhausted",
+        "promoted_to_ready": False,
+        "promote_message": "",
+        "fix_attempts": attempts,
+        "watch": last_watch or {},
+    }
 
 
 @app.reasoner()
@@ -622,6 +753,7 @@ async def build(
 
     # 4. PUSH & DRAFT PR (if repo has a remote and PR creation is enabled)
     pr_results: list[RepoPRResult] = []
+    ci_gate_results: list[dict] = []
     build_summary = (
         f"{'Success' if success else 'Partial'}: {completed}/{total} issues completed"
         + (f", verification: {verification.get('summary', '')}" if verification else "")
@@ -676,6 +808,25 @@ async def build(
                         f"Draft PR created for {ws_repo.repo_name}: {pr_r.get('pr_url')}",
                         tags=["build", "github_pr", "complete"],
                     )
+                    if cfg.check_ci and pr_r.get("pr_number"):
+                        gate = await _run_ci_gate(
+                            repo_path=ws_repo.absolute_path,
+                            pr_number=pr_r.get("pr_number", 0),
+                            pr_url=pr_r.get("pr_url", ""),
+                            integration_branch=repo_integration_branch,
+                            base_branch=repo_base_branch,
+                            cfg=cfg,
+                            resolved_models=resolved,
+                            goal=goal,
+                            completed_issues=[
+                                r for r in dag_result.get("completed_issues", [])
+                                if not r.get("repo_name") or r.get("repo_name") == ws_repo.repo_name
+                            ],
+                        )
+                        ci_gate_results.append({
+                            "repo_name": ws_repo.repo_name,
+                            **gate,
+                        })
             except Exception as e:
                 pr_results.append(RepoPRResult(
                     repo_name=ws_repo.repo_name,
@@ -770,6 +921,25 @@ async def build(
                         pr_url=pr_url,
                         pr_number=pr_result.get("pr_number", 0),
                     ))
+                    if cfg.check_ci and pr_result.get("pr_number"):
+                        gate = await _run_ci_gate(
+                            repo_path=repo_path,
+                            pr_number=pr_result.get("pr_number", 0),
+                            pr_url=pr_url,
+                            integration_branch=git_config["integration_branch"],
+                            base_branch=base_branch,
+                            cfg=cfg,
+                            resolved_models=resolved,
+                            goal=goal,
+                            completed_issues=dag_result.get("completed_issues", []),
+                        )
+                        ci_gate_results.append({
+                            "repo_name": (
+                                _repo_name_from_url(cfg.repo_url)
+                                if cfg.repo_url else "repo"
+                            ),
+                            **gate,
+                        })
             except Exception as e:
                 app.note(f"PR creation failed: {e}", tags=["build", "github_pr", "error"])
 
@@ -793,6 +963,7 @@ async def build(
         summary=f"{'Success' if success else 'Partial'}: {completed}/{total} issues completed"
                 + (f", verification: {verification.get('summary', '')}" if verification else ""),
         pr_results=pr_results,
+        ci_gate_results=ci_gate_results,
     ).model_dump()
 
 

--- a/swe_af/execution/ci_gate.py
+++ b/swe_af/execution/ci_gate.py
@@ -1,0 +1,262 @@
+"""Deterministic helpers for the post-PR CI gate.
+
+The CI gate watches GitHub Actions checks on a draft PR after SWE-AF pushes
+its work, using the ``gh`` CLI. Polling, log retrieval, and PR-state
+transitions live here so they can be unit-tested without a GitHub remote or
+an LLM in the loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import subprocess
+import time
+from collections.abc import Callable, Sequence
+from typing import Any
+
+from swe_af.execution.schemas import CIFailedCheck, CIWatchResult
+
+# Buckets (`gh pr checks --json bucket`) that mean "still running". Anything
+# outside this set is conclusive (pass/fail/cancel/skip).
+_PENDING_BUCKETS: frozenset[str] = frozenset({"pending", "queued"})
+_FAILURE_BUCKETS: frozenset[str] = frozenset({"fail", "cancel"})
+
+# Per-failure log tail size. Big enough to surface the actual error, small
+# enough to keep the CI-fixer prompt under control across multi-failure runs.
+_LOG_TAIL_CHARS: int = 3000
+
+# Regex to pull the run id out of the details_url returned by `gh pr checks`.
+# Expected shape: https://github.com/<owner>/<repo>/actions/runs/<run_id>/job/<job_id>
+_RUN_ID_RE = re.compile(r"/actions/runs/(\d+)(?:/|$)")
+
+
+CommandRunner = Callable[[Sequence[str], str], "subprocess.CompletedProcess[str]"]
+
+
+def _default_runner(
+    cmd: Sequence[str], cwd: str
+) -> "subprocess.CompletedProcess[str]":
+    return subprocess.run(
+        list(cmd),
+        cwd=cwd or None,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _parse_checks(payload: str) -> list[dict[str, Any]]:
+    """Parse `gh pr checks --json` output into a list of dicts.
+
+    Returns an empty list when no checks are configured for the PR yet.
+    Raises ``ValueError`` if the payload is non-empty but not parseable JSON.
+    """
+    text = (payload or "").strip()
+    if not text:
+        return []
+    data = json.loads(text)
+    if not isinstance(data, list):
+        raise ValueError(f"Expected JSON array from gh pr checks, got {type(data).__name__}")
+    return data
+
+
+def _is_conclusive(checks: Sequence[dict[str, Any]]) -> bool:
+    """All listed checks have settled (no pending/queued)."""
+    return all(c.get("bucket", "") not in _PENDING_BUCKETS for c in checks)
+
+
+def _classify(checks: Sequence[dict[str, Any]]) -> str:
+    """Classify a conclusive set of checks.
+
+    Returns ``"failed"`` if any required check failed/was cancelled,
+    ``"passed"`` otherwise. ``"skip"`` and ``"pass"`` buckets count as passing.
+    """
+    for c in checks:
+        if c.get("bucket", "") in _FAILURE_BUCKETS:
+            return "failed"
+    return "passed"
+
+
+def _extract_run_id(details_url: str) -> str:
+    if not details_url:
+        return ""
+    match = _RUN_ID_RE.search(details_url)
+    return match.group(1) if match else ""
+
+
+def _tail(text: str, max_chars: int = _LOG_TAIL_CHARS) -> str:
+    if len(text) <= max_chars:
+        return text
+    return "…[truncated]…\n" + text[-max_chars:]
+
+
+def _fetch_failed_logs(
+    repo_path: str,
+    run_id: str,
+    runner: CommandRunner,
+) -> str:
+    """Run `gh run view <id> --log-failed` and return a tail of the output."""
+    if not run_id:
+        return ""
+    proc = runner(["gh", "run", "view", run_id, "--log-failed"], repo_path)
+    body = proc.stdout or ""
+    if proc.returncode != 0 and not body:
+        body = proc.stderr or ""
+    return _tail(body)
+
+
+def _build_failed_checks(
+    raw_checks: Sequence[dict[str, Any]],
+    repo_path: str,
+    runner: CommandRunner,
+) -> list[CIFailedCheck]:
+    failures: list[CIFailedCheck] = []
+    for c in raw_checks:
+        if c.get("bucket", "") not in _FAILURE_BUCKETS:
+            continue
+        details_url = c.get("link", "") or c.get("detailsUrl", "")
+        run_id = _extract_run_id(details_url)
+        logs_excerpt = _fetch_failed_logs(repo_path, run_id, runner)
+        failures.append(
+            CIFailedCheck(
+                name=c.get("name", "?"),
+                workflow=c.get("workflow", ""),
+                conclusion=c.get("state", c.get("bucket", "")),
+                details_url=details_url,
+                logs_excerpt=logs_excerpt,
+            )
+        )
+    return failures
+
+
+async def watch_pr_checks(
+    *,
+    repo_path: str,
+    pr_number: int,
+    wait_seconds: int = 1500,
+    poll_seconds: int = 30,
+    runner: CommandRunner | None = None,
+    sleep: Callable[[float], Any] | None = None,
+    now: Callable[[], float] | None = None,
+) -> CIWatchResult:
+    """Poll `gh pr checks <pr>` until conclusive, the wait cap is hit, or no checks exist.
+
+    Returns a ``CIWatchResult`` describing the outcome. Failed checks include a
+    truncated log tail fetched via ``gh run view --log-failed`` so downstream
+    callers (the CI fixer) get actionable context without re-querying.
+
+    Parameters are dependency-injected so the polling loop is unit-testable
+    without invoking ``gh`` or sleeping in real wall-clock time.
+    """
+    cmd_runner: CommandRunner = runner or _default_runner
+    sleeper = sleep or asyncio.sleep
+    clock = now or time.monotonic
+
+    start = clock()
+
+    def elapsed() -> int:
+        return int(clock() - start)
+
+    last_checks: list[dict[str, Any]] = []
+    saw_any_check = False
+
+    while True:
+        proc = cmd_runner(
+            [
+                "gh", "pr", "checks", str(pr_number),
+                "--json", "bucket,state,name,workflow,link",
+            ],
+            repo_path,
+        )
+
+        if proc.returncode != 0:
+            stderr = (proc.stderr or "").strip()
+            # `gh pr checks` exits non-zero when there ARE failed checks but
+            # also when the call itself errors out. Distinguish via stdout
+            # presence: a parseable JSON body means we got real check data
+            # alongside the non-zero exit, so keep going.
+            try:
+                last_checks = _parse_checks(proc.stdout)
+            except ValueError:
+                last_checks = []
+            if not last_checks:
+                return CIWatchResult(
+                    status="error",
+                    pr_number=pr_number,
+                    elapsed_seconds=elapsed(),
+                    summary=f"`gh pr checks` failed: {stderr[:300]}",
+                )
+        else:
+            try:
+                last_checks = _parse_checks(proc.stdout)
+            except ValueError as e:
+                return CIWatchResult(
+                    status="error",
+                    pr_number=pr_number,
+                    elapsed_seconds=elapsed(),
+                    summary=f"Could not parse gh pr checks output: {e}",
+                )
+
+        if last_checks:
+            saw_any_check = True
+
+        if last_checks and _is_conclusive(last_checks):
+            verdict = _classify(last_checks)
+            if verdict == "passed":
+                return CIWatchResult(
+                    status="passed",
+                    pr_number=pr_number,
+                    elapsed_seconds=elapsed(),
+                    summary=f"All {len(last_checks)} check(s) passed",
+                )
+            failures = _build_failed_checks(last_checks, repo_path, cmd_runner)
+            return CIWatchResult(
+                status="failed",
+                pr_number=pr_number,
+                elapsed_seconds=elapsed(),
+                failed_checks=failures,
+                summary=f"{len(failures)} of {len(last_checks)} check(s) failing",
+            )
+
+        if elapsed() >= wait_seconds:
+            if not saw_any_check:
+                return CIWatchResult(
+                    status="no_checks",
+                    pr_number=pr_number,
+                    elapsed_seconds=elapsed(),
+                    summary=(
+                        f"No checks reported in {wait_seconds}s — "
+                        "PR has no CI configured or checks not yet started"
+                    ),
+                )
+            return CIWatchResult(
+                status="timed_out",
+                pr_number=pr_number,
+                elapsed_seconds=elapsed(),
+                summary=(
+                    f"Checks still pending after {wait_seconds}s "
+                    f"({len(last_checks)} reporting)"
+                ),
+            )
+
+        await sleeper(poll_seconds)
+
+
+def mark_pr_ready(
+    *,
+    repo_path: str,
+    pr_number: int,
+    runner: CommandRunner | None = None,
+) -> tuple[bool, str]:
+    """Promote a draft PR to ready-for-review via `gh pr ready <num>`.
+
+    Returns ``(success, message)``. ``message`` carries the gh stderr on
+    failure (truncated), or a short confirmation on success.
+    """
+    cmd_runner: CommandRunner = runner or _default_runner
+    proc = cmd_runner(["gh", "pr", "ready", str(pr_number)], repo_path)
+    if proc.returncode == 0:
+        return True, f"PR #{pr_number} marked ready for review"
+    return False, (proc.stderr or "").strip()[:300] or "gh pr ready failed"

--- a/swe_af/execution/schemas.py
+++ b/swe_af/execution/schemas.py
@@ -479,6 +479,7 @@ ROLE_TO_MODEL_FIELD: dict[str, str] = {
     "git": "git_model",
     "merger": "merger_model",
     "integration_tester": "integration_tester_model",
+    "ci_fixer": "ci_fixer_model",
 }
 
 MODEL_ROLE_KEYS: list[str] = list(ROLE_TO_MODEL_FIELD)
@@ -688,6 +689,15 @@ class BuildConfig(BaseModel):
     repos: list[RepoSpec] = []  # Multi-repo list; normalised by _normalize_repos
     enable_github_pr: bool = True  # Create draft PR after build
     github_pr_base: str = ""  # PR base branch (default: repo's default branch)
+    # Post-PR CI gate. When True, after the draft PR is opened SWE-AF waits for
+    # CI to be conclusive, runs a bounded fix-and-repush loop on failure, and
+    # promotes the PR with `gh pr ready` only when CI is green. When False,
+    # the build returns immediately after creating the draft PR (legacy
+    # behaviour).
+    check_ci: bool = True
+    max_ci_fix_cycles: int = 2  # number of fix → repush → re-watch iterations
+    ci_wait_seconds: int = 1500  # wall-clock cap per watch (25 min)
+    ci_poll_seconds: int = 30  # poll interval for `gh pr checks --json`
     agent_timeout_seconds: int = 2700
     max_advisor_invocations: int = 2
     enable_issue_advisor: bool = True
@@ -798,6 +808,10 @@ class BuildConfig(BaseModel):
             "enable_learning": self.enable_learning,
             "max_concurrent_issues": self.max_concurrent_issues,
             "level_failure_abort_threshold": self.level_failure_abort_threshold,
+            "check_ci": self.check_ci,
+            "max_ci_fix_cycles": self.max_ci_fix_cycles,
+            "ci_wait_seconds": self.ci_wait_seconds,
+            "ci_poll_seconds": self.ci_poll_seconds,
         }
 
 
@@ -810,6 +824,9 @@ class BuildResult(BaseModel):
     success: bool
     summary: str
     pr_results: list[RepoPRResult] = []  # Per-repo PR creation results
+    # Per-repo result of the post-PR CI gate (watch → fix → repush → ready).
+    # Empty when ``BuildConfig.check_ci`` is False or no PR was opened.
+    ci_gate_results: list[dict] = []
 
     @property
     def pr_url(self) -> str:
@@ -844,6 +861,38 @@ class GitHubPRResult(BaseModel):
     error_message: str = ""
 
 
+class CIFailedCheck(BaseModel):
+    """One failing GitHub check on a PR."""
+
+    name: str
+    workflow: str = ""
+    conclusion: str = ""  # FAILURE, CANCELLED, TIMED_OUT, ACTION_REQUIRED, etc.
+    details_url: str = ""
+    logs_excerpt: str = ""  # tail of the failed job's log, truncated
+
+
+class CIWatchResult(BaseModel):
+    """Outcome of waiting for CI checks on a PR."""
+
+    status: Literal["passed", "failed", "timed_out", "no_checks", "error"]
+    pr_number: int
+    elapsed_seconds: int = 0
+    failed_checks: list[CIFailedCheck] = []
+    summary: str = ""
+
+
+class CIFixResult(BaseModel):
+    """Output from one iteration of the CI fixer agent."""
+
+    fixed: bool  # True if the agent believes it has resolved all failures
+    files_changed: list[str] = []
+    commit_sha: str = ""  # SHA of the fix commit, if pushed
+    pushed: bool = False  # True if the agent pushed the fix to origin
+    summary: str = ""
+    rejected_workarounds: list[str] = []  # legitimate-fix self-checks the agent ran
+    error_message: str = ""
+
+
 class ExecutionConfig(BaseModel):
     """Configuration for the DAG executor."""
 
@@ -869,6 +918,12 @@ class ExecutionConfig(BaseModel):
     level_failure_abort_threshold: float = (
         0.8  # abort DAG when >= this fraction of a level fails
     )
+    # Mirrored from BuildConfig so the post-PR CI gate sees the same caps when
+    # invoked from the build pipeline.
+    check_ci: bool = True
+    max_ci_fix_cycles: int = 2
+    ci_wait_seconds: int = 1500
+    ci_poll_seconds: int = 30
 
     @model_validator(mode="before")
     @classmethod
@@ -959,3 +1014,7 @@ class ExecutionConfig(BaseModel):
     @property
     def integration_tester_model(self) -> str:
         return self._model_for("integration_tester_model")
+
+    @property
+    def ci_fixer_model(self) -> str:
+        return self._model_for("ci_fixer_model")

--- a/swe_af/fast/__init__.py
+++ b/swe_af/fast/__init__.py
@@ -133,6 +133,50 @@ async def run_github_pr(
     )
 
 
+@fast_router.reasoner()
+async def run_ci_watcher(
+    repo_path: str,
+    pr_number: int,
+    wait_seconds: int = 1500,
+    poll_seconds: int = 30,
+) -> dict:
+    """Thin wrapper around execution_agents.run_ci_watcher."""
+    import swe_af.reasoners.execution_agents as _ea  # noqa: PLC0415
+    return await _ea.run_ci_watcher(
+        repo_path=repo_path, pr_number=pr_number,
+        wait_seconds=wait_seconds, poll_seconds=poll_seconds,
+    )
+
+
+@fast_router.reasoner()
+async def run_ci_fixer(
+    repo_path: str,
+    pr_number: int,
+    pr_url: str,
+    integration_branch: str,
+    base_branch: str,
+    failed_checks: list[dict],
+    iteration: int = 1,
+    max_iterations: int = 2,
+    goal: str = "",
+    completed_issues: list[dict] | None = None,
+    previous_attempts: list[dict] | None = None,
+    model: str = "sonnet",
+    permission_mode: str = "",
+    ai_provider: str = "claude",
+) -> dict:
+    """Thin wrapper around execution_agents.run_ci_fixer."""
+    import swe_af.reasoners.execution_agents as _ea  # noqa: PLC0415
+    return await _ea.run_ci_fixer(
+        repo_path=repo_path, pr_number=pr_number, pr_url=pr_url,
+        integration_branch=integration_branch, base_branch=base_branch,
+        failed_checks=failed_checks, iteration=iteration,
+        max_iterations=max_iterations, goal=goal,
+        completed_issues=completed_issues, previous_attempts=previous_attempts,
+        model=model, permission_mode=permission_mode, ai_provider=ai_provider,
+    )
+
+
 from . import executor  # noqa: E402, F401 — registers fast_execute_tasks
 from . import planner  # noqa: E402, F401 — registers fast_plan_tasks
 from . import verifier  # noqa: E402, F401 — registers fast_verify
@@ -144,6 +188,8 @@ __all__ = [
     "run_verifier",
     "run_repo_finalize",
     "run_github_pr",
+    "run_ci_watcher",
+    "run_ci_fixer",
     "executor",
     "planner",
     "verifier",

--- a/swe_af/prompts/ci_fixer.py
+++ b/swe_af/prompts/ci_fixer.py
@@ -1,0 +1,226 @@
+"""Prompt builder for the CI Fixer agent role.
+
+The CI fixer runs after a draft PR has been opened and CI has reported a
+hard failure. Its job is to make CI green by producing a *legitimate* fix and
+pushing it to the PR's branch — never by silencing or weakening the test that
+caught the bug.
+"""
+
+from __future__ import annotations
+
+from swe_af.execution.schemas import CIFailedCheck
+
+SYSTEM_PROMPT = """\
+You are a senior engineer paged to make a failing CI check pass on an open
+pull request. The PR was just produced by an autonomous agent team and
+shipped to a draft PR. CI caught a real failure. Your job is to ship a
+LEGITIMATE FIX — one that an experienced reviewer on a healthy team would
+accept on the first read — and push it as a new commit to the PR's branch.
+
+## You are NOT done until
+
+1. The root cause of the failing check is understood.
+2. The fix addresses that root cause in the production code (or, in narrow
+   cases, in a test that was itself wrong — see "When the test is wrong"
+   below).
+3. The fix is committed and pushed to the integration branch (the branch
+   the PR is built from).
+4. You have re-run the relevant tests locally and they pass.
+
+## ABSOLUTELY FORBIDDEN — these are workarounds, not fixes
+
+You MUST NOT do any of the following to make the red check turn green:
+
+- Skip the failing test (`@pytest.mark.skip`, `pytest.skip(...)`,
+  `@unittest.skip`, `it.skip`, `xit`, `test.skip`, `t.Skip()`, `#[ignore]`).
+- Mark it as expected-to-fail (`@pytest.mark.xfail`,
+  `@unittest.expectedFailure`, `it.todo`, `#[should_panic]` added solely to
+  hide a real bug).
+- Comment out the failing test or its assertions.
+- Delete the failing test or the file containing it.
+- Loosen an assertion to make it tautological (e.g. `assert result is not
+  None` instead of `assert result == expected`).
+- Wrap the failing code in `try/except: pass`, `try/catch {}`, or any
+  swallow-the-error pattern that hides the failure from CI.
+- Change the assertion's expected value to whatever the buggy code currently
+  produces ("snapshot the bug").
+- Disable the failing CI job in the workflow file
+  (`continue-on-error: true`, removing the job, narrowing `paths:`, etc.).
+- Edit the test runner config (`pytest.ini`, `tox.ini`, `pyproject.toml`,
+  `jest.config.*`, etc.) to deselect the failing test.
+- Hardcode the failing input in a fixture so the bug can't be hit.
+- Mock or stub out the unit under test so the failing path is never
+  exercised.
+- Push a commit whose only purpose is to retry CI hoping the failure was
+  flaky. (If you genuinely believe a check is flaky, document the evidence
+  in your summary and STOP — do not re-push.)
+
+If you find yourself reaching for any of the above, STOP. Re-read the
+failure, find the actual bug, and fix the production code.
+
+## When the test is wrong
+
+It is occasionally legitimate to fix the TEST instead of the production
+code — but only when the test asserts something the spec/PRD does not
+require, or it depends on environment that doesn't exist in CI, or it has
+a genuine logic bug (off-by-one, wrong fixture, race). If you change a
+test, your summary MUST justify why the previous assertion was incorrect
+with reference to the PRD, the function's docstring, or the existing
+behaviour of the surrounding code. "Test was too strict" is not a
+justification — describe specifically what the spec requires and why the
+test diverged from it.
+
+## Workflow
+
+1. Read every failure block in the task prompt. Each contains the failing
+   job name, a URL, and a tail of the failed log.
+2. For each failure: open the relevant source files, locate the assertion
+   that failed, and trace it back to the production code that produced
+   the wrong behaviour.
+3. Implement the fix in the production code. Keep the change minimal and
+   focused — do not refactor unrelated areas.
+4. Re-run the failing tests locally with the same command CI used (look
+   for it in the log tail or the workflow yaml). Verify they pass.
+5. Run any closely-related tests too, to confirm you didn't regress
+   neighbouring behaviour.
+6. Stage and commit ONLY the files that belong to the fix:
+   `git add <files>` then `git commit -m "fix: ..."`. Do NOT use
+   `git add -A` — there may be untracked artifacts in the worktree.
+7. Push to the integration branch: `git push origin <integration_branch>`.
+8. Capture the new commit SHA (`git rev-parse HEAD`) and report it.
+9. Return a `CIFixResult` JSON object describing what you changed.
+
+## Self-check before pushing
+
+Before you `git push`, answer these in your head:
+
+- "If a reviewer ran the originally-failing test on the previous commit,
+  it would fail. If they run it on my new commit, will it pass for the
+  RIGHT reason — i.e. because the production code now does the right
+  thing — and not because I weakened the test?"
+- "Have I removed, skipped, or relaxed any test or assertion?" If yes,
+  re-justify it against the rules above or back the change out.
+
+List the workarounds you considered but rejected (and why) in
+`rejected_workarounds`. This is your audit trail and helps the next
+reviewer trust the fix.
+
+## Output
+
+Return a `CIFixResult` JSON object with:
+
+- `fixed`: true only if you both made the change AND re-ran the failing
+  tests locally and they passed.
+- `files_changed`: list of files you modified.
+- `commit_sha`: SHA of the new commit you pushed.
+- `pushed`: true if `git push` succeeded.
+- `summary`: 2-4 sentences describing the root cause and the fix. If you
+  edited a test, your justification goes here.
+- `rejected_workarounds`: list of strings, one per workaround you
+  considered and rejected. Empty list is fine if none were tempting.
+- `error_message`: empty on success; a short description of what blocked
+  you on failure (e.g. "couldn't reproduce locally", "tests still fail
+  after fix").
+
+## Tools Available
+
+- READ to inspect source and test files
+- EDIT/WRITE to modify code
+- BASH for running tests, git operations, and `gh run view --log-failed`
+  if you need more log context than what was provided\
+"""
+
+
+def ci_fixer_task_prompt(
+    *,
+    repo_path: str,
+    pr_number: int,
+    pr_url: str,
+    integration_branch: str,
+    base_branch: str,
+    failed_checks: list[CIFailedCheck | dict],
+    iteration: int,
+    max_iterations: int,
+    goal: str = "",
+    completed_issues: list[dict] | None = None,
+    previous_attempts: list[dict] | None = None,
+) -> str:
+    """Build the task prompt for one CI-fixer iteration.
+
+    ``failed_checks`` may be passed as either ``CIFailedCheck`` instances or
+    plain dicts (the dispatcher serialises them across the wire).
+    """
+    sections: list[str] = []
+    sections.append("## CI Fix Task")
+    sections.append(f"- **Repository path**: `{repo_path}`")
+    sections.append(f"- **PR**: #{pr_number} — {pr_url}")
+    sections.append(f"- **Integration branch (push target)**: `{integration_branch}`")
+    sections.append(f"- **Base branch**: `{base_branch}`")
+    sections.append(f"- **Attempt**: {iteration} of {max_iterations}")
+    if goal:
+        sections.append(f"- **Original build goal**: {goal}")
+
+    if completed_issues:
+        sections.append("\n### Issues delivered by this PR (for context)")
+        for issue in completed_issues:
+            name = issue.get("issue_name", issue.get("name", "?"))
+            summary = issue.get("result_summary", "")
+            sections.append(f"- **{name}**: {summary}")
+
+    if previous_attempts:
+        sections.append("\n### Previous CI-fix attempts on this PR")
+        for i, attempt in enumerate(previous_attempts, 1):
+            summary = attempt.get("summary", "(no summary)")
+            sha = attempt.get("commit_sha", "")
+            sections.append(
+                f"- Attempt {i}: {summary}"
+                + (f" (commit {sha[:7]})" if sha else "")
+            )
+        sections.append(
+            "\nThe failures below are what is STILL red after those attempts. "
+            "Re-read the new log tails carefully — the root cause may be "
+            "different from what was previously suspected."
+        )
+
+    sections.append("\n### Failing checks")
+    if not failed_checks:
+        sections.append("(none reported — investigate via `gh pr checks` directly)")
+    else:
+        for fc in failed_checks:
+            data = fc.model_dump() if hasattr(fc, "model_dump") else dict(fc)
+            name = data.get("name", "?")
+            workflow = data.get("workflow", "")
+            conclusion = data.get("conclusion", "")
+            url = data.get("details_url", "")
+            logs = data.get("logs_excerpt", "")
+            header = f"#### {name}"
+            if workflow:
+                header += f"  (workflow: {workflow})"
+            if conclusion:
+                header += f"  [{conclusion}]"
+            sections.append(header)
+            if url:
+                sections.append(f"Details: {url}")
+            if logs:
+                sections.append("Log tail (last failing output):")
+                sections.append("```")
+                sections.append(logs)
+                sections.append("```")
+            else:
+                sections.append(
+                    "(No log captured. Run "
+                    "`gh run view <run-id> --log-failed` to fetch it.)"
+                )
+
+    sections.append(
+        "\n## Your Task\n"
+        "1. Diagnose the root cause of each failing check (read code + logs).\n"
+        "2. Fix the PRODUCTION code — never silence or weaken the failing test "
+        "(see system prompt for the exhaustive forbidden list).\n"
+        "3. Re-run the failing tests locally with the same command CI ran.\n"
+        "4. Commit only the files that belong to the fix and push to "
+        f"`{integration_branch}`.\n"
+        "5. Return a `CIFixResult` JSON object with the new commit SHA."
+    )
+
+    return "\n".join(sections)

--- a/swe_af/reasoners/execution_agents.py
+++ b/swe_af/reasoners/execution_agents.py
@@ -11,9 +11,13 @@ import os
 from pydantic import BaseModel
 
 from swe_af.execution.fatal_error import FatalHarnessError, check_fatal_harness_error
+from swe_af.execution.ci_gate import watch_pr_checks
 from swe_af.execution.schemas import (
     DEFAULT_AGENT_MAX_TURNS,
     AdvisorAction,
+    CIFailedCheck,
+    CIFixResult,
+    CIWatchResult,
     CodeReviewResult,
     CoderResult,
     GitHubPRResult,
@@ -30,6 +34,8 @@ from swe_af.execution.schemas import (
     VerificationResult,
     WorkspaceInfo,
 )
+from swe_af.prompts.ci_fixer import SYSTEM_PROMPT as CI_FIXER_SYSTEM_PROMPT
+from swe_af.prompts.ci_fixer import ci_fixer_task_prompt
 from swe_af.prompts.fix_generator import SYSTEM_PROMPT as FIX_GENERATOR_SYSTEM_PROMPT
 from swe_af.prompts.fix_generator import fix_generator_task_prompt
 from swe_af.prompts.issue_advisor import SYSTEM_PROMPT as ISSUE_ADVISOR_SYSTEM_PROMPT
@@ -1457,4 +1463,141 @@ async def run_github_pr(
     return GitHubPRResult(
         success=False,
         error_message="GitHub PR agent failed to produce a valid result.",
+    ).model_dump()
+
+
+# ---------------------------------------------------------------------------
+# Phase C: Post-PR CI gate (watcher + fixer)
+# ---------------------------------------------------------------------------
+
+
+@router.reasoner()
+async def run_ci_watcher(
+    repo_path: str,
+    pr_number: int,
+    wait_seconds: int = 1500,
+    poll_seconds: int = 30,
+) -> dict:
+    """Poll `gh pr checks` until conclusive, the wait cap is hit, or no checks exist.
+
+    Deterministic — uses the `gh` CLI and does not invoke an LLM. Returns a
+    ``CIWatchResult`` dict; callers decide whether to fix-and-repush or
+    surface the failure.
+    """
+    router.note(
+        f"CI watcher: PR #{pr_number}, wait_cap={wait_seconds}s, poll={poll_seconds}s",
+        tags=["ci_watcher", "start"],
+    )
+
+    try:
+        result = await watch_pr_checks(
+            repo_path=repo_path,
+            pr_number=pr_number,
+            wait_seconds=wait_seconds,
+            poll_seconds=poll_seconds,
+        )
+    except Exception as e:
+        router.note(
+            f"CI watcher errored: {e}",
+            tags=["ci_watcher", "error"],
+        )
+        return CIWatchResult(
+            status="error",
+            pr_number=pr_number,
+            summary=f"CI watcher exception: {e}",
+        ).model_dump()
+
+    router.note(
+        f"CI watcher: status={result.status} ({result.summary})",
+        tags=["ci_watcher", "complete", result.status],
+    )
+    return result.model_dump()
+
+
+@router.reasoner()
+async def run_ci_fixer(
+    repo_path: str,
+    pr_number: int,
+    pr_url: str,
+    integration_branch: str,
+    base_branch: str,
+    failed_checks: list[dict],
+    iteration: int = 1,
+    max_iterations: int = 2,
+    goal: str = "",
+    completed_issues: list[dict] | None = None,
+    previous_attempts: list[dict] | None = None,
+    model: str = "sonnet",
+    permission_mode: str = "",
+    ai_provider: str = "claude",
+) -> dict:
+    """Diagnose the failing CI checks, fix the production code, and push.
+
+    The system prompt emphatically forbids workarounds (skipping tests,
+    weakening assertions, swallowing errors, disabling jobs). The agent must
+    produce a legitimate fix and push it as a new commit on
+    ``integration_branch`` so the PR's checks rerun.
+
+    Returns a ``CIFixResult`` dict.
+    """
+    router.note(
+        f"CI fixer: PR #{pr_number}, attempt {iteration}/{max_iterations}, "
+        f"{len(failed_checks)} failing check(s)",
+        tags=["ci_fixer", "start"],
+    )
+
+    typed_failures = [
+        fc if isinstance(fc, CIFailedCheck) else CIFailedCheck(**fc)
+        for fc in failed_checks
+    ]
+
+    task_prompt = ci_fixer_task_prompt(
+        repo_path=repo_path,
+        pr_number=pr_number,
+        pr_url=pr_url,
+        integration_branch=integration_branch,
+        base_branch=base_branch,
+        failed_checks=typed_failures,
+        iteration=iteration,
+        max_iterations=max_iterations,
+        goal=goal,
+        completed_issues=completed_issues,
+        previous_attempts=previous_attempts,
+    )
+
+    provider = "claude-code" if ai_provider == "claude" else ai_provider
+
+    try:
+        result = await router.harness(
+            task_prompt,
+            system_prompt=CI_FIXER_SYSTEM_PROMPT,
+            schema=CIFixResult,
+            model=model,
+            provider=provider,
+            tools=["Bash", "Read", "Edit", "Write", "Glob", "Grep"],
+            cwd=repo_path,
+            max_turns=DEFAULT_AGENT_MAX_TURNS,
+            permission_mode=permission_mode or None,
+        )
+        check_fatal_harness_error(result)
+        if result.parsed is not None:
+            router.note(
+                f"CI fixer complete: fixed={result.parsed.fixed}, "
+                f"pushed={result.parsed.pushed}, "
+                f"{len(result.parsed.files_changed)} file(s) changed",
+                tags=["ci_fixer", "complete"],
+            )
+            return result.parsed.model_dump()
+    except FatalHarnessError:
+        raise
+    except Exception as e:
+        router.note(
+            f"CI fixer agent failed: {e}",
+            tags=["ci_fixer", "error"],
+        )
+
+    return CIFixResult(
+        fixed=False,
+        summary="CI fixer agent failed to produce a valid result.",
+        error_message="CI fixer agent failed to produce a valid result.",
     ).model_dump()

--- a/tests/fast/test_fast_init_executor_planner_verifier_routing.py
+++ b/tests/fast/test_fast_init_executor_planner_verifier_routing.py
@@ -837,10 +837,11 @@ class TestBuildTimeoutPath:
 
 
 class TestFastRouterReasonerCount:
-    """After full import of all merged modules, fast_router must have exactly 8 reasoners."""
+    """After full import of all merged modules, fast_router must register all
+    expected reasoners — currently 10 (includes the post-PR CI gate pair)."""
 
-    def test_all_eight_reasoners_registered_via_subprocess(self) -> None:
-        """Subprocess validates full import chain produces 8 reasoners."""
+    def test_all_reasoners_registered_via_subprocess(self) -> None:
+        """Subprocess validates full import chain produces the expected reasoners."""
         code = """
 import os
 os.environ.setdefault("AGENTFIELD_SERVER", "http://localhost:9999")
@@ -853,6 +854,7 @@ names = {r["func"].__name__ for r in swe_af.fast.fast_router.reasoners}
 expected = {
     "run_git_init", "run_coder", "run_verifier",
     "run_repo_finalize", "run_github_pr",
+    "run_ci_watcher", "run_ci_fixer",
     "fast_execute_tasks", "fast_plan_tasks", "fast_verify",
 }
 missing = expected - names
@@ -862,13 +864,13 @@ if missing:
 if extra:
     print(f"EXTRA: {sorted(extra)}")
 assert not missing, f"Missing reasoners: {sorted(missing)}"
-assert len(names) == 8, f"Expected 8 reasoners, got {len(names)}: {sorted(names)}"
+assert names == expected, f"Unexpected reasoner set: {sorted(names)}"
 print("OK")
 """
         result = _run_subprocess(code, unset_keys=["NODE_ID"])
         assert result.returncode == 0, (
-            f"fast_router must have exactly 8 reasoners after full import chain; "
-            f"stdout={result.stdout!r}, stderr={result.stderr!r}"
+            f"fast_router reasoner set must match the expected set after full "
+            f"import chain; stdout={result.stdout!r}, stderr={result.stderr!r}"
         )
         assert "OK" in result.stdout
 

--- a/tests/test_ci_gate.py
+++ b/tests/test_ci_gate.py
@@ -1,0 +1,322 @@
+"""Tests for the post-PR CI gate (watcher + promote-to-ready).
+
+The watcher polls `gh pr checks` until conclusive. Polling is wired through
+injectable `runner`, `sleep`, and `now` callables so these tests run in
+microseconds without invoking gh, sleeping, or hitting GitHub.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import unittest
+from typing import Any
+
+from swe_af.execution.ci_gate import (
+    _classify,
+    _extract_run_id,
+    _is_conclusive,
+    _parse_checks,
+    _tail,
+    mark_pr_ready,
+    watch_pr_checks,
+)
+from swe_af.execution.schemas import CIWatchResult
+
+
+def _completed(stdout: str = "", stderr: str = "", returncode: int = 0):
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr,
+    )
+
+
+def _mk_check(bucket: str, name: str = "Tests", state: str = "", workflow: str = "CI"):
+    return {
+        "bucket": bucket,
+        "state": state or bucket.upper(),
+        "name": name,
+        "workflow": workflow,
+        "link": f"https://github.com/o/r/actions/runs/12345/job/{hash(name) & 0xFFFF}",
+    }
+
+
+class _ScriptedRunner:
+    """Returns pre-baked CompletedProcess values keyed by command shape.
+
+    Treats the first 3 args (`gh pr checks` or `gh run view`, etc.) as the
+    "kind" of call and pops the next scripted reply from a per-kind queue.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+        self.checks_queue: list[subprocess.CompletedProcess] = []
+        self.run_view_queue: list[subprocess.CompletedProcess] = []
+        self.ready_queue: list[subprocess.CompletedProcess] = []
+
+    def __call__(self, cmd, cwd):  # type: ignore[no-untyped-def]
+        self.calls.append(list(cmd))
+        if cmd[:3] == ["gh", "pr", "checks"]:
+            assert self.checks_queue, "ran out of scripted gh pr checks replies"
+            return self.checks_queue.pop(0)
+        if cmd[:3] == ["gh", "run", "view"]:
+            if self.run_view_queue:
+                return self.run_view_queue.pop(0)
+            return _completed(stdout="(no log captured)\n")
+        if cmd[:3] == ["gh", "pr", "ready"]:
+            if self.ready_queue:
+                return self.ready_queue.pop(0)
+            return _completed(returncode=0)
+        raise AssertionError(f"unexpected command in test: {cmd}")
+
+
+class _FakeClock:
+    def __init__(self) -> None:
+        self.t = 0.0
+
+    def now(self) -> float:
+        return self.t
+
+
+async def _no_sleep(_seconds: float) -> None:
+    return None
+
+
+class TestParseAndClassify(unittest.TestCase):
+    def test_parse_empty_payload(self) -> None:
+        self.assertEqual(_parse_checks(""), [])
+        self.assertEqual(_parse_checks("   \n"), [])
+
+    def test_parse_array(self) -> None:
+        payload = json.dumps([{"bucket": "pass", "name": "a"}])
+        self.assertEqual(_parse_checks(payload), [{"bucket": "pass", "name": "a"}])
+
+    def test_parse_non_array_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            _parse_checks(json.dumps({"not": "array"}))
+
+    def test_is_conclusive(self) -> None:
+        self.assertTrue(_is_conclusive([_mk_check("pass"), _mk_check("fail")]))
+        self.assertFalse(_is_conclusive([_mk_check("pass"), _mk_check("pending")]))
+        self.assertFalse(_is_conclusive([_mk_check("queued")]))
+        self.assertTrue(_is_conclusive([_mk_check("skip")]))
+
+    def test_classify_passes_when_only_pass_or_skip(self) -> None:
+        self.assertEqual(_classify([_mk_check("pass"), _mk_check("skip")]), "passed")
+
+    def test_classify_fails_on_any_failure(self) -> None:
+        self.assertEqual(_classify([_mk_check("pass"), _mk_check("fail")]), "failed")
+        self.assertEqual(_classify([_mk_check("cancel")]), "failed")
+
+    def test_extract_run_id(self) -> None:
+        self.assertEqual(
+            _extract_run_id("https://github.com/o/r/actions/runs/12345/job/678"),
+            "12345",
+        )
+        self.assertEqual(_extract_run_id(""), "")
+        self.assertEqual(_extract_run_id("not a url"), "")
+
+    def test_tail_truncates_long_strings(self) -> None:
+        s = "x" * 5000
+        out = _tail(s, max_chars=100)
+        self.assertTrue(out.startswith("…[truncated]…"))
+        self.assertEqual(len(out.rstrip()), len("…[truncated]…\n") + 100)
+
+    def test_tail_passes_short_strings_through(self) -> None:
+        self.assertEqual(_tail("short"), "short")
+
+
+class TestWatchPRChecks(unittest.IsolatedAsyncioTestCase):
+    async def test_passes_when_first_poll_is_all_green(self) -> None:
+        runner = _ScriptedRunner()
+        runner.checks_queue.append(_completed(stdout=json.dumps([
+            _mk_check("pass", "Tests"),
+            _mk_check("pass", "Lint"),
+        ])))
+        clock = _FakeClock()
+
+        result = await watch_pr_checks(
+            repo_path="/tmp/repo", pr_number=42,
+            wait_seconds=600, poll_seconds=10,
+            runner=runner, sleep=_no_sleep, now=clock.now,
+        )
+
+        self.assertEqual(result.status, "passed")
+        self.assertEqual(result.pr_number, 42)
+        self.assertEqual(len(result.failed_checks), 0)
+        self.assertEqual(len(runner.calls), 1)  # one poll, then conclusive
+
+    async def test_fails_and_collects_failed_logs(self) -> None:
+        runner = _ScriptedRunner()
+        runner.checks_queue.append(_completed(stdout=json.dumps([
+            _mk_check("pass", "Lint"),
+            _mk_check("fail", "Tests"),
+        ])))
+        runner.run_view_queue.append(_completed(stdout="E   AssertionError: foo != bar\n"))
+        clock = _FakeClock()
+
+        result = await watch_pr_checks(
+            repo_path="/tmp/repo", pr_number=7,
+            wait_seconds=600, poll_seconds=10,
+            runner=runner, sleep=_no_sleep, now=clock.now,
+        )
+
+        self.assertEqual(result.status, "failed")
+        self.assertEqual(len(result.failed_checks), 1)
+        fc = result.failed_checks[0]
+        self.assertEqual(fc.name, "Tests")
+        self.assertIn("AssertionError", fc.logs_excerpt)
+        # We did one `gh pr checks` and one `gh run view` to fetch logs
+        kinds = [c[:3] for c in runner.calls]
+        self.assertEqual(kinds.count(["gh", "pr", "checks"]), 1)
+        self.assertEqual(kinds.count(["gh", "run", "view"]), 1)
+
+    async def test_polls_until_conclusive(self) -> None:
+        runner = _ScriptedRunner()
+        # First two polls: still pending. Third: green.
+        runner.checks_queue.extend([
+            _completed(stdout=json.dumps([_mk_check("pending", "Tests")])),
+            _completed(stdout=json.dumps([_mk_check("pending", "Tests")])),
+            _completed(stdout=json.dumps([_mk_check("pass", "Tests")])),
+        ])
+
+        sleeps: list[float] = []
+
+        async def record_sleep(seconds: float) -> None:
+            sleeps.append(seconds)
+
+        clock = _FakeClock()
+
+        async def advancing_now() -> float:  # not used; just for clarity
+            return clock.t
+
+        # Bump the fake clock between polls so we exercise elapsed accounting.
+        original_runner = runner
+
+        def runner_with_advance(cmd: Any, cwd: str) -> Any:
+            clock.t += 5.0
+            return original_runner(cmd, cwd)
+
+        result = await watch_pr_checks(
+            repo_path="/tmp/repo", pr_number=1,
+            wait_seconds=600, poll_seconds=10,
+            runner=runner_with_advance, sleep=record_sleep, now=clock.now,
+        )
+
+        self.assertEqual(result.status, "passed")
+        self.assertEqual(len(runner.calls), 3)
+        self.assertEqual(sleeps, [10, 10])  # slept twice between three polls
+
+    async def test_times_out_when_checks_never_settle(self) -> None:
+        runner = _ScriptedRunner()
+        # Always pending.
+        for _ in range(20):
+            runner.checks_queue.append(
+                _completed(stdout=json.dumps([_mk_check("pending", "Tests")]))
+            )
+        clock = _FakeClock()
+
+        # Simulate 100s of wall time advancing every poll.
+        original_runner = runner
+
+        def advance(cmd: Any, cwd: str) -> Any:
+            clock.t += 100.0
+            return original_runner(cmd, cwd)
+
+        result = await watch_pr_checks(
+            repo_path="/tmp/repo", pr_number=99,
+            wait_seconds=300, poll_seconds=50,
+            runner=advance, sleep=_no_sleep, now=clock.now,
+        )
+
+        self.assertEqual(result.status, "timed_out")
+        self.assertGreaterEqual(result.elapsed_seconds, 300)
+
+    async def test_no_checks_when_pr_has_no_ci(self) -> None:
+        runner = _ScriptedRunner()
+        # gh returns an empty array repeatedly.
+        for _ in range(5):
+            runner.checks_queue.append(_completed(stdout="[]"))
+        clock = _FakeClock()
+
+        original_runner = runner
+
+        def advance(cmd: Any, cwd: str) -> Any:
+            clock.t += 200.0
+            return original_runner(cmd, cwd)
+
+        result = await watch_pr_checks(
+            repo_path="/tmp/repo", pr_number=5,
+            wait_seconds=300, poll_seconds=50,
+            runner=advance, sleep=_no_sleep, now=clock.now,
+        )
+
+        self.assertEqual(result.status, "no_checks")
+
+    async def test_failed_checks_with_nonzero_exit_still_parsed(self) -> None:
+        """`gh pr checks` exits non-zero when ANY check failed even though it
+        also prints valid JSON. Treat the body, not the exit code, as truth."""
+        runner = _ScriptedRunner()
+        runner.checks_queue.append(_completed(
+            stdout=json.dumps([
+                _mk_check("pass", "Lint"),
+                _mk_check("fail", "Tests"),
+            ]),
+            stderr="some checks failing",
+            returncode=8,  # gh exit code for "checks failing"
+        ))
+        runner.run_view_queue.append(_completed(stdout="boom"))
+        clock = _FakeClock()
+
+        result = await watch_pr_checks(
+            repo_path="/tmp/repo", pr_number=11,
+            wait_seconds=600, poll_seconds=10,
+            runner=runner, sleep=_no_sleep, now=clock.now,
+        )
+
+        self.assertEqual(result.status, "failed")
+        self.assertEqual(len(result.failed_checks), 1)
+
+    async def test_real_error_when_gh_fails_with_no_payload(self) -> None:
+        runner = _ScriptedRunner()
+        runner.checks_queue.append(_completed(
+            stdout="", stderr="gh: not authenticated", returncode=1,
+        ))
+        clock = _FakeClock()
+
+        result = await watch_pr_checks(
+            repo_path="/tmp/repo", pr_number=3,
+            wait_seconds=600, poll_seconds=10,
+            runner=runner, sleep=_no_sleep, now=clock.now,
+        )
+
+        self.assertEqual(result.status, "error")
+        self.assertIn("not authenticated", result.summary)
+
+
+class TestMarkPRReady(unittest.TestCase):
+    def test_promotes_on_success(self) -> None:
+        runner = _ScriptedRunner()
+        runner.ready_queue.append(_completed(returncode=0))
+        ok, msg = mark_pr_ready(repo_path="/tmp/r", pr_number=42, runner=runner)
+        self.assertTrue(ok)
+        self.assertIn("#42", msg)
+        self.assertEqual(runner.calls[-1], ["gh", "pr", "ready", "42"])
+
+    def test_reports_failure(self) -> None:
+        runner = _ScriptedRunner()
+        runner.ready_queue.append(_completed(stderr="not a draft", returncode=1))
+        ok, msg = mark_pr_ready(repo_path="/tmp/r", pr_number=42, runner=runner)
+        self.assertFalse(ok)
+        self.assertIn("not a draft", msg)
+
+
+class TestSchemas(unittest.TestCase):
+    def test_ci_watch_result_serialises_with_failures(self) -> None:
+        result = CIWatchResult(
+            status="failed", pr_number=1, elapsed_seconds=42,
+        )
+        self.assertEqual(result.model_dump()["status"], "failed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -272,6 +272,56 @@ class TestExecutionConfig(unittest.TestCase):
         self.assertIn("coding", str(ctx.exception))
         self.assertIn("models.coder", str(ctx.exception))
 
+    def test_ci_fixer_role_resolves(self) -> None:
+        """ci_fixer is a real role with its own model field, defaulting to the
+        runtime base. It can be overridden per-role like any other."""
+        cfg = ExecutionConfig(runtime="claude_code")
+        self.assertEqual(cfg.ci_fixer_model, "sonnet")
+
+        cfg = ExecutionConfig(runtime="open_code")
+        self.assertEqual(cfg.ci_fixer_model, "openrouter/minimax/minimax-m2.5")
+
+        cfg = ExecutionConfig(
+            runtime="claude_code", models={"ci_fixer": "opus"}
+        )
+        self.assertEqual(cfg.ci_fixer_model, "opus")
+        # other roles untouched
+        self.assertEqual(cfg.coder_model, "sonnet")
+
+
+class TestCIGateConfig(unittest.TestCase):
+    """check_ci defaults to True and its caps round-trip from BuildConfig
+    into ExecutionConfig so the post-PR gate sees consistent settings."""
+
+    def test_check_ci_defaults_true(self) -> None:
+        self.assertTrue(BuildConfig().check_ci)
+        self.assertTrue(ExecutionConfig().check_ci)
+
+    def test_ci_gate_caps_have_sensible_defaults(self) -> None:
+        cfg = BuildConfig()
+        self.assertEqual(cfg.max_ci_fix_cycles, 2)
+        self.assertEqual(cfg.ci_wait_seconds, 1500)
+        self.assertEqual(cfg.ci_poll_seconds, 30)
+
+    def test_ci_gate_caps_round_trip(self) -> None:
+        cfg = BuildConfig(
+            check_ci=False,
+            max_ci_fix_cycles=5,
+            ci_wait_seconds=600,
+            ci_poll_seconds=15,
+        )
+        d = cfg.to_execution_config_dict()
+        self.assertEqual(d["check_ci"], False)
+        self.assertEqual(d["max_ci_fix_cycles"], 5)
+        self.assertEqual(d["ci_wait_seconds"], 600)
+        self.assertEqual(d["ci_poll_seconds"], 15)
+
+        exec_cfg = ExecutionConfig(**d)
+        self.assertFalse(exec_cfg.check_ci)
+        self.assertEqual(exec_cfg.max_ci_fix_cycles, 5)
+        self.assertEqual(exec_cfg.ci_wait_seconds, 600)
+        self.assertEqual(exec_cfg.ci_poll_seconds, 15)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Drives a build end-to-end: after the draft PR is opened, SWE-AF watches CI on
that PR, runs a bounded fix-and-repush loop on failure, and promotes the PR
from draft to ready-for-review with `gh pr ready` only when checks are green.

This closes the gap that left [github-buddy PR #33](https://github.com/Agent-Field/github-buddy/pull/33)
in draft with a failing `Unit tests (webhook routing)` check after the
previous run finished "successfully" — verifier-level spot-checking missed
it and nothing watched CI after push.

## What changed

- `BuildConfig.check_ci` (default **true**), with caps `max_ci_fix_cycles=2`,
  `ci_wait_seconds=1500`, `ci_poll_seconds=30`. Set `check_ci=false` to
  revert to the legacy "open draft PR and exit" behaviour.
- New deterministic helper [swe_af/execution/ci_gate.py](swe_af/execution/ci_gate.py)
  polls `gh pr checks` until conclusive, fetches log tails for failed jobs,
  and provides `mark_pr_ready`. Polling is dependency-injected so unit tests
  run in microseconds.
- New reasoners `run_ci_watcher` (wraps the helper) and `run_ci_fixer`
  (LLM-driven). The fixer's system prompt explicitly forbids workarounds:
  no `pytest.skip`, `xfail`, commented-out tests, deleted tests, loosened
  assertions, swallowed errors, disabled CI jobs, snapshotted bugs, or
  mocked-out units under test. The agent must fix the production code (or
  justify a test edit against the spec) and is asked to enumerate rejected
  workarounds in the response as an audit trail.
- New `ci_fixer` model role registered in `ROLE_TO_MODEL_FIELD` (defaults
  to the runtime base; override via `models.ci_fixer`).
- Wired into both single-repo and multi-repo PR paths in `build`. Each
  repo's gate result is captured in `BuildResult.ci_gate_results`.
- README: new "Post-PR CI gate" section documents behaviour and config.

## Bounds and failure modes

- Up to `max_ci_fix_cycles` watch → fix → repush iterations after the
  initial push (default 2).
- Each watch waits at most `ci_wait_seconds` wall-clock (default 25 min).
- Explicit `final_status` values for visibility: `passed`, `no_checks`,
  `failed_exhausted`, `fixer_gave_up`, `timed_out`, `error`.
- On any non-pass terminal state the PR is **left in draft** so a human
  reviewer sees it needs attention.

## Tests

- `tests/test_ci_gate.py` (new): 17 tests covering parse/classify, the
  polling loop happy and failure paths, multi-poll until conclusive,
  wall-clock timeout, no-checks, gh-failure-with-no-payload, the
  `gh pr checks` non-zero-exit-with-valid-body convention, and
  `mark_pr_ready` success + failure.
- `tests/test_model_config.py`: new `ci_fixer` role test + `TestCIGateConfig`
  for the new flags' defaults and round-trip.
- `tests/fast/test_fast_init_executor_planner_verifier_routing.py`:
  fast-router reasoner-count expectation updated 8 → 10.

## Test plan

- [x] `pytest tests/test_ci_gate.py tests/test_model_config.py` — 53/53 pass
- [x] Full suite: same 12 pre-existing failures as `main` (mostly fast/test_app
      mocks + tomllib/Python 3.11 collection errors); no new regressions
- [ ] End-to-end Railway run: trigger a build that produces failing CI on
      the resulting PR; confirm the gate enters the fix loop, pushes a
      legitimate fix, and promotes to ready when green
- [ ] Verify `check_ci=false` returns immediately after draft PR creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)