### PR TITLE
fix(env): respect AI_MODEL/HARNESS_MODEL on SWE-AF + pin OpenCode small_model

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Add OpenCode to PATH for non-interactive shells
 ENV PATH="/root/.opencode/bin:${PATH}"
 
+# Pin OpenCode's model AND small_model to Kimi K2.6 so OpenCode's auto-pick
+# (used for session titles, summarization, etc. when small_model isn't
+# configured) cannot reach for a different OpenRouter model. Without this
+# config file, OpenCode silently selects a default like deepseek-v3.1 from
+# the available OpenRouter catalog when only OPENROUTER_API_KEY is set.
+# Per-call -m on `opencode run` already pins the main model; this file
+# pins the small_model too.
+RUN mkdir -p /root/.config/opencode && \
+    echo '{"$schema":"https://opencode.ai/config.json","model":"openrouter/moonshotai/kimi-k2.6","small_model":"openrouter/moonshotai/kimi-k2.6","provider":{"openrouter":{"options":{"apiKey":"{env:OPENROUTER_API_KEY}"},"models":{"moonshotai/kimi-k2.6":{}}}}}' \
+    > /root/.config/opencode/opencode.json
+
 # Git identity — env vars take highest precedence and are inherited by all
 # subprocesses including Claude Code agent instances spawned by the SDK
 ENV GIT_AUTHOR_NAME="SWE-AF" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,15 +22,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Add OpenCode to PATH for non-interactive shells
 ENV PATH="/root/.opencode/bin:${PATH}"
 
-# Pin OpenCode's model AND small_model to Kimi K2.6 so OpenCode's auto-pick
-# (used for session titles, summarization, etc. when small_model isn't
-# configured) cannot reach for a different OpenRouter model. Without this
-# config file, OpenCode silently selects a default like deepseek-v3.1 from
-# the available OpenRouter catalog when only OPENROUTER_API_KEY is set.
-# Per-call -m on `opencode run` already pins the main model; this file
-# pins the small_model too.
+# Tell OpenCode to read its model AND small_model from the deployer's
+# HARNESS_MODEL env var via {env:...} interpolation. Without this config,
+# OpenCode auto-selects a small_model from whatever providers it finds
+# keys for — landing on DeepSeek V3.1 in our environment, bypassing every
+# env var the deployer set. Per-call -m on `opencode run` pins the main
+# model regardless; small_model is what falls through to config, so it
+# has to honor the same env var the rest of the stack uses.
+#
+# Default HARNESS_MODEL inside the image so a fresh container with no
+# env override has *some* value to interpolate. Railway / docker-compose
+# overrides win because their env injects after the image's ENV.
+ENV HARNESS_MODEL=openrouter/moonshotai/kimi-k2.6
 RUN mkdir -p /root/.config/opencode && \
-    echo '{"$schema":"https://opencode.ai/config.json","model":"openrouter/moonshotai/kimi-k2.6","small_model":"openrouter/moonshotai/kimi-k2.6","provider":{"openrouter":{"options":{"apiKey":"{env:OPENROUTER_API_KEY}"},"models":{"moonshotai/kimi-k2.6":{}}}}}' \
+    echo '{"$schema":"https://opencode.ai/config.json","model":"{env:HARNESS_MODEL}","small_model":"{env:HARNESS_MODEL}","provider":{"openrouter":{"options":{"apiKey":"{env:OPENROUTER_API_KEY}"}}}}' \
     > /root/.config/opencode/opencode.json
 
 # Git identity — env vars take highest precedence and are inherited by all

--- a/swe_af/execution/schemas.py
+++ b/swe_af/execution/schemas.py
@@ -544,17 +544,32 @@ def _default_runtime() -> Literal["claude_code", "open_code"]:
     return "claude_code"
 
 
-def _default_model_from_env() -> str | None:
-    """Honor the ``SWE_DEFAULT_MODEL`` env var.
+_DEFAULT_MODEL_ENV_VARS: tuple[str, ...] = (
+    "SWE_DEFAULT_MODEL",
+    "AI_MODEL",
+    "HARNESS_MODEL",
+)
 
-    Lets the deployer pin a single model id that overrides every role
-    default — without editing code or threading a ``config`` through every
-    caller. Caller-supplied ``models={"default": …}`` and per-role overrides
-    still win (see ``resolve_runtime_models`` precedence). Empty or unset
-    returns ``None``, which means "use runtime base defaults".
+
+def _default_model_from_env() -> str | None:
+    """Pick a single model id from deployer env vars.
+
+    Cascades through the well-known env-var names this stack uses for model
+    selection so the same Railway / docker-compose variable that points
+    pr-af and github-buddy at a model also applies here, without needing
+    a SWE-AF-specific name. First non-empty value wins:
+
+        SWE_DEFAULT_MODEL  →  AI_MODEL  →  HARNESS_MODEL
+
+    Caller-supplied ``models={"default": …}`` and per-role overrides still
+    beat the env value (see ``resolve_runtime_models`` precedence). All
+    unset / empty → ``None``, which means "use the runtime base defaults".
     """
-    value = os.getenv("SWE_DEFAULT_MODEL", "").strip()
-    return value or None
+    for var in _DEFAULT_MODEL_ENV_VARS:
+        value = os.getenv(var, "").strip()
+        if value:
+            return value
+    return None
 
 
 def _legacy_hint_for_model_key(key: str) -> str:
@@ -627,7 +642,8 @@ def resolve_runtime_models(
 
     Resolution order (lowest → highest precedence):
         1. runtime base defaults (``_RUNTIME_BASE_MODELS[runtime]``)
-        2. ``SWE_DEFAULT_MODEL`` env var (applies to all roles)
+        2. env-var cascade: ``SWE_DEFAULT_MODEL`` → ``AI_MODEL`` →
+           ``HARNESS_MODEL`` (first non-empty wins, applies to all roles)
         3. caller's ``models["default"]``
         4. caller's ``models["<role>"]``
     """

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -190,7 +190,11 @@ class TestDefaultModelFromEnv(unittest.TestCase):
             )
 
     def test_empty_env_value_treated_as_unset(self) -> None:
-        with mock.patch.dict(os.environ, {"SWE_DEFAULT_MODEL": "   "}):
+        # All three cascade vars empty/whitespace → falls through to runtime base
+        with mock.patch.dict(
+            os.environ,
+            {"SWE_DEFAULT_MODEL": "   ", "AI_MODEL": "", "HARNESS_MODEL": "   "},
+        ):
             resolved = resolve_runtime_models(runtime="open_code", models=None)
             for field in ALL_MODEL_FIELDS:
                 self.assertEqual(
@@ -198,12 +202,52 @@ class TestDefaultModelFromEnv(unittest.TestCase):
                 )
 
     def test_unset_env_uses_runtime_base(self) -> None:
-        env = {k: v for k, v in os.environ.items() if k != "SWE_DEFAULT_MODEL"}
+        cascade_vars = {"SWE_DEFAULT_MODEL", "AI_MODEL", "HARNESS_MODEL"}
+        env = {k: v for k, v in os.environ.items() if k not in cascade_vars}
         with mock.patch.dict(os.environ, env, clear=True):
             resolved = resolve_runtime_models(runtime="open_code", models=None)
             for field in ALL_MODEL_FIELDS:
                 self.assertEqual(
                     resolved[field], "openrouter/minimax/minimax-m2.5"
+                )
+
+    def test_ai_model_env_used_when_swe_default_unset(self) -> None:
+        # AI_MODEL is the env var the rest of the stack (pr-af, github-buddy)
+        # uses — SWE-AF must respect it too without requiring a SWE-specific
+        # var, otherwise the deployer has to set the same model in two places.
+        cascade_vars = {"SWE_DEFAULT_MODEL", "AI_MODEL", "HARNESS_MODEL"}
+        env = {k: v for k, v in os.environ.items() if k not in cascade_vars}
+        env["AI_MODEL"] = "openrouter/moonshotai/kimi-k2.6"
+        with mock.patch.dict(os.environ, env, clear=True):
+            resolved = resolve_runtime_models(runtime="open_code", models=None)
+            for field in ALL_MODEL_FIELDS:
+                self.assertEqual(
+                    resolved[field], "openrouter/moonshotai/kimi-k2.6"
+                )
+
+    def test_harness_model_env_used_when_others_unset(self) -> None:
+        cascade_vars = {"SWE_DEFAULT_MODEL", "AI_MODEL", "HARNESS_MODEL"}
+        env = {k: v for k, v in os.environ.items() if k not in cascade_vars}
+        env["HARNESS_MODEL"] = "openrouter/moonshotai/kimi-k2.6"
+        with mock.patch.dict(os.environ, env, clear=True):
+            resolved = resolve_runtime_models(runtime="open_code", models=None)
+            for field in ALL_MODEL_FIELDS:
+                self.assertEqual(
+                    resolved[field], "openrouter/moonshotai/kimi-k2.6"
+                )
+
+    def test_swe_default_model_beats_ai_model_in_cascade(self) -> None:
+        # When both are set, the SWE-specific name wins so deployers can
+        # override the global AI_MODEL just for this service.
+        cascade_vars = {"SWE_DEFAULT_MODEL", "AI_MODEL", "HARNESS_MODEL"}
+        env = {k: v for k, v in os.environ.items() if k not in cascade_vars}
+        env["SWE_DEFAULT_MODEL"] = "openrouter/qwen/qwen-3-coder"
+        env["AI_MODEL"] = "openrouter/moonshotai/kimi-k2.6"
+        with mock.patch.dict(os.environ, env, clear=True):
+            resolved = resolve_runtime_models(runtime="open_code", models=None)
+            for field in ALL_MODEL_FIELDS:
+                self.assertEqual(
+                    resolved[field], "openrouter/qwen/qwen-3-coder"
                 )
 
     def test_env_flows_through_build_config(self) -> None:


### PR DESCRIPTION
## Summary

Two real env-var-respecting fixes. Neither one changes any model literal in code — both make existing deployer env vars actually take effect.

### 1. SWE-AF respects \`AI_MODEL\` / \`HARNESS_MODEL\` like the rest of the stack

\`pr-af\` and \`github-buddy\` both read \`AI_MODEL\` (and pr-af also \`HARNESS_MODEL\`) when picking a model. SWE-AF only read \`SWE_DEFAULT_MODEL\` — a SWE-specific name that had to be set separately. Result: when the Railway deployment had \`AI_MODEL=openrouter/moonshotai/kimi-k2.6:nitro\` set globally and \`SWE_DEFAULT_MODEL\` unset on SWE-AF, every SWE-AF role silently fell through to the \`open_code\` runtime base default (MiniMax M2.5) instead of inheriting the global \`AI_MODEL\`. Confirmed in production logs from PR #33 today: \`run_pr_resolver\` ran with \`\"model\":\"openrouter/minimax/minimax-m2.5\"\`.

\`_default_model_from_env()\` now cascades \`SWE_DEFAULT_MODEL → AI_MODEL → HARNESS_MODEL\` — first non-empty wins. The SWE-specific name stays at the top so deployers can still override just this service. Runtime base defaults are unchanged; caller-supplied \`models={...}\` still wins.

### 2. Pin OpenCode CLI's \`small_model\` to prevent auto-pick bypass

OpenCode runs \`-m <model>\` for the main model but uses a *separate* \`small_model\` for session titles, summarization, and prompt compaction. Without an \`~/.config/opencode/opencode.json\` on disk in the SWE-AF container — pr-af bakes one in but SWE-AF didn't — OpenCode auto-selects a default from whichever providers it finds keys for. With only \`OPENROUTER_API_KEY\` available, that auto-pick lands on DeepSeek V3.1, which showed up on the OpenRouter dashboard as 18 unaccounted requests/hr.

The Dockerfile now bakes in an opencode.json that pins both \`model\` and \`small_model\` to a single env-derived value, so neither path can drift.

## Commits

- \`fix(opencode): pin small_model so OpenCode can't auto-pick another model\`
- \`fix(env): cascade SWE_DEFAULT_MODEL → AI_MODEL → HARNESS_MODEL\`

No literal-default changes to runtime base maps or test fixtures.

## Test plan

- [x] \`AGENTFIELD_SERVER=http://localhost:9999 pytest tests/test_model_config.py\` → 37 passed (added 3 new cascade tests)
- [ ] On next deploy, verify OpenRouter dashboard shows zero MiniMax / DeepSeek traffic from this service's key

🤖 Generated with [Claude Code](https://claude.com/claude-code)