### PR TITLE
docs: document opencode web-search opt-in + add coder restraint guardrail

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,20 @@ ANTHROPIC_API_KEY=sk-ant-api03-...
 
 # Note: Can reuse ANTHROPIC_API_KEY from above for Claude models via OpenCode
 
+# --- Optional: Web search (open runtime) ---
+#
+# Enables opencode's built-in `websearch` and `webfetch` tools so coding
+# and review agents can look up external documentation, library APIs,
+# error messages, and version/deprecation status during a build.
+#
+# Both vars must be set. They reach the opencode subprocess via the
+# parent-env propagation in agentfield's run_cli — no SWE-AF wiring is
+# needed beyond setting them on the deployment.
+#
+# Get an Exa key at https://exa.ai/
+# OPENCODE_ENABLE_EXA=1
+# EXA_API_KEY=...
+
 # --- Optional: GitHub integration ---
 
 # GitHub personal access token (repo scope) — for draft PR creation

--- a/README.md
+++ b/README.md
@@ -303,6 +303,21 @@ JSON
 
 For OpenRouter with `open_code`, use model IDs in `openrouter/<provider>/<model>` format (for example `openrouter/minimax/minimax-m2.5`).
 
+### Optional: web search
+
+Coding and review agents can look up external documentation, library APIs, error messages, and version/deprecation status during a build. This is opt-in via two env vars on the deployment:
+
+```
+OPENCODE_ENABLE_EXA=1
+EXA_API_KEY=...
+```
+
+When set, opencode's built-in `websearch` and `webfetch` tools become available to every reasoner running through the open runtime — the model decides when to use them based on the task. Get a key at [exa.ai](https://exa.ai/).
+
+The coder reasoner additionally gets a brief restraint guideline appended to its system prompt, so a long coding loop doesn't rabbit-hole on searches it could answer by reading the codebase. No setup required beyond the env vars; the wiring inherits parent env naturally through agentfield's CLI harness.
+
+This works on the open runtime (opencode). The Claude runtime uses Anthropic's first-party `WebSearch`/`WebFetch` and is currently not wired here — file an issue if you want it.
+
 ## What Happens In One Build
 
 - Architecture is generated and reviewed before coding starts

--- a/swe_af/reasoners/execution_agents.py
+++ b/swe_af/reasoners/execution_agents.py
@@ -82,6 +82,7 @@ from swe_af.prompts.workspace import (
     workspace_cleanup_task_prompt,
     workspace_setup_task_prompt,
 )
+from swe_af.tools.web_search import maybe_apply_coder_guardrail
 
 from . import router
 
@@ -959,7 +960,7 @@ async def run_coder(
     try:
         result = await router.harness(
             task_prompt,
-            system_prompt=CODER_SYSTEM_PROMPT,
+            system_prompt=maybe_apply_coder_guardrail(CODER_SYSTEM_PROMPT),
             schema=CoderResult,
             model=model,
             provider=provider,

--- a/swe_af/tools/web_search.py
+++ b/swe_af/tools/web_search.py
@@ -1,0 +1,75 @@
+"""Helpers for steering reasoner behavior when opencode's web search is enabled.
+
+Opencode ships built-in ``websearch`` and ``webfetch`` tools that activate
+when ``OPENCODE_ENABLE_EXA=1`` and ``EXA_API_KEY`` are set in the deployment
+env. The opencode subprocess inherits parent env via agentfield's
+``run_cli`` (see ``agentfield.harness._cli``), so no SWE-AF wiring is
+required to *enable* web search — set the env vars in Railway / your deploy
+and reasoners running through opencode automatically gain the capability.
+
+Tool *awareness* is also handled for free: opencode advertises its built-in
+tools to the LLM via the standard tool-definition layer, so the model knows
+``websearch`` exists without any system-prompt boilerplate from us.
+
+What lives in this module is the *one* place a prompt-level addition
+genuinely earns its keep: the coder reasoner. ``run_coder`` runs many turns
+inside a single coding loop, and an unrestrained model will happily spend
+turns searching for things it could read from the codebase. The
+``WEB_SEARCH_CODER_GUARDRAIL`` snippet narrows the agent's discretion to
+the cases where external lookup is actually load-bearing.
+
+Other reasoners (architect, planner, reviewer, ...) don't get prompt
+additions — they're short or single-shot, the loop-risk is negligible,
+and the model's own judgment plus opencode's tool advertisement is
+sufficient. Add per-reasoner restraint guidance only if a specific
+reasoner is observed over-searching in practice.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+WEB_SEARCH_CODER_GUARDRAIL = """
+
+## When to use the web_search / web_fetch tools
+
+You may have access to a `websearch` (and possibly `webfetch`) tool. Use it sparingly. Reach for it ONLY when:
+
+- You encounter an unfamiliar API and cannot understand its behavior from the existing codebase
+- An error message is opaque and the codebase + test output don't explain it
+- You need to verify library/framework version compatibility for a specific call
+- You need to check whether a function or pattern is deprecated
+
+Do NOT use websearch for:
+- General programming knowledge or design patterns
+- Anything answerable by reading existing files in the repo
+- Style or convention questions — follow what the codebase already does
+
+Default to writing code. Reach for websearch only when a concrete blocker requires external context, then return immediately to the implementation.
+"""
+
+
+def _websearch_enabled() -> bool:
+    """True iff opencode's built-in websearch is gated open in the deploy env."""
+    return os.environ.get("OPENCODE_ENABLE_EXA") == "1" and bool(
+        os.environ.get("EXA_API_KEY")
+    )
+
+
+def maybe_apply_coder_guardrail(system_prompt: str) -> str:
+    """Append the coder-specific web-search guardrail when web search is enabled.
+
+    The guardrail is appended only when ``OPENCODE_ENABLE_EXA=1`` and
+    ``EXA_API_KEY`` are set, so the model isn't told about a tool it can't
+    use. When web search isn't enabled, returns ``system_prompt`` unchanged.
+    """
+    if not _websearch_enabled():
+        return system_prompt
+    return system_prompt + WEB_SEARCH_CODER_GUARDRAIL
+
+
+__all__ = [
+    "WEB_SEARCH_CODER_GUARDRAIL",
+    "maybe_apply_coder_guardrail",
+]

--- a/tests/test_web_search_guardrail.py
+++ b/tests/test_web_search_guardrail.py
@@ -1,0 +1,87 @@
+"""Tests for swe_af.tools.web_search.maybe_apply_coder_guardrail.
+
+The guardrail should append only when opencode's web-search env vars are
+set, so the model isn't told about a tool it can't use.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from swe_af.tools.web_search import (
+    WEB_SEARCH_CODER_GUARDRAIL,
+    _websearch_enabled,
+    maybe_apply_coder_guardrail,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    monkeypatch.delenv("OPENCODE_ENABLE_EXA", raising=False)
+    monkeypatch.delenv("EXA_API_KEY", raising=False)
+
+
+def test_returns_unchanged_when_no_env(monkeypatch):
+    """No env vars set → guardrail not appended (model isn't told about a
+    tool it can't use)."""
+    base = "You are a coder."
+    assert maybe_apply_coder_guardrail(base) == base
+    assert _websearch_enabled() is False
+
+
+def test_returns_unchanged_when_only_flag_set(monkeypatch):
+    """OPENCODE_ENABLE_EXA alone is insufficient — Exa needs a key too."""
+    monkeypatch.setenv("OPENCODE_ENABLE_EXA", "1")
+    base = "You are a coder."
+    assert maybe_apply_coder_guardrail(base) == base
+
+
+def test_returns_unchanged_when_only_key_set(monkeypatch):
+    """EXA_API_KEY alone is insufficient — opencode doesn't activate
+    websearch without the gate flag."""
+    monkeypatch.setenv("EXA_API_KEY", "fake-key")
+    base = "You are a coder."
+    assert maybe_apply_coder_guardrail(base) == base
+
+
+def test_returns_unchanged_when_flag_not_one(monkeypatch):
+    """Only ``OPENCODE_ENABLE_EXA=1`` enables — other truthy values
+    (true, yes, on, ...) don't satisfy opencode's gate."""
+    monkeypatch.setenv("OPENCODE_ENABLE_EXA", "true")
+    monkeypatch.setenv("EXA_API_KEY", "fake-key")
+    base = "You are a coder."
+    assert maybe_apply_coder_guardrail(base) == base
+
+
+def test_appends_when_both_env_vars_set(monkeypatch):
+    """Happy path: both env vars present → guardrail appended."""
+    monkeypatch.setenv("OPENCODE_ENABLE_EXA", "1")
+    monkeypatch.setenv("EXA_API_KEY", "fake-key")
+    assert _websearch_enabled() is True
+
+    base = "You are a coder."
+    result = maybe_apply_coder_guardrail(base)
+    assert result.startswith(base)
+    assert WEB_SEARCH_CODER_GUARDRAIL in result
+
+
+def test_guardrail_text_is_substantive(monkeypatch):
+    """The guardrail must actually steer the model — empty / one-liner
+    tip wouldn't do anything. Asserts the snippet mentions both
+    websearch and the restraint principle."""
+    text = WEB_SEARCH_CODER_GUARDRAIL
+    assert "websearch" in text.lower() or "web_search" in text.lower()
+    # Must convey "don't reach for it casually"
+    assert "Do NOT" in text or "do not" in text or "sparingly" in text
+    # Must give concrete *when to use* examples
+    assert "API" in text or "library" in text or "error message" in text
+    # Reasonable length — not a wall of text, not a one-liner
+    assert 200 < len(text) < 2000
+
+
+def test_empty_key_treated_as_absent(monkeypatch):
+    """An empty EXA_API_KEY string shouldn't pass the gate."""
+    monkeypatch.setenv("OPENCODE_ENABLE_EXA", "1")
+    monkeypatch.setenv("EXA_API_KEY", "")
+    base = "You are a coder."
+    assert maybe_apply_coder_guardrail(base) == base


### PR DESCRIPTION
## Summary

Documents how to enable web search on this stack (set `OPENCODE_ENABLE_EXA=1` + `EXA_API_KEY` in the deployment env — that's the whole knob) and adds one targeted prompt-level guardrail on `run_coder`.

The actual capability is already wired: opencode's built-in `websearch`/`webfetch` activate when those env vars are set, opencode's subprocess inherits them via [agentfield/run_cli](https://github.com/Agent-Field/agentfield/blob/main/sdk/python/agentfield/harness/_cli.py), and the model learns about the tools via the standard tool-definition layer (no system-prompt injection from us required for awareness). Verified end-to-end via the agentfield SDK against opencode — the model autonomously invoked Exa Web Search when asked a question that required current information.

## What's in the diff

- **`.env.example`** — adds the two env vars with brief docs
- **`README.md`** — adds an "Optional: web search" subsection in Quick Start
- **`swe_af/tools/web_search.py`** — single helper `maybe_apply_coder_guardrail(prompt)` plus the `WEB_SEARCH_CODER_GUARDRAIL` text. Helper appends the restraint snippet to a system prompt only when both env vars are set; otherwise returns the prompt unchanged so we don't tell the model about a tool it can't use.
- **`run_coder` only** — one-line change: `system_prompt=maybe_apply_coder_guardrail(CODER_SYSTEM_PROMPT)`.

## Why only `run_coder`

The coder reasoner runs many turns inside a single coding loop — that's the one place an unrestrained model could rabbit-hole on searches for things it could read from the codebase. Every other reasoner is short / single-shot / analytic, where the model's own judgment plus opencode's tool advertisement is sufficient. Add per-reasoner restraint guidance later only if a specific reasoner is observed over-searching.

## What's deliberately NOT added

- No "you have web search" boilerplate on every reasoner. opencode advertises tools natively; verified the model picks them up autonomously without prompt injection. Adding boilerplate would just eat context.
- No agentfield framework changes. The opencode-tools-allow-list gap (where `tools=[...]` is silently ignored on opencode/codex/gemini) is a real bug but not blocking web search — opencode enables tools by default, so no allow-list needed for them to function.

## Tests

7 unit tests on the helper covering env-var gating, the restraint snippet text contract, and edge cases (only one var set, empty string key, non-`1` flag value). All sub-second, no API keys required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)