### PR TITLE
feat(reasoners): wire agentfield web_search into 6 high-leverage reasoners

### DIFF
--- a/swe_af/reasoners/execution_agents.py
+++ b/swe_af/reasoners/execution_agents.py
@@ -82,6 +82,7 @@ from swe_af.prompts.workspace import (
     workspace_cleanup_task_prompt,
     workspace_setup_task_prompt,
 )
+from swe_af.tools.web_search import WEB_SEARCH_CODER_GUARDRAIL, with_web_search
 
 from . import router
 
@@ -169,10 +170,10 @@ async def run_retry_advisor(
             schema=RetryAdvice,
             model=model,
             provider=provider,
-            tools=["Read", "Write", "Glob", "Grep", "Bash"],
             cwd=repo_path,
             max_turns=DEFAULT_AGENT_MAX_TURNS,
             permission_mode=permission_mode or None,
+            **with_web_search(["Read", "Write", "Glob", "Grep", "Bash"]),
         )
         check_fatal_harness_error(result)
         if result.parsed is not None:
@@ -959,14 +960,14 @@ async def run_coder(
     try:
         result = await router.harness(
             task_prompt,
-            system_prompt=CODER_SYSTEM_PROMPT,
+            system_prompt=CODER_SYSTEM_PROMPT + WEB_SEARCH_CODER_GUARDRAIL,
             schema=CoderResult,
             model=model,
             provider=provider,
-            tools=["Read", "Write", "Edit", "Bash", "Glob", "Grep"],
             cwd=worktree_path,
             max_turns=DEFAULT_AGENT_MAX_TURNS,
             permission_mode=permission_mode or None,
+            **with_web_search(["Read", "Write", "Edit", "Bash", "Glob", "Grep"]),
         )
         check_fatal_harness_error(result)
         if result.parsed is not None:
@@ -1587,10 +1588,10 @@ async def run_ci_fixer(
             schema=CIFixResult,
             model=model,
             provider=provider,
-            tools=["Bash", "Read", "Edit", "Write", "Glob", "Grep"],
             cwd=repo_path,
             max_turns=DEFAULT_AGENT_MAX_TURNS,
             permission_mode=permission_mode or None,
+            **with_web_search(["Bash", "Read", "Edit", "Write", "Glob", "Grep"]),
         )
         check_fatal_harness_error(result)
         if result.parsed is not None:
@@ -1687,10 +1688,10 @@ async def run_pr_resolver(
             schema=PRResolveResult,
             model=model,
             provider=provider,
-            tools=["Bash", "Read", "Edit", "Write", "Glob", "Grep"],
             cwd=repo_path,
             max_turns=DEFAULT_AGENT_MAX_TURNS,
             permission_mode=permission_mode or None,
+            **with_web_search(["Bash", "Read", "Edit", "Write", "Glob", "Grep"]),
         )
         check_fatal_harness_error(result)
         if result.parsed is not None:

--- a/swe_af/reasoners/pipeline.py
+++ b/swe_af/reasoners/pipeline.py
@@ -22,6 +22,7 @@ from swe_af.reasoners.schemas import (
     PRD,
     ReviewResult,
 )
+from swe_af.tools.web_search import with_web_search
 
 from . import router
 
@@ -198,10 +199,10 @@ async def run_product_manager(
         provider=provider,
         model=model,
         max_turns=max_turns,
-        tools=["Read", "Write", "Glob", "Grep", "Bash"],
         permission_mode=permission_mode or None,
         system_prompt=system_prompt,
         cwd=repo_path,
+        **with_web_search(["Read", "Write", "Glob", "Grep", "Bash"]),
     )
     check_fatal_harness_error(result)
     if result.parsed is None:
@@ -258,10 +259,10 @@ async def run_architect(
         provider=provider,
         model=model,
         max_turns=max_turns,
-        tools=["Read", "Write", "Glob", "Grep", "Bash"],
         permission_mode=permission_mode or None,
         system_prompt=system_prompt,
         cwd=repo_path,
+        **with_web_search(["Read", "Write", "Glob", "Grep", "Bash"]),
     )
     check_fatal_harness_error(result)
     if result.parsed is None:

--- a/swe_af/tools/web_search.py
+++ b/swe_af/tools/web_search.py
@@ -1,0 +1,103 @@
+"""Helpers for enabling agentfield's web_search MCP tool in SWE-AF reasoners.
+
+Wraps ``agentfield.tools.web_search.get_web_search_server`` so reasoners can
+splice tool wiring into a single ``router.harness(...)`` call::
+
+    result = await router.harness(
+        prompt=task_prompt,
+        schema=...,
+        model=model,
+        provider=provider,
+        cwd=repo_path,
+        max_turns=DEFAULT_AGENT_MAX_TURNS,
+        permission_mode=permission_mode or None,
+        **with_web_search(["Read", "Write", "Glob", "Grep", "Bash"]),
+    )
+
+For the coder reasoner specifically — where adding a search tool to a
+many-turn coding loop carries loop-risk — also concatenate
+:data:`WEB_SEARCH_CODER_GUARDRAIL` onto the system prompt.
+
+Graceful degradation:
+  - If the installed agentfield doesn't ship the web_search helper (i.e.
+    pre-0.1.78 floor), this module silently no-ops: ``with_web_search``
+    returns the original tools list unchanged and omits ``mcp_servers``.
+  - If ``claude_agent_sdk`` isn't installed (non-claude-code provider env),
+    same behavior. Reasoners stay correct; web search is just unavailable.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Any, Dict, List, Optional, Tuple
+
+try:
+    from agentfield.tools.web_search import get_web_search_server  # type: ignore
+except ImportError:  # pragma: no cover - older agentfield without tools.web_search
+    get_web_search_server = None  # type: ignore[assignment]
+
+
+WEB_SEARCH_CODER_GUARDRAIL = """
+
+## When to use the web_search tool
+
+You have access to a `web_search` tool. Use it sparingly. Reach for it ONLY when:
+
+- You encounter an unfamiliar API and cannot understand its behavior from the existing codebase
+- An error message is opaque and the codebase + test output don't explain it
+- You need to verify library/framework version compatibility for a specific call
+- You need to check whether a function or pattern is deprecated
+
+Do NOT use web_search for:
+- General programming knowledge or design patterns — write code from what you already know
+- Anything answerable by reading existing files in the repo
+- Style or convention questions — follow what the codebase already does
+
+Default to writing code. Reach for web_search only when a concrete blocker requires external context, then return immediately to the implementation.
+"""
+
+
+@lru_cache(maxsize=1)
+def _cached_server() -> Optional[Tuple[Any, List[str]]]:
+    """Build (and memoize) the in-process MCP server, or return None if unavailable."""
+    if get_web_search_server is None:
+        return None
+    try:
+        return get_web_search_server()
+    except ImportError:
+        # claude_agent_sdk isn't installed — non-claude-code env; skip silently.
+        return None
+
+
+def with_web_search(tools: List[str]) -> Dict[str, Any]:
+    """Return harness kwargs that enable web_search alongside ``tools``.
+
+    Result is a dict with ``tools`` (extended with the namespaced web_search
+    tool name) and, when web_search is available, ``mcp_servers``. When the
+    feature isn't available (older agentfield, missing SDK), returns just
+    ``{"tools": tools}`` — so reasoners stay correct under any deployment.
+    """
+    cached = _cached_server()
+    if cached is None:
+        return {"tools": list(tools)}
+    server, tool_names = cached
+    return {
+        "tools": [*tools, *tool_names],
+        "mcp_servers": {"af_search": server},
+    }
+
+
+def is_web_search_available() -> bool:
+    """Return True when the web_search tool can be wired into a harness call.
+
+    False indicates the installed agentfield is too old (no
+    ``tools.web_search`` module) or claude_agent_sdk isn't installed.
+    """
+    return _cached_server() is not None
+
+
+__all__ = [
+    "WEB_SEARCH_CODER_GUARDRAIL",
+    "with_web_search",
+    "is_web_search_available",
+]

--- a/tests/test_reasoner_web_search_wiring.py
+++ b/tests/test_reasoner_web_search_wiring.py
@@ -28,16 +28,35 @@ import pytest
 # ---------------------------------------------------------------------------
 
 
+_FAKE_SERVER = {"type": "sdk", "name": "af_search", "instance": object()}
+_FAKE_TOOL_NAMES = ["mcp__af_search__web_search"]
+
+
 @pytest.fixture
 def captured_harness(monkeypatch):
     """Wire up the singleton router with a stub agent + AsyncMock harness so
     reasoner code (which calls router.note/router.harness) runs end-to-end
     without spinning up the real Agent / FastAPI machinery.
 
+    Also forces ``with_web_search`` into the "available" branch by patching
+    its underlying ``get_web_search_server`` to a deterministic fake. This
+    makes the wiring contract testable independent of which agentfield
+    version (or whether claude_agent_sdk) is installed in the test env —
+    important right now because this PR ships against the existing
+    ``agentfield>=0.1.77`` floor (which doesn't yet include the helper).
+    The dedicated graceful-degradation tests in test_web_search_helper.py
+    cover the no-helper / no-SDK paths separately.
+
     Captures the kwargs each reasoner passes to ``harness`` so tests can
     inspect them.
     """
     from swe_af.reasoners import router
+    from swe_af.tools import web_search as ws
+
+    monkeypatch.setattr(
+        ws, "get_web_search_server", lambda: (_FAKE_SERVER, _FAKE_TOOL_NAMES)
+    )
+    ws._cached_server.cache_clear()
 
     class _FakeResult:
         is_error = False

--- a/tests/test_reasoner_web_search_wiring.py
+++ b/tests/test_reasoner_web_search_wiring.py
@@ -1,0 +1,274 @@
+"""Functional/structural tests: verify the 6 targeted reasoners actually
+attach the web_search MCP server when they invoke ``router.harness``.
+
+These tests stand in between pure unit tests of the helper (which prove
+``with_web_search`` returns the right shape) and the live end-to-end test
+(which proves Claude actually calls the tool). They prove the *wiring* —
+that each chosen reasoner's harness call carries ``mcp_servers`` and the
+namespaced web_search tool name.
+
+Approach: monkeypatch ``router.harness`` with an ``AsyncMock`` and call
+each reasoner with the minimum scaffolding (tmp dir, valid pydantic
+objects). We don't care about the harness output — we only inspect what
+was passed in.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def captured_harness(monkeypatch):
+    """Wire up the singleton router with a stub agent + AsyncMock harness so
+    reasoner code (which calls router.note/router.harness) runs end-to-end
+    without spinning up the real Agent / FastAPI machinery.
+
+    Captures the kwargs each reasoner passes to ``harness`` so tests can
+    inspect them.
+    """
+    from swe_af.reasoners import router
+
+    class _FakeResult:
+        is_error = False
+        error_message = None
+        result = "{}"
+        # parsed is a MagicMock so .model_dump() returns something dict-like
+        # and reasoner post-call code (return result.parsed.model_dump()) doesn't
+        # crash on a real schema mismatch — we only care about the kwargs
+        # passed to harness here, not the downstream return value.
+        parsed = MagicMock()
+        cost_usd = 0.0
+        num_turns = 1
+        messages: List[dict] = []
+
+    captured: Dict[str, Any] = {}
+
+    async def _capture(*args, **kwargs) -> _FakeResult:
+        captured.update(kwargs)
+        captured["_args"] = args
+        return _FakeResult()
+
+    # Stand-in agent: no-op for note/log methods, AsyncMock for harness.
+    class _StubAgent:
+        async def harness(self, *args, **kwargs):
+            return await _capture(*args, **kwargs)
+
+        def note(self, *args, **kwargs):
+            return None
+
+        def __getattr__(self, item):
+            # Permissive default for any other router-delegated method —
+            # returns a no-op callable so reasoner code that calls e.g.
+            # router.discover() doesn't blow up the test setup.
+            return lambda *a, **kw: None
+
+    monkeypatch.setattr(router, "_agent", _StubAgent())
+    return captured
+
+
+@pytest.fixture
+def sample_prd_dict() -> Dict[str, Any]:
+    return {
+        "validated_description": "Tiny CLI that prints hello.",
+        "acceptance_criteria": ["Prints 'hello' when run."],
+        "must_have": ["A main function."],
+        "nice_to_have": [],
+        "out_of_scope": [],
+        "assumptions": [],
+        "risks": [],
+    }
+
+
+@pytest.fixture
+def sample_architecture_dict() -> Dict[str, Any]:
+    return {
+        "summary": "Single Python file.",
+        "components": [
+            {
+                "name": "main",
+                "responsibility": "Entry point",
+                "touches_files": ["main.py"],
+                "depends_on": [],
+            }
+        ],
+        "interfaces": ["CLI"],
+        "decisions": [{"decision": "Use stdlib only", "rationale": "Simplicity"}],
+        "file_changes_overview": "Add main.py.",
+    }
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """Empty tmp dir that satisfies the reasoners' repo_path arg."""
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Wiring contract
+# ---------------------------------------------------------------------------
+
+
+def _assert_web_search_attached(captured: Dict[str, Any]) -> None:
+    """Every web-search-enabled harness call must carry both:
+    - mcp_servers={'af_search': <McpSdkServerConfig>}
+    - tools list containing 'mcp__af_search__web_search'
+    """
+    assert "mcp_servers" in captured, (
+        "harness call did not receive mcp_servers — web_search wiring missing"
+    )
+    assert "af_search" in captured["mcp_servers"], (
+        f"mcp_servers missing 'af_search' key, got {list(captured['mcp_servers'])}"
+    )
+
+    tools: List[str] = captured.get("tools", [])
+    assert "mcp__af_search__web_search" in tools, (
+        f"tools list missing the namespaced web_search tool — got {tools}"
+    )
+
+
+async def test_run_architect_attaches_web_search(
+    captured_harness, sample_prd_dict, repo
+):
+    from swe_af.reasoners.pipeline import run_architect
+
+    await run_architect(prd=sample_prd_dict, repo_path=str(repo))
+
+    _assert_web_search_attached(captured_harness)
+    # And the original baseline tools must still be present
+    tools = captured_harness["tools"]
+    for required in ("Read", "Write", "Glob", "Grep", "Bash"):
+        assert required in tools
+
+
+async def test_run_product_manager_attaches_web_search(
+    captured_harness, repo, monkeypatch
+):
+    """run_product_manager has slightly different scaffolding (it builds the
+    PRD rather than receiving one). We need a goal arg and a repo_path."""
+    from swe_af.reasoners.pipeline import run_product_manager
+
+    await run_product_manager(goal="build a hello cli", repo_path=str(repo))
+
+    _assert_web_search_attached(captured_harness)
+
+
+async def test_run_retry_advisor_attaches_web_search(captured_harness, repo):
+    from swe_af.reasoners.execution_agents import run_retry_advisor
+
+    await run_retry_advisor(
+        issue={"name": "example", "description": "Sample failing issue"},
+        error_message="Test failed",
+        error_context="full test output",
+        attempt_number=1,
+        repo_path=str(repo),
+    )
+
+    _assert_web_search_attached(captured_harness)
+
+
+async def test_run_coder_attaches_web_search_and_appends_guardrail(
+    captured_harness, repo
+):
+    """run_coder must (a) attach web_search and (b) append the guardrail to
+    its system prompt — the loop-risk mitigation."""
+    from swe_af.reasoners.execution_agents import run_coder
+    from swe_af.tools.web_search import WEB_SEARCH_CODER_GUARDRAIL
+
+    await run_coder(
+        issue={
+            "name": "example",
+            "description": "implement hello cli",
+            "depends_on": [],
+        },
+        worktree_path=str(repo),
+        iteration=1,
+    )
+
+    _assert_web_search_attached(captured_harness)
+
+    # System prompt must end with (or contain) the guardrail snippet
+    sys_prompt = captured_harness.get("system_prompt", "")
+    assert WEB_SEARCH_CODER_GUARDRAIL.strip() in sys_prompt, (
+        "run_coder did not append WEB_SEARCH_CODER_GUARDRAIL to system_prompt"
+    )
+
+
+async def test_run_ci_fixer_attaches_web_search(captured_harness, repo):
+    from swe_af.reasoners.execution_agents import run_ci_fixer
+
+    await run_ci_fixer(
+        repo_path=str(repo),
+        pr_number=1,
+        pr_url="https://github.com/example/repo/pull/1",
+        integration_branch="integration/example",
+        base_branch="main",
+        failed_checks=[],
+    )
+
+    _assert_web_search_attached(captured_harness)
+
+
+async def test_run_pr_resolver_attaches_web_search(captured_harness, repo):
+    from swe_af.reasoners.execution_agents import run_pr_resolver
+
+    await run_pr_resolver(
+        repo_path=str(repo),
+        pr_number=1,
+        pr_url="https://github.com/example/repo/pull/1",
+        head_branch="feat/example",
+        base_branch="main",
+    )
+
+    _assert_web_search_attached(captured_harness)
+
+
+# ---------------------------------------------------------------------------
+# Negative coverage: deliberately-excluded reasoners must NOT enable web_search
+# ---------------------------------------------------------------------------
+
+
+async def test_run_tech_lead_does_not_attach_web_search(
+    captured_harness, sample_prd_dict, repo
+):
+    """run_tech_lead is in the deliberate skip-list (review-only, all answers
+    are in PRD+architecture). Verify it stays that way to prevent scope
+    creep — adding web_search to it would inflate cost without payoff."""
+    from swe_af.reasoners.pipeline import run_tech_lead
+
+    await run_tech_lead(prd=sample_prd_dict, repo_path=str(repo))
+
+    assert "mcp_servers" not in captured_harness or not captured_harness.get(
+        "mcp_servers"
+    )
+    tools = captured_harness.get("tools", [])
+    assert "mcp__af_search__web_search" not in tools
+
+
+async def test_run_sprint_planner_does_not_attach_web_search(
+    captured_harness, sample_prd_dict, sample_architecture_dict, repo
+):
+    """run_sprint_planner is also deliberately excluded (pure decomposition)."""
+    from swe_af.reasoners.pipeline import run_sprint_planner
+
+    await run_sprint_planner(
+        prd=sample_prd_dict,
+        architecture=sample_architecture_dict,
+        repo_path=str(repo),
+    )
+
+    assert "mcp_servers" not in captured_harness or not captured_harness.get(
+        "mcp_servers"
+    )
+    tools = captured_harness.get("tools", [])
+    assert "mcp__af_search__web_search" not in tools

--- a/tests/test_web_search_helper.py
+++ b/tests/test_web_search_helper.py
@@ -1,0 +1,137 @@
+"""Unit tests for swe_af.tools.web_search.
+
+Verifies the helper that splices web_search into a router.harness call:
+- with_web_search returns the right kwargs shape
+- The lru_cache is invalidatable in tests
+- Graceful degradation when agentfield doesn't ship the helper, or when
+  claude_agent_sdk isn't installed (each reasoner must keep working in
+  that case — web_search is opportunistic, not required).
+"""
+
+from __future__ import annotations
+
+import importlib
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    """Ensure each test starts with a fresh cache so monkeypatched providers
+    are picked up rather than a stale build from a prior test."""
+    from swe_af.tools import web_search as ws
+
+    ws._cached_server.cache_clear()
+    yield
+    ws._cached_server.cache_clear()
+
+
+def test_with_web_search_extends_tools_and_attaches_server():
+    """When agentfield's web_search is available, the helper must return both
+    extended tools AND mcp_servers under the 'af_search' key."""
+    from swe_af.tools.web_search import with_web_search
+
+    out = with_web_search(["Read", "Bash"])
+
+    assert "tools" in out
+    assert "mcp_servers" in out
+
+    # Original tools preserved, in order; namespaced tool name appended
+    tools = out["tools"]
+    assert tools[:2] == ["Read", "Bash"]
+    assert any(t.startswith("mcp__af_search__") for t in tools[2:])
+    assert "mcp__af_search__web_search" in tools
+
+    # MCP server is keyed under 'af_search' (matches what the SWE-AF reasoner
+    # wiring assumes when reading mcp_servers in the harness call)
+    assert "af_search" in out["mcp_servers"]
+    assert out["mcp_servers"]["af_search"] is not None
+
+
+def test_with_web_search_returns_a_fresh_list_each_call():
+    """Mutating the returned tools list must not bleed into subsequent calls
+    (the helper must not return the same list object)."""
+    from swe_af.tools.web_search import with_web_search
+
+    a = with_web_search(["Read"])
+    a["tools"].append("MUTATED")
+
+    b = with_web_search(["Read"])
+    assert "MUTATED" not in b["tools"]
+
+
+def test_is_web_search_available_returns_true_when_wired():
+    from swe_af.tools.web_search import is_web_search_available
+
+    assert is_web_search_available() is True
+
+
+def test_graceful_degradation_when_agentfield_missing_web_search():
+    """Older agentfield versions (<0.1.78) won't ship tools.web_search. The
+    helper must silently skip wiring rather than crashing the reasoner."""
+    from swe_af.tools import web_search as ws
+
+    # Simulate the import-failure branch
+    with patch.object(ws, "get_web_search_server", None):
+        ws._cached_server.cache_clear()
+
+        out = ws.with_web_search(["Read", "Bash"])
+
+        # Just the original tools, no mcp_servers, no extra entries
+        assert out == {"tools": ["Read", "Bash"]}
+        assert ws.is_web_search_available() is False
+
+
+def test_graceful_degradation_when_get_server_raises_import_error():
+    """If claude_agent_sdk is missing at server-build time, the helper must
+    no-op (the importable but un-callable case — different from above)."""
+    from swe_af.tools import web_search as ws
+
+    def _raise(*args, **kwargs):
+        raise ImportError("claude_agent_sdk not installed")
+
+    with patch.object(ws, "get_web_search_server", _raise):
+        ws._cached_server.cache_clear()
+
+        out = ws.with_web_search(["Read"])
+        assert out == {"tools": ["Read"]}
+        assert ws.is_web_search_available() is False
+
+
+def test_cached_server_is_called_once_across_invocations(monkeypatch):
+    """The MCP server is built once per process (lru_cache), not per harness
+    call — important for cost since each call would otherwise re-instantiate
+    an in-process server."""
+    from swe_af.tools import web_search as ws
+
+    call_count = {"n": 0}
+    real = ws.get_web_search_server
+
+    def _counting():
+        call_count["n"] += 1
+        return real()
+
+    monkeypatch.setattr(ws, "get_web_search_server", _counting)
+    ws._cached_server.cache_clear()
+
+    ws.with_web_search(["Read"])
+    ws.with_web_search(["Read", "Bash"])
+    ws.with_web_search(["Edit"])
+
+    assert call_count["n"] == 1
+
+
+def test_guardrail_text_is_non_empty_and_actionable():
+    """The coder guardrail text must mention 'web_search' (so the model can
+    follow the cross-reference) and discourage casual use."""
+    from swe_af.tools.web_search import WEB_SEARCH_CODER_GUARDRAIL
+
+    assert "web_search" in WEB_SEARCH_CODER_GUARDRAIL
+    # Must include both positive (when to use) and negative (when not to use) guidance
+    assert (
+        "Do NOT use" in WEB_SEARCH_CODER_GUARDRAIL
+        or "do not use" in WEB_SEARCH_CODER_GUARDRAIL
+    )
+    # Should be substantial enough to actually steer behavior — but not a wall of text
+    assert 200 < len(WEB_SEARCH_CODER_GUARDRAIL) < 2000

--- a/tests/test_web_search_helper.py
+++ b/tests/test_web_search_helper.py
@@ -6,6 +6,13 @@ Verifies the helper that splices web_search into a router.harness call:
 - Graceful degradation when agentfield doesn't ship the helper, or when
   claude_agent_sdk isn't installed (each reasoner must keep working in
   that case — web_search is opportunistic, not required).
+
+Why we mock ``get_web_search_server``: this PR ships against the existing
+``agentfield>=0.1.77`` floor (the new ``tools.web_search`` module ships in
+0.1.78). We need the helper-shape tests to verify wiring whether or not
+the installed agentfield happens to expose the function — so we monkeypatch
+it to a known fake. The dedicated graceful-degradation tests below do not
+use this fixture; they exercise the real None / ImportError paths.
 """
 
 from __future__ import annotations
@@ -14,6 +21,26 @@ import importlib
 from unittest.mock import patch
 
 import pytest
+
+
+_FAKE_SERVER = {"type": "sdk", "name": "af_search", "instance": object()}
+_FAKE_TOOL_NAMES = ["mcp__af_search__web_search"]
+
+
+def _fake_get_web_search_server():
+    return _FAKE_SERVER, _FAKE_TOOL_NAMES
+
+
+@pytest.fixture
+def fake_web_search(monkeypatch):
+    """Pretend agentfield's web_search helper is installed and returns a
+    deterministic fake. Use this on tests that verify the wiring shape."""
+    from swe_af.tools import web_search as ws
+
+    monkeypatch.setattr(ws, "get_web_search_server", _fake_get_web_search_server)
+    ws._cached_server.cache_clear()
+    yield
+    ws._cached_server.cache_clear()
 
 
 @pytest.fixture(autouse=True)
@@ -27,7 +54,7 @@ def _reset_cache():
     ws._cached_server.cache_clear()
 
 
-def test_with_web_search_extends_tools_and_attaches_server():
+def test_with_web_search_extends_tools_and_attaches_server(fake_web_search):
     """When agentfield's web_search is available, the helper must return both
     extended tools AND mcp_servers under the 'af_search' key."""
     from swe_af.tools.web_search import with_web_search
@@ -49,7 +76,7 @@ def test_with_web_search_extends_tools_and_attaches_server():
     assert out["mcp_servers"]["af_search"] is not None
 
 
-def test_with_web_search_returns_a_fresh_list_each_call():
+def test_with_web_search_returns_a_fresh_list_each_call(fake_web_search):
     """Mutating the returned tools list must not bleed into subsequent calls
     (the helper must not return the same list object)."""
     from swe_af.tools.web_search import with_web_search
@@ -61,7 +88,7 @@ def test_with_web_search_returns_a_fresh_list_each_call():
     assert "MUTATED" not in b["tools"]
 
 
-def test_is_web_search_available_returns_true_when_wired():
+def test_is_web_search_available_returns_true_when_wired(fake_web_search):
     from swe_af.tools.web_search import is_web_search_available
 
     assert is_web_search_available() is True
@@ -106,11 +133,10 @@ def test_cached_server_is_called_once_across_invocations(monkeypatch):
     from swe_af.tools import web_search as ws
 
     call_count = {"n": 0}
-    real = ws.get_web_search_server
 
     def _counting():
         call_count["n"] += 1
-        return real()
+        return _fake_get_web_search_server()
 
     monkeypatch.setattr(ws, "get_web_search_server", _counting)
     ws._cached_server.cache_clear()


### PR DESCRIPTION
## Summary

Wires `agentfield.tools.web_search` (introduced in [Agent-Field/agentfield#543](https://github.com/Agent-Field/agentfield/pull/543)) into the SWE-AF reasoners where external documentation lookup measurably improves output. The selection was made deliberately — most reasoners get nothing from web access and would only pay the latency tax.

### Tier 1 — clear value, no caveats

| Reasoner | Why |
|---|---|
| `run_architect` | Library / framework / API decisions cascade to every downstream coder. One good architecture decision saves dozens of failed coding loops. |
| `run_ci_fixer` | CI errors are exactly what Stack Overflow exists for. Diagnosing a build failure without web access is hand-tied. |
| `run_pr_resolver` | Same as ci_fixer + addresses review comments that may reference external context. |

### Tier 2 — added with prompt-level scoping

| Reasoner | Caveat |
|---|---|
| `run_coder` | Highest loop-risk reasoner. Appends `WEB_SEARCH_CODER_GUARDRAIL` to the system prompt restricting use to: unfamiliar APIs, opaque error messages, library-version compatibility, deprecation status. **Default is to write code; reach for web_search only when blocked by external context.** |
| `run_retry_advisor` | Diagnosing a coder failure often hinges on an error-message lookup. Cheap (advisory-only). |
| `run_product_manager` | PRDs occasionally need external grounding. Marginal — included since the wiring cost is one line. |

### Deliberately NOT wired

`run_tech_lead`, `run_sprint_planner`, `run_issue_writer`, `run_verifier`, `run_qa`, `run_code_reviewer`, `run_qa_synthesizer`, `generate_fix_issues`, `run_merger`, `run_integration_tester`, `run_repo_finalize`, `run_github_pr`, `run_ci_watcher`, `run_replanner`, `run_issue_advisor`, and all `*workspace*` / `git_init` reasoners. These are pure git/synthesis ops, deterministic flows, or already have full repo context to answer from.

`test_run_tech_lead_does_not_attach_web_search` and `test_run_sprint_planner_does_not_attach_web_search` are negative-coverage tests that guard against scope creep silently re-enabling web access on excluded reasoners.

## How it works

Each wired call replaces `tools=[...]` with `**with_web_search([...])`, which:
1. Extends the tools list with the namespaced `mcp__af_search__web_search` tool name
2. Attaches an in-process MCP server (built via `claude_agent_sdk.create_sdk_mcp_server`) under `mcp_servers["af_search"]`

The MCP server is built once per process via `lru_cache`.

## Rollout

This PR ships with the existing `agentfield>=0.1.77` floor. The helper is **gracefully degrading**:

- When agentfield 0.1.78+ is installed (with the new `tools.web_search` module), the feature activates automatically.
- When the older 0.1.77 is installed (current floor), `with_web_search` silently no-ops and returns just `{"tools": [...]}`. Reasoners behave identically to today.

A one-line follow-up bumps `agentfield>=0.1.78` once that release ships, activating the feature in CI / production. No flag day required.

## Test plan

- 7 unit tests on the helper itself (output shape, mutation safety, both graceful-degradation branches, server-build memoization, guardrail text contract)
- 8 wiring contract tests proving each of the 6 wired reasoners passes `mcp_servers` + the namespaced tool name to `harness`, plus 2 negative-coverage tests for the deliberately-excluded `run_tech_lead` and `run_sprint_planner`
- `run_coder` test additionally verifies `WEB_SEARCH_CODER_GUARDRAIL` ends up in the system prompt — the loop-risk mitigation
- All 15 new tests are sub-second, no API keys required, run on every CI invocation

The end-to-end test that drives a real Claude harness through the full search-and-respond pipeline lives in agentfield as `tests/test_harness_web_search_e2e.py` (harness_live marker, gated on `ANTHROPIC_API_KEY` + `JINA_API_KEY`).

### Pre-existing test failures

`tests/test_conftest_malformed_planner_execute_nodeids_integration.py::test_agentfield_server_guard_logic_rejects_real_hosts` and `::test_agentfield_server_guard_accepts_localhost_url` fail on `main` independently of this PR. Verified by checking out clean main and running both — same 2 failures, no others. Not in scope for this PR; flagging for a separate fix.

## Sister PR

Depends on (does not block-merge):
- [Agent-Field/agentfield#543](https://github.com/Agent-Field/agentfield/pull/543) — the framework feature this consumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)