### PR TITLE
fix(deps): mirror hax-sdk + python-dotenv into Docker requirements

### DIFF
--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -2,6 +2,8 @@
 #
 # Same runtime dependencies as requirements.txt.
 
-agentfield>=0.1.73
+agentfield>=0.1.77
 pydantic>=2.0
 claude-agent-sdk==0.1.20
+hax-sdk>=0.2.0
+python-dotenv>=1.0


### PR DESCRIPTION
## Summary

- The Dockerfile installs from `requirements-docker.txt`, but that file had drifted from `requirements.txt` and was missing `hax-sdk` (added in #66) and `python-dotenv`.
- Deployed SWE-AF image therefore had no `hax` module. The HITL approval gate at `swe_af/app.py:622` (`from hax import HaxClient`) blew up at runtime with `No module named 'hax'` whenever `HAX_API_KEY` was set.
- Also bumps `agentfield` floor in the Docker list from `>=0.1.73` to `>=0.1.77` to match runtime `requirements.txt` (left-over drift from #62).

## Repro

Failing run on the test deployment: `run_1778185367193_ab50c1cd` (build reasoner, execution `exec_20260507_202248_rtahrqx2`). Error in internal logs:

```
❌ Execution exec_20260507_202248_rtahrqx2 failed asynchronously: No module named 'hax'
```

## Test plan

- [ ] CI builds the new image successfully.
- [ ] Re-trigger an `app.call("swe-planner.build", ...)` with `HAX_API_KEY` set on the test deployment and confirm the approval gate creates a hax request instead of crashing.
- [ ] No-`HAX_API_KEY` path is unchanged (the import is gated behind that env var, so the failure mode and the fix only affect the approval flow).

## Notes

The two requirements files are easy to drift. Worth a follow-up to either consolidate (single file + extras) or wire a CI check that diffs them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)