### PR TITLE
Open PRs ready for review (not draft); drop draft-promotion step

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ This is the core factory-control behavior: control agents supervise worker agent
 One click deploys SWE-AF + AgentField control plane + PostgreSQL. Set two environment variables in Railway:
 
 - `CLAUDE_CODE_OAUTH_TOKEN` — run `claude setup-token` in [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) (uses Pro/Max subscription credits)
-- `GH_TOKEN` — GitHub personal access token with `repo` scope for draft PR creation
+- `GH_TOKEN` — GitHub personal access token with `repo` scope for PR creation
 
 Once deployed, trigger a build:
 
@@ -419,7 +419,7 @@ Benchmark assets, logs, evaluator, and generated projects live in [`examples/age
 ```bash
 cp .env.example .env
 # Add your API key: ANTHROPIC_API_KEY, OPENROUTER_API_KEY, OPENAI_API_KEY, or GOOGLE_API_KEY
-# Optionally add GH_TOKEN for draft PR workflow
+# Optionally add GH_TOKEN for PR workflow
 
 docker compose up -d
 ```
@@ -482,9 +482,9 @@ Use a host control plane instead of Docker control-plane service:
 docker compose -f docker-compose.local.yml up -d
 ```
 
-## GitHub Repo Workflow (Clone -> Build -> Draft PR)
+## GitHub Repo Workflow (Clone -> Build -> PR)
 
-Pass `repo_url` instead of `repo_path` to let SWE-AF clone and open a draft PR after execution.
+Pass `repo_url` instead of `repo_path` to let SWE-AF clone and open a PR after execution.
 
 ```bash
 curl -X POST http://localhost:8080/api/v1/execute/async/swe-planner.build \
@@ -514,19 +514,20 @@ Requirements:
 
 ### Post-PR CI gate
 
-After SWE-AF pushes the integration branch and opens a draft PR, it watches
-GitHub Actions on that PR until checks are conclusive. If they fail, a
-bounded fix-and-repush loop runs an agent that is explicitly forbidden from
-silencing tests (no `pytest.skip`, no `xfail`, no commenting tests out, no
-loosening assertions) — it must produce a legitimate fix in the production
-code and push a new commit. When CI is green, the PR is promoted from draft
-to ready-for-review via `gh pr ready`.
+After SWE-AF pushes the integration branch and opens a PR (ready for review,
+not draft), it watches GitHub Actions on that PR until checks are
+conclusive. If they fail, a bounded fix-and-repush loop runs an agent that
+is explicitly forbidden from silencing tests (no `pytest.skip`, no `xfail`,
+no commenting tests out, no loosening assertions) — it must produce a
+legitimate fix in the production code and push a new commit. When CI is
+green, the gate returns success; when CI fails after fix attempts, the PR
+stays open with visible failing checks so a human reviewer can step in.
 
 Configuration on `BuildConfig`:
 
 | Field | Default | Purpose |
 |---|---|---|
-| `check_ci` | `true` | Run the post-PR CI gate. Set `false` to return immediately after the draft PR is created. |
+| `check_ci` | `true` | Run the post-PR CI gate. Set `false` to return immediately after the PR is created. |
 | `max_ci_fix_cycles` | `2` | Cap on watch → fix → repush iterations after the initial push. |
 | `ci_wait_seconds` | `1500` | Wall-clock cap per `gh pr checks` watch (25 min). |
 | `ci_poll_seconds` | `30` | Poll interval for `gh pr checks`. |
@@ -584,7 +585,7 @@ Every specialist is also callable directly:
 | `run_integration_tester` | merged repo -> integration results                   |
 | `run_verifier`           | repo + PRD -> acceptance pass/fail                   |
 | `generate_fix_issues`    | failed criteria -> targeted fix issues               |
-| `run_github_pr`          | branch -> push + draft PR                            |
+| `run_github_pr`          | branch -> push + PR                            |
 
 </details>
 

--- a/swe_af/app.py
+++ b/swe_af/app.py
@@ -18,7 +18,6 @@ from swe_af.reasoners.pipeline import _assign_sequence_numbers, _compute_levels,
 from swe_af.reasoners.schemas import PlanResult, ReviewResult
 
 from agentfield import Agent
-from swe_af.execution.ci_gate import mark_pr_ready
 from swe_af.execution.envelope import unwrap_call_result as _unwrap
 from swe_af.execution.schemas import (
     BuildConfig,
@@ -182,8 +181,11 @@ async def _run_ci_gate(
     goal: str,
     completed_issues: list[dict],
 ) -> dict:
-    """Watch CI on the freshly-pushed draft PR; fix-and-repush if it fails;
-    promote to ready-for-review when green.
+    """Watch CI on the freshly-pushed PR; fix-and-repush if it fails.
+
+    PRs are opened ready for review (no draft phase), so this gate only does
+    the watch + fix-loop work — there's no promotion step. On terminal
+    failure the PR stays open with visible failing checks for human review.
 
     Returns a summary dict the build can attach to its response. Bounded by
     ``cfg.max_ci_fix_cycles`` and ``cfg.ci_wait_seconds`` per watch.
@@ -207,28 +209,24 @@ async def _run_ci_gate(
         status = watch.get("status", "error")
 
         if status in ("passed", "no_checks"):
-            ok, msg = mark_pr_ready(repo_path=repo_path, pr_number=pr_number)
             app.note(
-                f"CI gate: {status} → {msg}",
-                tags=["ci_gate", "ready" if ok else "ready_failed"],
+                f"CI gate: {status} — PR ready for review",
+                tags=["ci_gate", "ready"],
             )
             return {
                 "final_status": "passed" if status == "passed" else "no_checks",
-                "promoted_to_ready": ok,
-                "promote_message": msg,
                 "fix_attempts": attempts,
                 "watch": watch,
             }
 
         if status in ("timed_out", "error"):
             app.note(
-                f"CI gate: {status} — leaving PR in draft. {watch.get('summary', '')}",
+                f"CI gate: {status} — PR stays open with failing checks. "
+                f"{watch.get('summary', '')}",
                 tags=["ci_gate", status],
             )
             return {
                 "final_status": status,
-                "promoted_to_ready": False,
-                "promote_message": "",
                 "fix_attempts": attempts,
                 "watch": watch,
             }
@@ -237,13 +235,11 @@ async def _run_ci_gate(
         if cycle >= cfg.max_ci_fix_cycles:
             app.note(
                 f"CI gate: exhausted {cfg.max_ci_fix_cycles} fix cycle(s) — "
-                "leaving PR in draft",
+                "PR stays open with failing checks",
                 tags=["ci_gate", "exhausted"],
             )
             return {
                 "final_status": "failed_exhausted",
-                "promoted_to_ready": False,
-                "promote_message": "",
                 "fix_attempts": attempts,
                 "watch": watch,
             }
@@ -276,13 +272,11 @@ async def _run_ci_gate(
         if not fix.get("pushed"):
             app.note(
                 f"CI gate: fixer did not push ({fix.get('summary', 'no summary')}) — "
-                "leaving PR in draft",
+                "PR stays open with failing checks",
                 tags=["ci_gate", "fixer_no_push"],
             )
             return {
                 "final_status": "fixer_gave_up",
-                "promoted_to_ready": False,
-                "promote_message": "",
                 "fix_attempts": attempts,
                 "watch": watch,
             }
@@ -293,8 +287,6 @@ async def _run_ci_gate(
     # Loop fell through (shouldn't happen because the failed branch returns).
     return {
         "final_status": "loop_exhausted",
-        "promoted_to_ready": False,
-        "promote_message": "",
         "fix_attempts": attempts,
         "watch": last_watch or {},
     }
@@ -761,7 +753,7 @@ async def build(
 
     if manifest and len(manifest.repos) > 1:
         # Multi-repo: one PR per repo where create_pr=True
-        app.note("Phase 4: Multi-repo Push + Draft PRs", tags=["build", "github_pr", "multi-repo"])
+        app.note("Phase 4: Multi-repo Push + PRs", tags=["build", "github_pr", "multi-repo"])
         for ws_repo in manifest.repos:
             if not ws_repo.create_pr or not cfg.enable_github_pr:
                 continue
@@ -805,7 +797,7 @@ async def build(
                 ))
                 if pr_r.get("pr_url"):
                     app.note(
-                        f"Draft PR created for {ws_repo.repo_name}: {pr_r.get('pr_url')}",
+                        f"PR created for {ws_repo.repo_name}: {pr_r.get('pr_url')}",
                         tags=["build", "github_pr", "complete"],
                     )
                     if cfg.check_ci and pr_r.get("pr_number"):
@@ -842,7 +834,7 @@ async def build(
         # Single-repo: existing PR logic, wrap result in RepoPRResult
         remote_url = git_config.get("remote_url", "") if git_config else ""
         if remote_url and cfg.enable_github_pr:
-            app.note("Phase 4: Push + Draft PR", tags=["build", "github_pr"])
+            app.note("Phase 4: Push + PR", tags=["build", "github_pr"])
             base_branch = (
                 cfg.github_pr_base
                 or (git_config.get("remote_default_branch") if git_config else "")
@@ -866,7 +858,7 @@ async def build(
                 ), "run_github_pr")
                 pr_url = pr_result.get("pr_url", "")
                 if pr_url:
-                    app.note(f"Draft PR created: {pr_url}", tags=["build", "github_pr", "complete"])
+                    app.note(f"PR created: {pr_url}", tags=["build", "github_pr", "complete"])
 
                     # Programmatically append plan docs to PR body
                     if prd_markdown or architecture_markdown:

--- a/swe_af/execution/ci_gate.py
+++ b/swe_af/execution/ci_gate.py
@@ -1,9 +1,12 @@
 """Deterministic helpers for the post-PR CI gate.
 
-The CI gate watches GitHub Actions checks on a draft PR after SWE-AF pushes
-its work, using the ``gh`` CLI. Polling, log retrieval, and PR-state
-transitions live here so they can be unit-tested without a GitHub remote or
-an LLM in the loop.
+The CI gate watches GitHub Actions checks on a PR after SWE-AF pushes its
+work, using the ``gh`` CLI. Polling and log retrieval live here so they can
+be unit-tested without a GitHub remote or an LLM in the loop.
+
+PRs are opened ready for review (no draft phase). ``mark_pr_ready`` remains
+in this module as a backwards-compatible no-op for callers that still
+invoke it, but the build pipeline no longer calls it.
 """
 
 from __future__ import annotations
@@ -251,6 +254,10 @@ def mark_pr_ready(
     runner: CommandRunner | None = None,
 ) -> tuple[bool, str]:
     """Promote a draft PR to ready-for-review via `gh pr ready <num>`.
+
+    Kept for backwards compatibility and as a manually-callable utility.
+    The build pipeline no longer invokes this — PRs are now opened ready
+    for review from the start (no draft phase) so promotion is unnecessary.
 
     Returns ``(success, message)``. ``message`` carries the gh stderr on
     failure (truncated), or a short confirmation on success.

--- a/swe_af/execution/schemas.py
+++ b/swe_af/execution/schemas.py
@@ -687,13 +687,14 @@ class BuildConfig(BaseModel):
     permission_mode: str = ""
     repo_url: str = ""  # GitHub URL to clone (single-repo shorthand)
     repos: list[RepoSpec] = []  # Multi-repo list; normalised by _normalize_repos
-    enable_github_pr: bool = True  # Create draft PR after build
+    enable_github_pr: bool = True  # Create PR (ready for review) after build
     github_pr_base: str = ""  # PR base branch (default: repo's default branch)
-    # Post-PR CI gate. When True, after the draft PR is opened SWE-AF waits for
-    # CI to be conclusive, runs a bounded fix-and-repush loop on failure, and
-    # promotes the PR with `gh pr ready` only when CI is green. When False,
-    # the build returns immediately after creating the draft PR (legacy
-    # behaviour).
+    # Post-PR CI gate. When True, after the PR is opened SWE-AF waits for CI
+    # to be conclusive and runs a bounded fix-and-repush loop on failure.
+    # PRs are opened ready for review (no draft phase), so this gate does
+    # NOT toggle a draft → ready promotion — passing CI is success, failing
+    # CI leaves the PR open with visible failing checks. When False, the
+    # build returns immediately after creating the PR.
     check_ci: bool = True
     max_ci_fix_cycles: int = 2  # number of fix → repush → re-watch iterations
     ci_wait_seconds: int = 1500  # wall-clock cap per watch (25 min)
@@ -853,7 +854,7 @@ class RepoFinalizeResult(BaseModel):
 
 
 class GitHubPRResult(BaseModel):
-    """Result of pushing and creating a draft PR on GitHub."""
+    """Result of pushing and creating a PR on GitHub."""
 
     success: bool
     pr_url: str = ""

--- a/swe_af/prompts/github_pr.py
+++ b/swe_af/prompts/github_pr.py
@@ -1,24 +1,24 @@
-"""Prompt builder for the GitHub Push + Draft PR agent role."""
+"""Prompt builder for the GitHub Push + PR agent role."""
 
 from __future__ import annotations
 
 SYSTEM_PROMPT = """\
 You are a DevOps engineer responsible for pushing completed work to GitHub and
-creating a draft pull request. You work at the end of an autonomous build
-pipeline that has already planned, coded, tested, and verified the changes.
+creating a pull request. You work at the end of an autonomous build pipeline
+that has already planned, coded, tested, and verified the changes.
 
 ## Your Responsibilities
 
 1. Push the integration branch to the remote origin.
-2. Create a **draft** pull request using the `gh` CLI.
+2. Create a pull request using the `gh` CLI.
 3. Return the PR URL and number.
 
 ## Constraints
 
 - Use `git push origin <branch>` to push.
-- Use `gh pr create --draft` to create the PR.
+- Use `gh pr create` to create the PR (NOT `--draft` — open the PR ready for review).
 - The `GH_TOKEN` environment variable is already set for authentication.
-- Do NOT merge the PR — it must remain a draft.
+- Do NOT merge the PR.
 - Do NOT modify any code or files.
 - If push or PR creation fails, report the error clearly.
 
@@ -51,7 +51,7 @@ def github_pr_task_prompt(
     """Build the task prompt for the GitHub PR agent."""
     sections: list[str] = []
 
-    sections.append("## Push & Draft PR Task")
+    sections.append("## Push & PR Task")
     sections.append(f"- **Repository path**: `{repo_path}`")
     sections.append(f"- **Integration branch**: `{integration_branch}`")
     sections.append(f"- **Base branch (PR target)**: `{base_branch}`")
@@ -93,7 +93,8 @@ def github_pr_task_prompt(
         "1. Push the integration branch to `origin`.\n"
         "2. Generate a concise PR title from the goal (imperative mood, <70 chars).\n"
         "3. Generate the PR body with Summary, Changes, and Test plan sections.\n"
-        "4. Create a draft PR: `gh pr create --draft --base <base> --head <branch> --title '...' --body '...'`\n"
+        "4. Create a PR: `gh pr create --base <base> --head <branch> --title '...' --body '...'`\n"
+        "   (do NOT pass `--draft` — the PR should be opened ready for review).\n"
         "5. Return a GitHubPRResult JSON object with success, pr_url, pr_number."
     )
 


### PR DESCRIPTION
## Summary

- The github_pr agent's prompt was hardcoded to `gh pr create --draft`, so every SWE-AF build produced a draft PR. With the post-PR CI gate from #57, drafts are no longer the right default — the gate itself watches CI and runs a bounded fix-and-repush loop on failure, so the PR can land ready for review from the start.
- This PR removes the draft phase end-to-end: prompt change, CI-gate cleanup, doc updates.

## What changed

- **`swe_af/prompts/github_pr.py`** — system prompt + task prompt no longer say "draft"; agent is told to use plain `gh pr create` (with explicit guidance NOT to pass `--draft`).
- **`swe_af/app.py`** — removed the `mark_pr_ready` import + call in `_run_ci_gate`. PRs are already ready when the gate starts; promotion is a no-op or error. Updated docstrings + log messages: "leaving PR in draft" → "PR stays open with failing checks". Dropped the `promoted_to_ready` / `promote_message` fields from the gate's return dict — only consumed internally (verified by grep).
- **`swe_af/execution/schemas.py`** — updated comments on `BuildConfig.enable_github_pr` / `check_ci` and `RepoPRResult` docstring.
- **`swe_af/execution/ci_gate.py`** — module docstring + `mark_pr_ready` docstring describe the function as a backwards-compat utility no longer called by the build pipeline. The function itself is **unchanged**; tests for it still pass.
- **README.md** — Post-PR CI gate section + GitHub Repo Workflow heading describe the new behaviour.

## Behaviour delta

| Scenario | Before | After |
|---|---|---|
| CI passes | Draft PR → `gh pr ready` → ready PR | PR ready from creation; gate returns success |
| CI fails after fix attempts | PR stays in draft | PR stays open with visible failing checks |
| `check_ci=False` | Draft PR, build returns | Ready PR, build returns |

Failure visibility now comes from GitHub's standard failing-checks UI on a real PR rather than from the draft state.

## Tests

- `pytest tests/test_ci_gate.py tests/test_model_config.py -q` → 53/53 pass.
- `mark_pr_ready` is still tested (kept for backwards compat); just no longer in the build flow.

## Commits

1. `prompts: open PRs ready for review, not as draft` — the load-bearing prompt change.
2. `ci_gate: drop draft-promotion step; PRs are now created ready` — companion app.py + schemas + ci_gate cleanup.
3. `docs: README — PRs are now opened ready for review` — README.

## Test plan

- [x] `pytest tests/test_ci_gate.py tests/test_model_config.py` passes
- [x] `python3 -m py_compile` over edited files
- [ ] CI green on this PR
- [ ] Manual: deploy this branch, run a real build (e.g. via `github buddy implement` on an issue), confirm the resulting PR is opened ready for review (not draft) and the CI gate still watches/fixes as expected

## Related

- Builds on #57 (post-PR CI gate). Both are required to make `github buddy implement` produce a non-draft PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)