### PR TITLE
chore(deps): bump agentfield floor to 0.1.81

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Autonomous SWE agent node for AgentField"
 requires-python = ">=3.12"
 dependencies = [
-    "agentfield>=0.1.80",
+    "agentfield>=0.1.81",
     "pydantic>=2.0",
     # Compatibility pin: newer SDK builds have surfaced
     # "Unknown message type: rate_limit_event" during streaming.

--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -2,7 +2,7 @@
 #
 # Same runtime dependencies as requirements.txt.
 
-agentfield>=0.1.80
+agentfield>=0.1.81
 pydantic>=2.0
 claude-agent-sdk==0.1.20
 hax-sdk>=0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 #
 # Install: python -m pip install -r requirements.txt
 
-agentfield>=0.1.80
+agentfield>=0.1.81
 pydantic>=2.0
 claude-agent-sdk==0.1.20
 hax-sdk>=0.2.0


### PR DESCRIPTION
## Summary
- Bump agentfield constraint from \`>=0.1.80\` to \`>=0.1.81\` in requirements.txt, requirements-docker.txt, and pyproject.toml.
- Picks up the poll-driven cross-reasoner pause propagation fix from Agent-Field/agentfield#562 (shipped in v0.1.81).

## Why
v0.1.80 attempted the same fix via an SSE event listener gated behind \`enable_event_stream\` (default off, not enabled on any deployed service). It never fired in production — \`implement_from_issue\` still tripped its 7200s wallclock budget despite a long hax-sdk approval gap. v0.1.81 moves the pause toggle into \`wait_for_result\`'s polling loop, which runs unconditionally.

## Test plan
- [ ] CI green
- [ ] After deploy, run an \`implement_from_issue\` flow that hits a hax-sdk approval gate; the parent watchdog should not trip the 2hr budget if active work is under it

🤖 Generated with [Claude Code](https://claude.com/claude-code)