### PR TITLE
chore(deps): bump agentfield floor to 0.1.79

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Autonomous SWE agent node for AgentField"
 requires-python = ">=3.12"
 dependencies = [
-    "agentfield>=0.1.77",
+    "agentfield>=0.1.79",
     "pydantic>=2.0",
     # Compatibility pin: newer SDK builds have surfaced
     # "Unknown message type: rate_limit_event" during streaming.

--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -2,7 +2,7 @@
 #
 # Same runtime dependencies as requirements.txt.
 
-agentfield>=0.1.77
+agentfield>=0.1.79
 pydantic>=2.0
 claude-agent-sdk==0.1.20
 hax-sdk>=0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 #
 # Install: python -m pip install -r requirements.txt
 
-agentfield>=0.1.77
+agentfield>=0.1.79
 pydantic>=2.0
 claude-agent-sdk==0.1.20
 hax-sdk>=0.2.0


### PR DESCRIPTION
## Summary

Bumps the `agentfield` SDK floor from `>=0.1.77` to `>=0.1.79` across `requirements.txt`, `requirements-docker.txt`, and `pyproject.toml`.

## Why this matters

0.1.79 contains the pause-aware reasoner-timeout fix (Agent-Field/agentfield#552). The `build` reasoner sits inside `app.pause()` while waiting for hax-sdk plan approvals, so any review that took longer than `default_execution_timeout` (7200s) was billed against the reasoner budget and surfaced as `Reasoner 'build' timed out after 7200.0s`. With 0.1.79, time spent in `pause()` is subtracted from elapsed before the watchdog compares against the budget.

## Why bumping the constraint string is required

Docker layer caching keys off the requirements file contents. Leaving the constraint at `>=0.1.77` would let the cached `pip install` layer keep installing whatever it last resolved (0.1.77) even though 0.1.79 is now on PyPI. Forcing the string to `>=0.1.79` invalidates that layer and pulls the fix on the next image build.

## Test plan

- [ ] CI green
- [ ] After merge, redeploy on Railway and confirm the new image was rebuilt (not pulled from cache)
- [ ] Confirm `agentfield` resolves to 0.1.79+ in the running container (`pip show agentfield`)
- [ ] Verify a long-running plan approval no longer trips the 7200s timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)