### PR TITLE
feat: add resolve() — update existing PRs (merge base, fix CI, address comments, push)

### DIFF
--- a/swe_af/app.py
+++ b/swe_af/app.py
@@ -1197,6 +1197,367 @@ async def execute(
 
 
 @app.reasoner()
+async def resolve(
+    pr_url: str,
+    pr_number: int,
+    repo_url: str,
+    head_branch: str,
+    base_branch: str = "main",
+    ci_failures: list[dict] | None = None,
+    review_comments: list[dict] | None = None,
+    additional_context: str = "",
+    config: dict | None = None,
+) -> dict:
+    """Update an existing PR: merge base, fix CI, address review comments, push.
+
+    Single-repo only (v1) — no multi-repo workspace, no forked-PR support.
+    Caller is expected to pass the PR's own head_branch (within the same
+    repo as ``repo_url``); SWE-AF will check it out, merge ``base_branch``
+    into it (always merge, never rebase), hand the working tree to the
+    PR-resolver agent, push, run the CI fix loop, and post brief replies +
+    resolve threads for every addressed review comment.
+
+    Returns a dict with shape::
+
+        {
+            "pr_url": str,
+            "pr_number": int,
+            "head_branch": str,
+            "base_branch": str,
+            "merge_state": "clean" | "merged" | "conflict" | "skipped",
+            "resolve_result": <PRResolveResult>,
+            "ci_gate": {...} | None,
+            "thread_replies": [{"comment_id", "thread_id", "replied", "resolved"}, ...],
+            "summary": str,
+            "success": bool,
+        }
+    """
+    ci_failures = ci_failures or []
+    review_comments = review_comments or []
+    cfg = BuildConfig(**config) if config else BuildConfig()
+    cfg.enable_github_pr = False  # the PR already exists — never create
+
+    if not pr_number or not head_branch or not repo_url or not pr_url:
+        raise ValueError(
+            "resolve requires non-empty pr_url, pr_number, repo_url, head_branch"
+        )
+
+    build_id = uuid.uuid4().hex[:8]
+    repo_name = _repo_name_from_url(repo_url)
+    repo_path = f"/workspaces/{repo_name}-resolve-{build_id}"
+
+    app.note(
+        f"Resolve starting (build_id={build_id}) — PR #{pr_number}",
+        tags=["resolve", "start"],
+    )
+
+    # ---- 1. Clone -----------------------------------------------------------
+    os.makedirs(repo_path, exist_ok=True)
+    clone = subprocess.run(
+        ["git", "clone", repo_url, repo_path],
+        capture_output=True, text=True,
+    )
+    if clone.returncode != 0:
+        err = clone.stderr.strip()
+        app.note(
+            f"Resolve clone failed: {err}",
+            tags=["resolve", "clone", "error"],
+        )
+        raise RuntimeError(f"git clone failed: {err}")
+
+    # ---- 2. Fetch PR head + checkout ---------------------------------------
+    fetch_pr = subprocess.run(
+        ["git", "fetch", "origin", f"pull/{pr_number}/head:{head_branch}"],
+        cwd=repo_path, capture_output=True, text=True,
+    )
+    if fetch_pr.returncode != 0:
+        # Fallback: branch may already be a regular ref on origin (same-repo PR).
+        fetch_branch = subprocess.run(
+            ["git", "fetch", "origin", f"{head_branch}:{head_branch}"],
+            cwd=repo_path, capture_output=True, text=True,
+        )
+        if fetch_branch.returncode != 0:
+            err = (fetch_pr.stderr + "\n" + fetch_branch.stderr).strip()
+            app.note(
+                f"Resolve fetch PR head failed: {err}",
+                tags=["resolve", "fetch", "error"],
+            )
+            raise RuntimeError(f"git fetch PR head failed: {err}")
+
+    checkout = subprocess.run(
+        ["git", "checkout", head_branch],
+        cwd=repo_path, capture_output=True, text=True,
+    )
+    if checkout.returncode != 0:
+        err = checkout.stderr.strip()
+        app.note(
+            f"Resolve checkout failed: {err}",
+            tags=["resolve", "checkout", "error"],
+        )
+        raise RuntimeError(f"git checkout {head_branch} failed: {err}")
+
+    # Configure committer identity for any merge / commit we make in this
+    # workspace. Without this, `git commit` errors on a fresh clone in the
+    # SWE-AF container. Match the existing run_github_pr / repo_finalize
+    # convention (a bot identity).
+    for key, value in (
+        ("user.email", os.getenv("SWE_AF_GIT_EMAIL", "swe-af@users.noreply.github.com")),
+        ("user.name", os.getenv("SWE_AF_GIT_NAME", "SWE-AF")),
+    ):
+        subprocess.run(
+            ["git", "config", key, value],
+            cwd=repo_path, capture_output=True, text=True,
+        )
+
+    # ---- 3. Merge base into head (always merge, never rebase) --------------
+    merge_state, conflicted_files = _attempt_base_merge(
+        repo_path=repo_path,
+        base_branch=base_branch,
+    )
+    app.note(
+        f"Resolve merge state: {merge_state}"
+        + (f" ({len(conflicted_files)} conflict(s))" if conflicted_files else ""),
+        tags=["resolve", "merge", merge_state],
+    )
+
+    # ---- 4. Run the PR resolver agent --------------------------------------
+    resolved_models = cfg.resolved_models()
+    # Prefer the ci_fixer slot (sized for code-fix tasks); fall back to coder
+    # if not configured.
+    resolver_model = (
+        resolved_models.get("ci_fixer_model")
+        or resolved_models.get("coder_model")
+        or "sonnet"
+    )
+
+    resolve_result = _unwrap(await app.call(
+        f"{NODE_ID}.run_pr_resolver",
+        repo_path=repo_path,
+        pr_number=pr_number,
+        pr_url=pr_url,
+        head_branch=head_branch,
+        base_branch=base_branch,
+        merge_state=merge_state,
+        conflicted_files=conflicted_files,
+        failed_checks=ci_failures,
+        review_comments=review_comments,
+        additional_context=additional_context,
+        model=resolver_model,
+        permission_mode=cfg.permission_mode,
+        ai_provider=cfg.ai_provider,
+    ), "run_pr_resolver")
+
+    # ---- 5. Ensure push happened (agent may have skipped on failure) -------
+    pushed = bool(resolve_result.get("pushed"))
+    if not pushed and resolve_result.get("commit_shas"):
+        # Agent committed but didn't push — push for it.
+        push = subprocess.run(
+            ["git", "push", "origin", head_branch],
+            cwd=repo_path, capture_output=True, text=True,
+        )
+        if push.returncode == 0:
+            pushed = True
+            resolve_result["pushed"] = True
+            app.note(
+                f"Resolve: pushed agent's commits to {head_branch}",
+                tags=["resolve", "push"],
+            )
+        else:
+            app.note(
+                f"Resolve push failed: {push.stderr.strip()}",
+                tags=["resolve", "push", "error"],
+            )
+
+    # ---- 6. Post-push CI watch + fix loop ----------------------------------
+    ci_gate: dict | None = None
+    if pushed and cfg.check_ci:
+        try:
+            ci_gate = await _run_ci_gate(
+                repo_path=repo_path,
+                pr_number=pr_number,
+                pr_url=pr_url,
+                integration_branch=head_branch,
+                base_branch=base_branch,
+                cfg=cfg,
+                resolved_models=resolved_models,
+                goal=f"Resolve PR #{pr_number}",
+                completed_issues=[],
+            )
+        except Exception as e:
+            app.note(
+                f"Resolve CI gate errored (non-fatal): {e}",
+                tags=["resolve", "ci_gate", "error"],
+            )
+
+    # ---- 7. Reply + resolveReviewThread for addressed comments -------------
+    addressed = [
+        c for c in resolve_result.get("addressed_comments", [])
+        if c.get("addressed")
+    ]
+    thread_replies: list[dict] = []
+    if addressed:
+        thread_replies = await _post_thread_replies_and_resolve(
+            repo_path=repo_path,
+            pr_number=pr_number,
+            addressed=addressed,
+        )
+
+    # ---- 8. Workspace cleanup (non-blocking) -------------------------------
+    try:
+        import shutil
+        shutil.rmtree(repo_path, ignore_errors=True)
+    except Exception:
+        pass
+
+    success = bool(resolve_result.get("fixed") and pushed)
+    summary = (
+        f"PR #{pr_number}: merge={merge_state}, "
+        f"{len(resolve_result.get('files_changed', []))} file(s) changed, "
+        f"{sum(1 for c in addressed)}/{len(resolve_result.get('addressed_comments', []))} comment(s) addressed"
+        + (f", CI={ci_gate.get('final_status', 'n/a')}" if ci_gate else "")
+    )
+
+    app.note(
+        f"Resolve {'succeeded' if success else 'completed with issues'}: {summary}",
+        tags=["resolve", "complete"],
+    )
+
+    return {
+        "pr_url": pr_url,
+        "pr_number": pr_number,
+        "head_branch": head_branch,
+        "base_branch": base_branch,
+        "merge_state": merge_state,
+        "resolve_result": resolve_result,
+        "ci_gate": ci_gate,
+        "thread_replies": thread_replies,
+        "summary": summary,
+        "success": success,
+    }
+
+
+def _attempt_base_merge(*, repo_path: str, base_branch: str) -> tuple[str, list[str]]:
+    """Fetch ``base_branch`` and merge it into the current branch.
+
+    Returns ``(merge_state, conflicted_files)`` where ``merge_state`` is one of
+    "clean" (already up to date), "merged" (merge succeeded), "conflict" (merge
+    in progress with unresolved conflicts), or "skipped" (couldn't fetch base).
+
+    Always uses ``git merge`` — never rebase — to preserve PR history.
+    """
+    fetch = subprocess.run(
+        ["git", "fetch", "origin", base_branch],
+        cwd=repo_path, capture_output=True, text=True,
+    )
+    if fetch.returncode != 0:
+        return "skipped", []
+
+    # Already up to date? — check if base is an ancestor of HEAD.
+    ancestor = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", f"origin/{base_branch}", "HEAD"],
+        cwd=repo_path, capture_output=True, text=True,
+    )
+    if ancestor.returncode == 0:
+        return "clean", []
+
+    merge = subprocess.run(
+        ["git", "merge", "--no-edit", "--no-ff", f"origin/{base_branch}"],
+        cwd=repo_path, capture_output=True, text=True,
+    )
+    if merge.returncode == 0:
+        return "merged", []
+
+    # Merge produced conflicts — list them and leave the merge in progress
+    # for the resolver agent to finish.
+    diff = subprocess.run(
+        ["git", "diff", "--name-only", "--diff-filter=U"],
+        cwd=repo_path, capture_output=True, text=True,
+    )
+    conflicted = [
+        line.strip() for line in diff.stdout.splitlines() if line.strip()
+    ]
+    return "conflict", conflicted
+
+
+async def _post_thread_replies_and_resolve(
+    *,
+    repo_path: str,
+    pr_number: int,
+    addressed: list[dict],
+) -> list[dict]:
+    """Post a brief reply and resolve the thread for each addressed comment.
+
+    Uses the ``gh`` CLI (authenticated via GH_TOKEN in the SWE-AF container)
+    so the GraphQL ``resolveReviewThread`` mutation runs under the same
+    identity as the push. Replies are short — the agent's ``note`` field is
+    used verbatim, capped at 500 chars to keep PR conversations tidy.
+
+    Returns one entry per addressed comment with the outcome of both the
+    reply post and the thread resolution. Failures are non-fatal — the
+    push has already landed, so the PR is in a good state regardless.
+    """
+    results: list[dict] = []
+    for entry in addressed:
+        comment_id = int(entry.get("comment_id") or 0)
+        thread_id = (entry.get("thread_id") or "").strip()
+        note = (entry.get("note") or "Addressed.").strip()[:500] or "Addressed."
+
+        replied = False
+        resolved = False
+        reply_error = ""
+        resolve_error = ""
+
+        # Inline review-thread reply (REST). Skipped for non-review comments
+        # (comment_id == 0), e.g. PR conversation comments — those don't have
+        # a per-line thread to reply on; the orchestrator's status comment
+        # carries the response.
+        if comment_id:
+            reply_path = (
+                f"repos/:owner/:repo/pulls/{pr_number}/comments/{comment_id}/replies"
+            )
+            reply = subprocess.run(
+                [
+                    "gh", "api", "-X", "POST", reply_path,
+                    "-f", f"body={note}",
+                ],
+                cwd=repo_path, capture_output=True, text=True,
+            )
+            if reply.returncode == 0:
+                replied = True
+            else:
+                reply_error = reply.stderr.strip()[:300]
+
+        # Thread resolution (GraphQL). Skipped when no thread id is known.
+        if thread_id:
+            mutation = (
+                "mutation($id:ID!){resolveReviewThread(input:{threadId:$id})"
+                "{thread{isResolved}}}"
+            )
+            res = subprocess.run(
+                [
+                    "gh", "api", "graphql",
+                    "-f", f"query={mutation}",
+                    "-f", f"id={thread_id}",
+                ],
+                cwd=repo_path, capture_output=True, text=True,
+            )
+            if res.returncode == 0:
+                resolved = True
+            else:
+                resolve_error = res.stderr.strip()[:300]
+
+        results.append({
+            "comment_id": comment_id,
+            "thread_id": thread_id,
+            "replied": replied,
+            "resolved": resolved,
+            "reply_error": reply_error,
+            "resolve_error": resolve_error,
+        })
+    return results
+
+
+@app.reasoner()
 async def resume_build(
     repo_path: str,
     artifacts_dir: str = ".artifacts",

--- a/swe_af/execution/schemas.py
+++ b/swe_af/execution/schemas.py
@@ -894,6 +894,65 @@ class CIFixResult(BaseModel):
     error_message: str = ""
 
 
+class ReviewCommentRef(BaseModel):
+    """One review comment on an existing PR that the resolver should consider.
+
+    Carries enough context for the resolver to find the comment thread, decide
+    whether the change addresses it, and (back in github-buddy) reply +
+    resolveReviewThread via the GraphQL API.
+
+    `thread_id` is the GraphQL node id of the PR review thread (used to call
+    `resolveReviewThread`). `comment_id` is the REST id of the comment (used
+    to post the inline reply via `/repos/{o}/{r}/pulls/{n}/comments/{id}/replies`).
+    Either may be empty when the source comment is a plain issue-comment on
+    the PR conversation (not anchored to a code line) — in that case the
+    resolver still addresses it but no thread can be resolved.
+    """
+
+    comment_id: int = 0  # 0 when not a review comment (e.g. PR conversation comment)
+    thread_id: str = ""  # GraphQL node id of the review thread; empty for non-review
+    path: str = ""  # File path the comment is anchored to ("" for non-review)
+    line: int = 0  # Line number the comment is anchored to (0 for non-review)
+    author: str = ""  # GitHub login of the commenter
+    body: str = ""  # The comment body (markdown)
+    url: str = ""  # html_url for the comment
+
+
+class AddressedComment(BaseModel):
+    """The resolver agent's record of one comment it claims to have addressed.
+
+    Used to drive the post-resolve "reply + resolveReviewThread" pass. The
+    agent decides which comments it actually addressed (it may judge some
+    irrelevant or out-of-scope and explain in `note`); only entries with
+    `addressed=True` get a reply posted and the thread resolved.
+    """
+
+    comment_id: int = 0
+    thread_id: str = ""
+    addressed: bool
+    note: str = ""  # one-line: "fixed by ...", "skipped because ..."
+
+
+class PRResolveResult(BaseModel):
+    """Output from one run of the PR-resolver agent.
+
+    The agent both resolves any in-progress merge from base AND addresses CI
+    failures + review comments in a single harness session, then commits and
+    pushes. Caller (the `resolve` entry reasoner) then runs the existing CI
+    watch+fix loop and posts replies on every `addressed=True` comment.
+    """
+
+    fixed: bool  # True if the agent believes it produced a correct, complete fix
+    merge_resolved: bool = False  # True iff a merge from base was completed (with or without prior conflicts)
+    files_changed: list[str] = []
+    commit_shas: list[str] = []  # All new commits the agent created (merge + fixes)
+    pushed: bool = False  # True if `git push` succeeded
+    addressed_comments: list[AddressedComment] = []
+    summary: str = ""
+    rejected_workarounds: list[str] = []  # legitimate-fix self-checks the agent ran
+    error_message: str = ""
+
+
 class ExecutionConfig(BaseModel):
     """Configuration for the DAG executor."""
 

--- a/swe_af/prompts/pr_resolver.py
+++ b/swe_af/prompts/pr_resolver.py
@@ -1,0 +1,302 @@
+"""Prompt builder for the PR Resolver agent role.
+
+The PR resolver runs against an OPEN pull request that has any combination of:
+  - merge conflicts against the base branch (already attempted by the caller;
+    the working tree may have unresolved conflict markers when the agent
+    starts).
+  - failing CI checks.
+  - actionable review comments (someone asked for a change).
+
+Its job is to land legitimate fixes for all three on the PR's existing head
+branch and push. It is NOT a CI-only fixer — see ``ci_fixer.py`` for that —
+but it inherits the same "no workarounds, no silenced tests" discipline.
+"""
+
+from __future__ import annotations
+
+from swe_af.execution.schemas import CIFailedCheck, ReviewCommentRef
+
+
+SYSTEM_PROMPT = """\
+You are a senior engineer paged to bring an open pull request back to a
+mergeable state. The PR was opened earlier (by another agent or by a human)
+and now has some combination of: merge conflicts against the base branch,
+failing CI checks, and review comments asking for changes. Your job is to
+land legitimate fixes for all of them on the PR's existing head branch and
+push. The PR already exists — do NOT create a new one.
+
+## You are NOT done until
+
+1. The merge from base is complete (no remaining conflict markers, the merge
+   commit is on the head branch) — if a merge was in progress when you
+   started.
+2. Every failing CI check has been root-caused and fixed in the production
+   code (or in a test that was itself wrong — see "When the test is wrong"
+   below).
+3. Every review comment in the task prompt has been triaged: addressed with
+   a code change, or explicitly marked not-actionable in your output (with a
+   short reason). Reviewers sometimes leave comments that don't require a
+   change — be honest about which is which.
+4. The fix is committed and pushed to the PR's head branch (not a new
+   branch).
+5. You have re-run the relevant tests locally and they pass.
+
+## ABSOLUTELY FORBIDDEN — these are workarounds, not fixes
+
+You MUST NOT do any of the following to make CI green or to "address" a
+review comment:
+
+- Skip the failing test (`@pytest.mark.skip`, `pytest.skip(...)`,
+  `@unittest.skip`, `it.skip`, `xit`, `test.skip`, `t.Skip()`, `#[ignore]`).
+- Mark it as expected-to-fail (`@pytest.mark.xfail`,
+  `@unittest.expectedFailure`, `it.todo`, `#[should_panic]` added solely to
+  hide a real bug).
+- Comment out the failing test or its assertions.
+- Delete the failing test or the file containing it.
+- Loosen an assertion to make it tautological.
+- Wrap the failing code in `try/except: pass` / `try/catch {}` to swallow
+  the error.
+- Change the assertion's expected value to match the buggy output
+  ("snapshot the bug").
+- Disable the failing CI job in the workflow file.
+- Edit the test runner config to deselect the failing test.
+- Hardcode the failing input in a fixture.
+- Mock or stub out the unit under test so the failing path is never hit.
+- Push a no-op commit hoping CI was flaky.
+- "Resolve" a merge conflict by deleting one side of the conflict without
+  understanding what each side was trying to do — preserve both intents
+  unless one is genuinely obsolete and you can justify why.
+
+If you find yourself reaching for any of the above, STOP. Re-read the
+failure or comment and fix the underlying cause.
+
+## When the test is wrong
+
+It is occasionally legitimate to fix the TEST instead of the production
+code — only when the test asserts something the spec/PRD does not require,
+depends on environment that doesn't exist in CI, or has a genuine logic bug.
+Your summary MUST justify why the previous assertion was incorrect with
+reference to the spec, the function's docstring, or the surrounding code's
+behaviour. "Test was too strict" is not a justification.
+
+## Workflow
+
+1. Run `git status` and `git log --oneline -5`. Confirm you are on the PR's
+   head branch and identify whether a merge is in progress (look for
+   `MERGE_HEAD`, conflict markers in tracked files).
+2. If a merge is in progress: open every conflicted file, understand both
+   sides, write the resolution that preserves both intents. Stage with
+   `git add <file>` and complete the merge with `git commit --no-edit` (or
+   with a short message if --no-edit isn't possible).
+3. For each failing CI check: open the relevant source files, locate the
+   assertion that failed, trace it to the production code, and fix it.
+   Re-run the failing test locally with the same command CI used.
+4. For each review comment: read the comment in the context of the file +
+   line it's anchored to. Decide if it asks for a change. If yes, make the
+   change — reviewer comments often capture domain knowledge the original
+   author didn't have. If no (it's a question, a thanks, an outdated remark
+   already covered by another change), record `addressed=false` with a
+   short reason in `note`.
+5. Run any closely-related tests too, to confirm you didn't regress
+   neighbouring behaviour.
+6. Stage and commit ONLY the files that belong to your fix:
+   `git add <files>` then `git commit -m "fix: ..."`. Do NOT use
+   `git add -A` — there may be untracked artifacts.
+7. Push to the PR's head branch: `git push origin <head_branch>`. The PR
+   already exists; pushing updates it. Do NOT use `gh pr create`.
+8. Capture every new commit SHA you produced (merge + fix commits).
+9. Return a `PRResolveResult` JSON object describing what you changed.
+
+## Self-check before pushing
+
+Before you `git push`, answer these in your head:
+
+- "If a reviewer ran the originally-failing test on the previous commit,
+  it would fail. If they run it on my new commit, will it pass for the
+  RIGHT reason — i.e. because the production code now does the right
+  thing — and not because I weakened the test?"
+- "Have I removed, skipped, or relaxed any test or assertion?" If yes,
+  re-justify it against the rules above or back the change out.
+- "For each review comment I marked addressed=true, did I actually change
+  something that responds to the comment?" If not, mark addressed=false
+  with a reason.
+
+## Reply tone for `note` and `summary`
+
+Replies posted on resolved review threads will be brief (one or two
+sentences). Match that tone in your `note` field per addressed comment —
+state what you changed, no preamble. The `summary` field is one paragraph
+covering the merge + CI + comment work as a whole.
+
+## Output
+
+Return a `PRResolveResult` JSON object with:
+
+- `fixed`: true only if you both made the changes AND re-ran the failing
+  tests locally and they passed.
+- `merge_resolved`: true iff you completed a merge from base.
+- `files_changed`: list of files you modified.
+- `commit_shas`: list of every new commit SHA you produced (merge + fixes).
+- `pushed`: true if `git push` succeeded.
+- `addressed_comments`: one entry per review comment in the task prompt,
+  with `addressed` true/false and a short `note`. Preserve `comment_id` and
+  `thread_id` from the input verbatim — the orchestrator uses them to
+  reply + resolve the thread.
+- `summary`: 2-4 sentences covering the whole pass.
+- `rejected_workarounds`: list of strings, one per workaround you considered
+  and rejected. Empty list is fine.
+- `error_message`: empty on success; short description of what blocked you.
+
+## Tools Available
+
+- READ to inspect source and test files
+- EDIT/WRITE to modify code (and to resolve conflict markers)
+- BASH for running tests, git operations, and `gh run view --log-failed` if
+  you need more log context than what was provided\
+"""
+
+
+def pr_resolver_task_prompt(
+    *,
+    repo_path: str,
+    pr_number: int,
+    pr_url: str,
+    head_branch: str,
+    base_branch: str,
+    merge_state: str,
+    conflicted_files: list[str],
+    failed_checks: list[CIFailedCheck | dict],
+    review_comments: list[ReviewCommentRef | dict],
+    additional_context: str = "",
+) -> str:
+    """Build the task prompt for one PR-resolver run.
+
+    ``merge_state`` is one of:
+      - "clean":     no merge in progress — base was already merged or the
+                     branch is up to date with base.
+      - "merged":    merge from base was just completed automatically by the
+                     orchestrator (no conflicts).
+      - "conflict":  merge from base is in progress and ``conflicted_files``
+                     lists the files with unresolved conflict markers.
+      - "skipped":   no merge attempted (e.g. caller chose to leave the
+                     branch as-is).
+    """
+    sections: list[str] = []
+    sections.append("## PR Resolve Task")
+    sections.append(f"- **Repository path**: `{repo_path}`")
+    sections.append(f"- **PR**: #{pr_number} — {pr_url}")
+    sections.append(f"- **Head branch (push target)**: `{head_branch}`")
+    sections.append(f"- **Base branch**: `{base_branch}`")
+    sections.append(f"- **Merge state**: `{merge_state}`")
+
+    if merge_state == "conflict" and conflicted_files:
+        sections.append("\n### Conflicted files (unresolved merge markers)")
+        for path in conflicted_files:
+            sections.append(f"- `{path}`")
+        sections.append(
+            "\nA `git merge origin/" + base_branch + "` is currently in "
+            "progress. Resolve every conflict, stage the files, and complete "
+            "the merge with `git commit --no-edit` BEFORE moving on to CI / "
+            "review comments."
+        )
+    elif merge_state == "merged":
+        sections.append(
+            "\nThe orchestrator already merged `origin/" + base_branch + "` "
+            "into the head branch with no conflicts — that commit is already "
+            "on HEAD. You do not need to redo it; proceed to CI + comments."
+        )
+    elif merge_state == "clean":
+        sections.append(
+            "\nNo merge from base was needed (the branch is already up to "
+            "date). Proceed to CI + comments."
+        )
+    elif merge_state == "skipped":
+        sections.append(
+            "\nNo merge from base was attempted by the orchestrator. If you "
+            "see drift causing CI failures, you may run the merge yourself "
+            "(`git fetch origin " + base_branch + " && git merge --no-edit "
+            "origin/" + base_branch + "`); otherwise leave history alone."
+        )
+
+    if failed_checks:
+        sections.append("\n### Failing CI checks")
+        for fc in failed_checks:
+            data = fc.model_dump() if hasattr(fc, "model_dump") else dict(fc)
+            name = data.get("name", "?")
+            workflow = data.get("workflow", "")
+            conclusion = data.get("conclusion", "")
+            url = data.get("details_url", "")
+            logs = data.get("logs_excerpt", "")
+            header = f"#### {name}"
+            if workflow:
+                header += f"  (workflow: {workflow})"
+            if conclusion:
+                header += f"  [{conclusion}]"
+            sections.append(header)
+            if url:
+                sections.append(f"Details: {url}")
+            if logs:
+                sections.append("Log tail (last failing output):")
+                sections.append("```")
+                sections.append(logs)
+                sections.append("```")
+            else:
+                sections.append(
+                    "(No log captured. Run "
+                    "`gh run view <run-id> --log-failed` to fetch it.)"
+                )
+    else:
+        sections.append("\n### Failing CI checks\n(none — CI is green or hasn't run yet.)")
+
+    if review_comments:
+        sections.append("\n### Review comments to address")
+        sections.append(
+            "Each comment was pre-classified as actionable. Triage each one: "
+            "if it asks for a change you agree with, make it; if not, mark "
+            "`addressed=false` with a one-line reason. Preserve `comment_id` "
+            "and `thread_id` verbatim in your output — the orchestrator uses "
+            "them to reply and resolve the thread."
+        )
+        for rc in review_comments:
+            data = rc.model_dump() if hasattr(rc, "model_dump") else dict(rc)
+            cid = data.get("comment_id", 0)
+            tid = data.get("thread_id", "")
+            path = data.get("path", "")
+            line = data.get("line", 0)
+            author = data.get("author", "")
+            body = data.get("body", "")
+            url = data.get("url", "")
+            anchor = ""
+            if path and line:
+                anchor = f"`{path}:{line}` — "
+            elif path:
+                anchor = f"`{path}` — "
+            sections.append(
+                f"\n#### Comment {cid} (thread {tid or 'n/a'})"
+            )
+            sections.append(f"{anchor}@{author}: {body}")
+            if url:
+                sections.append(f"({url})")
+    else:
+        sections.append(
+            "\n### Review comments to address\n(none flagged actionable.)"
+        )
+
+    if additional_context:
+        sections.append("\n### Additional context")
+        sections.append(additional_context)
+
+    sections.append(
+        "\n## Your Task\n"
+        "1. Complete any in-progress merge from base.\n"
+        "2. Fix every failing CI check by changing PRODUCTION code (no "
+        "silenced tests).\n"
+        "3. Address every actionable review comment, recording each one in "
+        "`addressed_comments` (true/false + brief note).\n"
+        "4. Re-run failing tests locally to confirm they pass.\n"
+        f"5. Commit + `git push origin {head_branch}` — do NOT create a new "
+        "PR.\n"
+        "6. Return a `PRResolveResult` JSON object."
+    )
+
+    return "\n".join(sections)

--- a/swe_af/reasoners/execution_agents.py
+++ b/swe_af/reasoners/execution_agents.py
@@ -25,17 +25,21 @@ from swe_af.execution.schemas import (
     IntegrationTestResult,
     IssueAdvisorDecision,
     MergeResult,
+    PRResolveResult,
     QAResult,
     QASynthesisResult,
     ReplanAction,
     ReplanDecision,
     RepoFinalizeResult,
     RetryAdvice,
+    ReviewCommentRef,
     VerificationResult,
     WorkspaceInfo,
 )
 from swe_af.prompts.ci_fixer import SYSTEM_PROMPT as CI_FIXER_SYSTEM_PROMPT
 from swe_af.prompts.ci_fixer import ci_fixer_task_prompt
+from swe_af.prompts.pr_resolver import SYSTEM_PROMPT as PR_RESOLVER_SYSTEM_PROMPT
+from swe_af.prompts.pr_resolver import pr_resolver_task_prompt
 from swe_af.prompts.fix_generator import SYSTEM_PROMPT as FIX_GENERATOR_SYSTEM_PROMPT
 from swe_af.prompts.fix_generator import fix_generator_task_prompt
 from swe_af.prompts.issue_advisor import SYSTEM_PROMPT as ISSUE_ADVISOR_SYSTEM_PROMPT
@@ -1600,4 +1604,105 @@ async def run_ci_fixer(
         fixed=False,
         summary="CI fixer agent failed to produce a valid result.",
         error_message="CI fixer agent failed to produce a valid result.",
+    ).model_dump()
+
+
+@router.reasoner()
+async def run_pr_resolver(
+    repo_path: str,
+    pr_number: int,
+    pr_url: str,
+    head_branch: str,
+    base_branch: str,
+    merge_state: str = "skipped",
+    conflicted_files: list[str] | None = None,
+    failed_checks: list[dict] | None = None,
+    review_comments: list[dict] | None = None,
+    additional_context: str = "",
+    model: str = "sonnet",
+    permission_mode: str = "",
+    ai_provider: str = "claude",
+) -> dict:
+    """Resolve an open PR: complete an in-progress merge, fix CI, address comments, push.
+
+    The agent is started with the working tree already on the PR's head
+    branch. ``merge_state`` tells it whether a merge from base is in progress
+    ("conflict"), was already completed ("merged"), wasn't needed ("clean"),
+    or was deliberately skipped ("skipped").
+
+    Returns a ``PRResolveResult`` dict. The orchestrator (``app.resolve``)
+    consumes ``addressed_comments`` to drive the post-resolve thread-reply
+    pass and uses ``pushed`` to decide whether to run the CI fix loop.
+    """
+    failed_checks = failed_checks or []
+    review_comments = review_comments or []
+    conflicted_files = conflicted_files or []
+
+    router.note(
+        f"PR resolver: PR #{pr_number}, merge_state={merge_state}, "
+        f"{len(failed_checks)} failing check(s), "
+        f"{len(review_comments)} review comment(s)",
+        tags=["pr_resolver", "start"],
+    )
+
+    typed_failures = [
+        fc if isinstance(fc, CIFailedCheck) else CIFailedCheck(**fc)
+        for fc in failed_checks
+    ]
+    typed_comments = [
+        rc if isinstance(rc, ReviewCommentRef) else ReviewCommentRef(**rc)
+        for rc in review_comments
+    ]
+
+    task_prompt = pr_resolver_task_prompt(
+        repo_path=repo_path,
+        pr_number=pr_number,
+        pr_url=pr_url,
+        head_branch=head_branch,
+        base_branch=base_branch,
+        merge_state=merge_state,
+        conflicted_files=conflicted_files,
+        failed_checks=typed_failures,
+        review_comments=typed_comments,
+        additional_context=additional_context,
+    )
+
+    provider = "claude-code" if ai_provider == "claude" else ai_provider
+
+    try:
+        result = await router.harness(
+            task_prompt,
+            system_prompt=PR_RESOLVER_SYSTEM_PROMPT,
+            schema=PRResolveResult,
+            model=model,
+            provider=provider,
+            tools=["Bash", "Read", "Edit", "Write", "Glob", "Grep"],
+            cwd=repo_path,
+            max_turns=DEFAULT_AGENT_MAX_TURNS,
+            permission_mode=permission_mode or None,
+        )
+        check_fatal_harness_error(result)
+        if result.parsed is not None:
+            router.note(
+                f"PR resolver complete: fixed={result.parsed.fixed}, "
+                f"pushed={result.parsed.pushed}, "
+                f"merge_resolved={result.parsed.merge_resolved}, "
+                f"{len(result.parsed.files_changed)} file(s) changed, "
+                f"{sum(1 for c in result.parsed.addressed_comments if c.addressed)}"
+                f"/{len(result.parsed.addressed_comments)} comment(s) addressed",
+                tags=["pr_resolver", "complete"],
+            )
+            return result.parsed.model_dump()
+    except FatalHarnessError:
+        raise
+    except Exception as e:
+        router.note(
+            f"PR resolver agent failed: {e}",
+            tags=["pr_resolver", "error"],
+        )
+
+    return PRResolveResult(
+        fixed=False,
+        summary="PR resolver agent failed to produce a valid result.",
+        error_message="PR resolver agent failed to produce a valid result.",
     ).model_dump()

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -1,0 +1,440 @@
+"""Unit tests for the ``resolve`` entry reasoner and its support helpers.
+
+The heavy work in ``resolve()`` is shelled out to ``subprocess`` (clone,
+fetch, merge, push, gh CLI) and to a single ``run_pr_resolver`` reasoner
+call. These tests mock those boundaries so the orchestration shape — input
+validation, merge-state classification, agent invocation kwargs, thread
+reply pass — can be exercised without touching the network or the harness.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+os.environ.setdefault("AGENTFIELD_SERVER", "http://localhost:9999")
+
+
+# ---------------------------------------------------------------------------
+# Schema sanity
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSchemas:
+    def test_review_comment_ref_round_trip(self) -> None:
+        from swe_af.execution.schemas import ReviewCommentRef
+
+        rc = ReviewCommentRef(
+            comment_id=42,
+            thread_id="PRRT_xyz",
+            path="foo/bar.py",
+            line=17,
+            author="alice",
+            body="please rename this",
+            url="https://example/comments/42",
+        )
+        assert rc.model_dump()["comment_id"] == 42
+        assert ReviewCommentRef(**rc.model_dump()) == rc
+
+    def test_review_comment_ref_defaults_for_non_review_comment(self) -> None:
+        """PR-conversation comments have no thread or anchor — defaults must allow that."""
+        from swe_af.execution.schemas import ReviewCommentRef
+
+        rc = ReviewCommentRef(author="alice", body="thoughts?")
+        assert rc.comment_id == 0
+        assert rc.thread_id == ""
+        assert rc.path == ""
+        assert rc.line == 0
+
+    def test_pr_resolve_result_defaults(self) -> None:
+        from swe_af.execution.schemas import PRResolveResult
+
+        rr = PRResolveResult(fixed=True)
+        # All optional fields default to falsy/empty so a minimal agent
+        # response still parses.
+        assert rr.merge_resolved is False
+        assert rr.commit_shas == []
+        assert rr.addressed_comments == []
+        assert rr.pushed is False
+
+    def test_addressed_comment_round_trip(self) -> None:
+        from swe_af.execution.schemas import AddressedComment
+
+        ac = AddressedComment(
+            comment_id=1,
+            thread_id="PRRT_x",
+            addressed=True,
+            note="Fixed by renaming foo→bar",
+        )
+        assert ac.addressed is True
+        assert AddressedComment(**ac.model_dump()) == ac
+
+
+# ---------------------------------------------------------------------------
+# _attempt_base_merge — merge-state classification
+# ---------------------------------------------------------------------------
+
+
+def _make_completed_process(returncode: int, stdout: str = "", stderr: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr,
+    )
+
+
+class TestAttemptBaseMerge:
+    """The helper must classify merge state without relying on a real git repo."""
+
+    def test_skipped_when_fetch_fails(self) -> None:
+        from swe_af.app import _attempt_base_merge
+
+        with patch("swe_af.app.subprocess.run") as run:
+            run.return_value = _make_completed_process(1, stderr="no remote")
+            state, conflicts = _attempt_base_merge(
+                repo_path="/tmp/x", base_branch="main",
+            )
+        assert state == "skipped"
+        assert conflicts == []
+        # Only the fetch call was made — we shouldn't try to merge if fetch
+        # didn't even succeed.
+        assert run.call_count == 1
+
+    def test_clean_when_base_already_ancestor(self) -> None:
+        from swe_af.app import _attempt_base_merge
+
+        # Sequence: fetch ok, merge-base --is-ancestor returns 0 ("yes").
+        with patch("swe_af.app.subprocess.run") as run:
+            run.side_effect = [
+                _make_completed_process(0),  # fetch
+                _make_completed_process(0),  # merge-base --is-ancestor (0 == is-ancestor)
+            ]
+            state, conflicts = _attempt_base_merge(
+                repo_path="/tmp/x", base_branch="main",
+            )
+        assert state == "clean"
+        assert conflicts == []
+
+    def test_merged_when_merge_succeeds(self) -> None:
+        from swe_af.app import _attempt_base_merge
+
+        with patch("swe_af.app.subprocess.run") as run:
+            run.side_effect = [
+                _make_completed_process(0),  # fetch
+                _make_completed_process(1),  # merge-base --is-ancestor (1 == not-ancestor)
+                _make_completed_process(0),  # git merge succeeds
+            ]
+            state, conflicts = _attempt_base_merge(
+                repo_path="/tmp/x", base_branch="main",
+            )
+        assert state == "merged"
+        assert conflicts == []
+
+    def test_conflict_lists_unmerged_files(self) -> None:
+        from swe_af.app import _attempt_base_merge
+
+        with patch("swe_af.app.subprocess.run") as run:
+            run.side_effect = [
+                _make_completed_process(0),  # fetch
+                _make_completed_process(1),  # not ancestor
+                _make_completed_process(1, stderr="CONFLICT"),  # merge fails
+                _make_completed_process(
+                    0,
+                    stdout="src/a.py\nsrc/b.py\n\n",
+                ),  # git diff --name-only --diff-filter=U
+            ]
+            state, conflicts = _attempt_base_merge(
+                repo_path="/tmp/x", base_branch="main",
+            )
+        assert state == "conflict"
+        assert conflicts == ["src/a.py", "src/b.py"]
+
+
+# ---------------------------------------------------------------------------
+# resolve() input validation
+# ---------------------------------------------------------------------------
+
+
+class TestResolveInputValidation:
+    @pytest.mark.asyncio
+    async def test_missing_required_args_raises(self) -> None:
+        import swe_af.app as app_mod
+
+        with pytest.raises(ValueError, match="non-empty pr_url"):
+            await app_mod.resolve(
+                pr_url="",
+                pr_number=1,
+                repo_url="https://github.com/o/r.git",
+                head_branch="feature/x",
+            )
+
+        with pytest.raises(ValueError):
+            await app_mod.resolve(
+                pr_url="https://github.com/o/r/pull/1",
+                pr_number=0,
+                repo_url="https://github.com/o/r.git",
+                head_branch="feature/x",
+            )
+
+        with pytest.raises(ValueError):
+            await app_mod.resolve(
+                pr_url="https://github.com/o/r/pull/1",
+                pr_number=1,
+                repo_url="https://github.com/o/r.git",
+                head_branch="",
+            )
+
+
+# ---------------------------------------------------------------------------
+# resolve() orchestration shape
+# ---------------------------------------------------------------------------
+
+
+class TestResolveOrchestration:
+    """The end-to-end happy path: clone → checkout → merge → resolver → push → CI gate → threads."""
+
+    @pytest.mark.asyncio
+    async def test_resolve_calls_resolver_with_merge_state_and_pushes_threads(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """resolve() must:
+        - clone the repo,
+        - run the merge helper,
+        - call run_pr_resolver with merge_state + conflicted_files + ci_failures + review_comments,
+        - skip PR creation (no run_github_pr call),
+        - run the CI gate,
+        - post replies + resolve threads for every addressed comment.
+        """
+        import swe_af.app as app_mod
+        from swe_af.execution.schemas import PRResolveResult
+
+        # 1. Mock the merge helper so we can pin merge_state in the test.
+        monkeypatch.setattr(
+            app_mod,
+            "_attempt_base_merge",
+            lambda *, repo_path, base_branch: ("merged", []),
+        )
+
+        # 2. Mock subprocess so clone / checkout / fetch / push / gh-api all
+        #    succeed without touching the filesystem or network. We also
+        #    capture the calls so we can assert "no `gh pr create`" later.
+        captured_subprocess: list[list[str]] = []
+
+        def fake_run(cmd, *args, **kwargs):
+            captured_subprocess.append(list(cmd))
+            return _make_completed_process(0, stdout="", stderr="")
+
+        monkeypatch.setattr(app_mod.subprocess, "run", fake_run)
+
+        # 3. Mock os.makedirs so we don't try to create /workspaces/...
+        monkeypatch.setattr(app_mod.os, "makedirs", lambda *a, **k: None)
+
+        # 4. Mock the resolver agent reasoner. The reply pass keys off
+        #    addressed_comments — return one addressed and one not.
+        resolver_payload = PRResolveResult(
+            fixed=True,
+            merge_resolved=True,
+            files_changed=["src/a.py"],
+            commit_shas=["abc123"],
+            pushed=True,
+            addressed_comments=[
+                {
+                    "comment_id": 11,
+                    "thread_id": "PRRT_aaa",
+                    "addressed": True,
+                    "note": "Renamed foo to bar",
+                },
+                {
+                    "comment_id": 22,
+                    "thread_id": "PRRT_bbb",
+                    "addressed": False,
+                    "note": "Not actionable: question only",
+                },
+            ],
+            summary="resolver summary",
+        ).model_dump()
+
+        # 5. Mock the CI gate so we don't poll a real PR.
+        captured_ci_gate_kwargs: dict = {}
+
+        async def fake_ci_gate(**kwargs):
+            captured_ci_gate_kwargs.update(kwargs)
+            return {"final_status": "passed", "fix_attempts": [], "watch": {}}
+
+        monkeypatch.setattr(app_mod, "_run_ci_gate", fake_ci_gate)
+
+        # 6. Mock app.call so the resolver invocation returns our payload, and
+        #    so we can assert run_github_pr is NEVER called.
+        captured_calls: list[tuple[str, dict]] = []
+
+        async def fake_call(target, **kwargs):
+            captured_calls.append((target, kwargs))
+            if "run_pr_resolver" in target:
+                return {"result": resolver_payload}
+            return {"result": {}}
+
+        monkeypatch.setattr(app_mod.app, "call", fake_call)
+        monkeypatch.setattr(app_mod.app, "note", lambda *a, **k: None)
+
+        def mock_unwrap(raw, name):
+            if isinstance(raw, dict) and "result" in raw:
+                return raw["result"]
+            return raw
+
+        monkeypatch.setattr(app_mod, "_unwrap", mock_unwrap)
+
+        # ---- act ----------------------------------------------------------
+        result = await app_mod.resolve(
+            pr_url="https://github.com/o/r/pull/7",
+            pr_number=7,
+            repo_url="https://github.com/o/r.git",
+            head_branch="feature/x",
+            base_branch="main",
+            ci_failures=[
+                {"name": "tests", "logs_excerpt": "AssertionError"},
+            ],
+            review_comments=[
+                {
+                    "comment_id": 11,
+                    "thread_id": "PRRT_aaa",
+                    "path": "src/a.py",
+                    "line": 5,
+                    "author": "alice",
+                    "body": "please rename this",
+                },
+                {
+                    "comment_id": 22,
+                    "thread_id": "PRRT_bbb",
+                    "path": "src/b.py",
+                    "line": 10,
+                    "author": "bob",
+                    "body": "what about this?",
+                },
+            ],
+        )
+
+        # ---- assert: resolver was called with the right kwargs ------------
+        resolver_calls = [
+            (t, kw) for t, kw in captured_calls if "run_pr_resolver" in t
+        ]
+        assert len(resolver_calls) == 1
+        _, kw = resolver_calls[0]
+        assert kw["pr_number"] == 7
+        assert kw["head_branch"] == "feature/x"
+        assert kw["base_branch"] == "main"
+        assert kw["merge_state"] == "merged"
+        assert kw["conflicted_files"] == []
+        assert len(kw["failed_checks"]) == 1
+        assert len(kw["review_comments"]) == 2
+
+        # ---- assert: PR creation was NOT triggered ------------------------
+        github_pr_calls = [
+            t for t, _ in captured_calls if "run_github_pr" in t
+        ]
+        assert github_pr_calls == [], (
+            f"resolve() must never create a PR; got: {github_pr_calls}"
+        )
+        # And no shell-level `gh pr create` either.
+        for cmd in captured_subprocess:
+            assert not (cmd[:3] == ["gh", "pr", "create"]), cmd
+
+        # ---- assert: CI gate ran with PR number + head as integration ----
+        assert captured_ci_gate_kwargs["pr_number"] == 7
+        assert captured_ci_gate_kwargs["integration_branch"] == "feature/x"
+        assert captured_ci_gate_kwargs["base_branch"] == "main"
+
+        # ---- assert: thread replies posted only for addressed=true -------
+        assert len(result["thread_replies"]) == 1
+        reply = result["thread_replies"][0]
+        assert reply["comment_id"] == 11
+        assert reply["thread_id"] == "PRRT_aaa"
+        assert reply["replied"] is True
+        assert reply["resolved"] is True
+
+        # ---- assert: gh subprocess saw the inline reply + GraphQL mutation
+        gh_api_cmds = [
+            cmd for cmd in captured_subprocess
+            if cmd and cmd[0] == "gh" and cmd[1] == "api"
+        ]
+        # One reply POST + one graphql mutation (skipped for the not-addressed comment).
+        assert len(gh_api_cmds) == 2
+        # The reply path must include the comment id of the addressed one.
+        reply_cmd = next(c for c in gh_api_cmds if "replies" in " ".join(c))
+        assert "/comments/11/replies" in " ".join(reply_cmd)
+        # The graphql mutation must reference the resolved thread id.
+        graphql_cmd = next(c for c in gh_api_cmds if "graphql" in c)
+        assert "id=PRRT_aaa" in graphql_cmd
+
+        # ---- assert: top-level shape -------------------------------------
+        assert result["pr_number"] == 7
+        assert result["head_branch"] == "feature/x"
+        assert result["merge_state"] == "merged"
+        assert result["success"] is True
+        assert result["resolve_result"]["pushed"] is True
+        assert result["ci_gate"]["final_status"] == "passed"
+
+
+class TestResolvePushFallback:
+    """If the agent committed but didn't push, resolve() must push for it."""
+
+    @pytest.mark.asyncio
+    async def test_resolve_pushes_when_agent_committed_but_didnt_push(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        import swe_af.app as app_mod
+        from swe_af.execution.schemas import PRResolveResult
+
+        monkeypatch.setattr(
+            app_mod,
+            "_attempt_base_merge",
+            lambda *, repo_path, base_branch: ("clean", []),
+        )
+
+        push_invocations: list[list[str]] = []
+
+        def fake_run(cmd, *args, **kwargs):
+            if cmd and cmd[:2] == ["git", "push"]:
+                push_invocations.append(list(cmd))
+            return _make_completed_process(0)
+
+        monkeypatch.setattr(app_mod.subprocess, "run", fake_run)
+        monkeypatch.setattr(app_mod.os, "makedirs", lambda *a, **k: None)
+
+        # Resolver returned commits but pushed=False.
+        resolver_payload = PRResolveResult(
+            fixed=True,
+            commit_shas=["abc"],
+            pushed=False,
+        ).model_dump()
+
+        async def fake_call(target, **kwargs):
+            if "run_pr_resolver" in target:
+                return {"result": resolver_payload}
+            return {"result": {}}
+
+        async def fake_ci_gate(**kwargs):
+            return {"final_status": "passed", "fix_attempts": [], "watch": {}}
+
+        monkeypatch.setattr(app_mod.app, "call", fake_call)
+        monkeypatch.setattr(app_mod.app, "note", lambda *a, **k: None)
+        monkeypatch.setattr(app_mod, "_run_ci_gate", fake_ci_gate)
+
+        def mock_unwrap(raw, name):
+            return raw["result"] if isinstance(raw, dict) and "result" in raw else raw
+
+        monkeypatch.setattr(app_mod, "_unwrap", mock_unwrap)
+
+        result = await app_mod.resolve(
+            pr_url="https://github.com/o/r/pull/9",
+            pr_number=9,
+            repo_url="https://github.com/o/r.git",
+            head_branch="feature/y",
+            base_branch="main",
+        )
+
+        # The orchestrator pushed exactly once on the agent's behalf.
+        assert any(
+            cmd[:4] == ["git", "push", "origin", "feature/y"]
+            for cmd in push_invocations
+        ), push_invocations
+        assert result["resolve_result"]["pushed"] is True


### PR DESCRIPTION
## Summary

Adds a new entry reasoner, `resolve(pr_url, pr_number, repo_url, head_branch, base_branch, ci_failures, review_comments, …)`, that updates an existing pull request rather than creating a new one. Companion to `build()` — same agentic infrastructure, different entry point.

The flow:

1. Clone the repo into a build-id-scoped workspace.
2. Fetch `pull/<n>/head` (with same-repo branch fallback) and check out the PR's head branch.
3. `git fetch origin <base>` and **`git merge --no-edit --no-ff origin/<base>`** — always merge, never rebase, to preserve PR history. Records merge_state as `clean` (already up to date) / `merged` (auto-resolved) / `conflict` (markers in tree) / `skipped` (couldn't fetch base).
4. Hand the working tree to a new `run_pr_resolver` harness reasoner (parallel to `run_ci_fixer`) with the merge state, conflicted file list, failing CI checks, and pre-classified review comments. The agent's system prompt mirrors the CI fixer's no-workarounds discipline, extended with conflict-resolution and comment-triage workflow.
5. Push to the existing head branch (no `gh pr create` — `cfg.enable_github_pr=False`). If the agent committed but didn't push, the orchestrator pushes for it.
6. Run the existing `_run_ci_gate` watch+fix loop against the existing `pr_number`.
7. For every comment the agent marked addressed, post a brief inline reply (REST `/comments/{id}/replies`) and resolve the thread (GraphQL `resolveReviewThread`) under the same GH_TOKEN that landed the commits.
8. Clean up the workspace.

New schemas: `ReviewCommentRef`, `AddressedComment`, `PRResolveResult`. Single-repo only (v1) — multi-repo workspace and forked-PR support are deferred. github-buddy will be the primary caller (sibling PR adds the `github buddy resolve` command); the entry can also be invoked directly via `app.call("swe-planner.resolve", …)`.

## Test plan

- [x] 11 new unit tests in `tests/test_resolve.py` covering:
  - `PRResolveResult` / `ReviewCommentRef` / `AddressedComment` schema round-trips and defaults.
  - `_attempt_base_merge` classification: skipped / clean / merged / conflict (with file list).
  - `resolve()` input validation (raises on missing `pr_url` / `pr_number` / `head_branch`).
  - Orchestration shape: clone + merge helper + `run_pr_resolver` invocation kwargs (merge_state, conflicted_files, ci_failures, review_comments) + **no `run_github_pr` call** (PR exists; never re-create) + **no `gh pr create` shell-out** + `_run_ci_gate` invoked with the existing `pr_number` and the PR's head branch as `integration_branch` + thread replies posted only for `addressed=true` (`gh api …/replies` and `gh api graphql … resolveReviewThread`).
  - Push fallback: when the agent committed but didn't push, `resolve()` runs `git push origin <head_branch>` itself.
- [x] Pre-existing 12 test failures on `main` reproduce on `main` without my changes (test infrastructure / order-dependence; unrelated to this PR).
- [x] `python3 -m py_compile swe_af/app.py swe_af/reasoners/execution_agents.py swe_af/prompts/pr_resolver.py swe_af/execution/schemas.py` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)