### PR TITLE
chore(deps): bump agentfield floor to 0.1.80

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Autonomous SWE agent node for AgentField"
 requires-python = ">=3.12"
 dependencies = [
-    "agentfield>=0.1.79",
+    "agentfield>=0.1.80",
     "pydantic>=2.0",
     # Compatibility pin: newer SDK builds have surfaced
     # "Unknown message type: rate_limit_event" during streaming.

--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -2,7 +2,7 @@
 #
 # Same runtime dependencies as requirements.txt.
 
-agentfield>=0.1.79
+agentfield>=0.1.80
 pydantic>=2.0
 claude-agent-sdk==0.1.20
 hax-sdk>=0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 #
 # Install: python -m pip install -r requirements.txt
 
-agentfield>=0.1.79
+agentfield>=0.1.80
 pydantic>=2.0
 claude-agent-sdk==0.1.20
 hax-sdk>=0.2.0


### PR DESCRIPTION
## Summary

Bumps the agentfield SDK floor from 0.1.79 to 0.1.80 across requirements.txt, requirements-docker.txt, and pyproject.toml.

0.1.80 ships cross-reasoner pause-clock propagation (Agent-Field/agentfield#555). Without this floor bump, Docker layer caching keeps shipping 0.1.79 and the parent ``build`` reasoner still times out at 7200s while a child is paused on a hax-sdk approval — the v0.1.79 fix only covered the reasoner that calls ``pause()`` directly, not ancestors awaiting it via ``app.call``.

## Test plan
- [ ] CI green
- [ ] Manual verify on the test deployment that an ``implement_from_issue`` run with a hax-sdk approval gap no longer times out the parent at 7200s

🤖 Generated with [Claude Code](https://claude.com/claude-code)