### PR TITLE
feat(resolve): add optional goal parameter for free-form change requests

### DIFF
--- a/swe_af/app.py
+++ b/swe_af/app.py
@@ -1213,10 +1213,17 @@ async def resolve(
     base_branch: str = "main",
     ci_failures: list[dict] | None = None,
     review_comments: list[dict] | None = None,
+    goal: str = "",
     additional_context: str = "",
     config: dict | None = None,
 ) -> dict:
     """Update an existing PR: merge base, fix CI, address review comments, push.
+
+    ``goal`` is an optional free-form instruction from the caller (e.g. a
+    user comment on the PR asking for a specific change). When non-empty it
+    is rendered as the primary task in the resolver agent's prompt, with
+    CI failures and review comments treated as secondary work to fold in.
+    When empty the prompt is unchanged from the comments-and-CI-only flow.
 
     Single-repo only (v1) — no multi-repo workspace, no forked-PR support.
     Caller is expected to pass the PR's own head_branch (within the same
@@ -1349,6 +1356,7 @@ async def resolve(
         conflicted_files=conflicted_files,
         failed_checks=ci_failures,
         review_comments=review_comments,
+        goal=goal,
         additional_context=additional_context,
         model=resolver_model,
         permission_mode=cfg.permission_mode,

--- a/swe_af/prompts/pr_resolver.py
+++ b/swe_af/prompts/pr_resolver.py
@@ -167,6 +167,7 @@ def pr_resolver_task_prompt(
     conflicted_files: list[str],
     failed_checks: list[CIFailedCheck | dict],
     review_comments: list[ReviewCommentRef | dict],
+    goal: str = "",
     additional_context: str = "",
 ) -> str:
     """Build the task prompt for one PR-resolver run.
@@ -188,6 +189,10 @@ def pr_resolver_task_prompt(
     sections.append(f"- **Head branch (push target)**: `{head_branch}`")
     sections.append(f"- **Base branch**: `{base_branch}`")
     sections.append(f"- **Merge state**: `{merge_state}`")
+
+    if goal:
+        sections.append("\n### User-requested change (primary instruction)")
+        sections.append(goal)
 
     if merge_state == "conflict" and conflicted_files:
         sections.append("\n### Conflicted files (unresolved merge markers)")
@@ -286,17 +291,37 @@ def pr_resolver_task_prompt(
         sections.append("\n### Additional context")
         sections.append(additional_context)
 
-    sections.append(
-        "\n## Your Task\n"
-        "1. Complete any in-progress merge from base.\n"
-        "2. Fix every failing CI check by changing PRODUCTION code (no "
-        "silenced tests).\n"
-        "3. Address every actionable review comment, recording each one in "
-        "`addressed_comments` (true/false + brief note).\n"
-        "4. Re-run failing tests locally to confirm they pass.\n"
-        f"5. Commit + `git push origin {head_branch}` — do NOT create a new "
-        "PR.\n"
-        "6. Return a `PRResolveResult` JSON object."
+    task_lines = ["\n## Your Task"]
+    step = 1
+    if goal:
+        task_lines.append(
+            f"{step}. Apply the user-requested change described above. This "
+            "is the PRIMARY instruction for this run; CI fixes and review "
+            "comments below are secondary work to fold in along the way."
+        )
+        step += 1
+    task_lines.append(f"{step}. Complete any in-progress merge from base.")
+    step += 1
+    task_lines.append(
+        f"{step}. Fix every failing CI check by changing PRODUCTION code "
+        "(no silenced tests)."
     )
+    step += 1
+    task_lines.append(
+        f"{step}. Address every actionable review comment, recording each "
+        "one in `addressed_comments` (true/false + brief note)."
+    )
+    step += 1
+    task_lines.append(
+        f"{step}. Re-run failing tests locally to confirm they pass."
+    )
+    step += 1
+    task_lines.append(
+        f"{step}. Commit + `git push origin {head_branch}` — do NOT create "
+        "a new PR."
+    )
+    step += 1
+    task_lines.append(f"{step}. Return a `PRResolveResult` JSON object.")
+    sections.append("\n".join(task_lines))
 
     return "\n".join(sections)

--- a/swe_af/reasoners/execution_agents.py
+++ b/swe_af/reasoners/execution_agents.py
@@ -1627,6 +1627,7 @@ async def run_pr_resolver(
     conflicted_files: list[str] | None = None,
     failed_checks: list[dict] | None = None,
     review_comments: list[dict] | None = None,
+    goal: str = "",
     additional_context: str = "",
     model: str = "sonnet",
     permission_mode: str = "",
@@ -1673,6 +1674,7 @@ async def run_pr_resolver(
         conflicted_files=conflicted_files,
         failed_checks=typed_failures,
         review_comments=typed_comments,
+        goal=goal,
         additional_context=additional_context,
     )
 

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -463,3 +463,90 @@ class TestResolvePushFallback:
             for cmd in push_invocations
         ), push_invocations
         assert result["resolve_result"]["pushed"] is True
+
+
+# ---------------------------------------------------------------------------
+# pr_resolver_task_prompt — goal field rendering
+# ---------------------------------------------------------------------------
+
+
+class TestPrResolverTaskPromptGoal:
+    """The optional `goal` field reframes the resolver's primary task.
+
+    When the caller (e.g. github-buddy's `make_changes` command) passes a
+    free-form instruction, it must appear as the headline task with CI /
+    comments demoted to secondary work. When omitted, output must be
+    unchanged from the prior comments-and-CI-only flow.
+    """
+
+    def _build(self, **overrides):
+        from swe_af.prompts.pr_resolver import pr_resolver_task_prompt
+
+        defaults = dict(
+            repo_path="/workspaces/r",
+            pr_number=7,
+            pr_url="https://github.com/o/r/pull/7",
+            head_branch="feature/x",
+            base_branch="main",
+            merge_state="clean",
+            conflicted_files=[],
+            failed_checks=[],
+            review_comments=[],
+        )
+        defaults.update(overrides)
+        return pr_resolver_task_prompt(**defaults)
+
+    def test_no_goal_omits_user_request_section(self) -> None:
+        prompt = self._build()
+        assert "User-requested change" not in prompt
+        assert "Apply the user-requested change" not in prompt
+        # Without a goal the first numbered task is still merge completion.
+        assert "1. Complete any in-progress merge from base." in prompt
+
+    def test_goal_renders_section_and_promotes_to_step_one(self) -> None:
+        prompt = self._build(goal="Rename foo() to bar() across the package.")
+
+        assert "### User-requested change (primary instruction)" in prompt
+        assert "Rename foo() to bar() across the package." in prompt
+        assert "1. Apply the user-requested change described above." in prompt
+        # CI / comments / merge are demoted to later steps.
+        assert "2. Complete any in-progress merge from base." in prompt
+
+    def test_goal_coexists_with_ci_failures_and_comments(self) -> None:
+        from swe_af.execution.schemas import CIFailedCheck, ReviewCommentRef
+
+        prompt = self._build(
+            goal="Fix the typo on line 42 of README.md.",
+            failed_checks=[
+                CIFailedCheck(
+                    name="unit",
+                    workflow="CI",
+                    conclusion="failure",
+                    details_url="https://example.com/run/1",
+                    logs_excerpt="AssertionError: expected 1 got 2",
+                ),
+            ],
+            review_comments=[
+                ReviewCommentRef(
+                    comment_id=42,
+                    thread_id="T_abc",
+                    path="src/a.py",
+                    line=10,
+                    author="alice",
+                    body="please rename",
+                    url="https://github.com/o/r/pull/7#discussion_r42",
+                ),
+            ],
+        )
+
+        assert "### User-requested change (primary instruction)" in prompt
+        assert "Fix the typo on line 42 of README.md." in prompt
+        assert "### Failing CI checks" in prompt
+        assert "AssertionError" in prompt
+        assert "### Review comments to address" in prompt
+        assert "please rename" in prompt
+        # User-requested change is rendered before CI / comments in document order.
+        goal_at = prompt.index("User-requested change")
+        ci_at = prompt.index("Failing CI checks")
+        comments_at = prompt.index("Review comments to address")
+        assert goal_at < ci_at < comments_at


### PR DESCRIPTION
## Summary
- Adds an optional `goal: str = ""` parameter to `swe-planner.resolve` and threads it through `run_pr_resolver` to `pr_resolver_task_prompt`.
- When `goal` is non-empty, the prompt renders a headline `### User-requested change (primary instruction)` section and prepends a step 1 to the task list: "Apply the user-requested change described above. This is the primary instruction; CI/comments below are secondary."
- When `goal` is empty, prompt output is byte-identical to today.

## Why
This paves the way for a sibling github-buddy command (`github buddy <free-form change description>`) that delegates user-described PR edits to SWE-AF, without overloading the existing `resolve` semantics — which today is structured around CI failures + pre-classified review comments. Rather than synthesize a fake review comment, github-buddy will pass the user's instruction through `goal` and the resolver agent will treat it as the primary task.

Backwards compatible — every existing caller passes no `goal` and gets the prior prompt verbatim.

## Test plan
- [x] 3 new unit tests in `tests/test_resolve.py::TestPrResolverTaskPromptGoal` covering goal-empty, goal-only, and goal-with-CI-and-comments rendering.
- [x] Full test suite green (495 passed; 2 pre-existing failures unrelated to this change — they also fail on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)