### PR TITLE
chore(deps): bump agentfield floor to >=0.1.77

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Autonomous SWE agent node for AgentField"
 requires-python = ">=3.12"
 dependencies = [
-    "agentfield>=0.1.73",
+    "agentfield>=0.1.77",
     "pydantic>=2.0",
     # Compatibility pin: newer SDK builds have surfaced
     # "Unknown message type: rate_limit_event" during streaming.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@
 #
 # Install: python -m pip install -r requirements.txt
 
-agentfield>=0.1.73
+agentfield>=0.1.77
 pydantic>=2.0
 claude-agent-sdk==0.1.20


### PR DESCRIPTION
## Summary
- Bumps the `agentfield` floor in both `pyproject.toml` and `requirements.txt` from `>=0.1.73` to `>=0.1.77` to pick up the cooperative cancellation feature shipped in agentfield#542.
- Both pin sites are updated so the Railway install path (`pip install -r requirements.txt` then `pip install -e .`) lands on the same floor regardless of which file is consulted first.
- Without this floor, SWE-AF still serves `swe-planner.build` / `swe-planner.resolve` on Railway but doesn't honor cancel-tree — an overlong resolver run can be marked cancelled in the control plane, but the in-flight Claude Agent SDK call or git/CI loop keeps running and burns spend until natural completion.

## Test plan
- [x] `pip install -r requirements.txt` resolves to agentfield 0.1.77 or later.
- [x] `pip install -e .` resolves to agentfield 0.1.77 or later.
- [ ] Deploy to Railway, kick off a `github buddy implement` on a non-trivial issue (multi-minute resolver loop), hit cancel-tree from the control-plane UI, confirm SWE-AF short-circuits within seconds (CancelledError surfaces inside the Claude Agent SDK await) rather than running to completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)