### PR TITLE
chore(deps): bump agentfield floor to 0.1.82

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Autonomous SWE agent node for AgentField"
 requires-python = ">=3.12"
 dependencies = [
-    "agentfield>=0.1.81",
+    "agentfield>=0.1.82",
     "pydantic>=2.0",
     # Compatibility pin: newer SDK builds have surfaced
     # "Unknown message type: rate_limit_event" during streaming.

--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -2,7 +2,7 @@
 #
 # Same runtime dependencies as requirements.txt.
 
-agentfield>=0.1.81
+agentfield>=0.1.82
 pydantic>=2.0
 claude-agent-sdk==0.1.20
 hax-sdk>=0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 #
 # Install: python -m pip install -r requirements.txt
 
-agentfield>=0.1.81
+agentfield>=0.1.82
 pydantic>=2.0
 claude-agent-sdk==0.1.20
 hax-sdk>=0.2.0


### PR DESCRIPTION
## Summary
- Bumps the `agentfield` floor from `>=0.1.81` to `>=0.1.82`.
- Picks up the polling-task pause-aware overdue-check fix shipped in [agentfield#564](https://github.com/Agent-Field/agentfield/pull/564).
- Floor bump (not just constraint widening) so Docker layer caching invalidates and the new wheel is actually pulled.

## Why

v0.1.81 only got half the pause-propagation fix: `wait_for_result`s own loop became pause-aware, but the manager's background polling task (`_poll_active_executions`) kept calling the wallclock-only `is_overdue` check on every cycle. After `timeout` seconds of wallclock — regardless of how much was spent in the awaited child's `waiting` state — it flipped the local execution to TIMEOUT and the wait loop surfaced it as `ExecutionTimeoutError("Execution timed out after N seconds")`.

v0.1.82 attaches the parent PauseClock to the awaited `ExecutionState` so both the wait loop and the polling task read paused-time from the same source. Now the parent budget actually means "active wallclock," matching the contract `expires_in_hours` already implied for `Agent.pause()`.

## Test plan
- [ ] CI green (build + lint + unit/functional tests as applicable)
- [ ] After merge + redeploy: parent reasoner survives a full ``max_execution_timeout`` of *active* time across long human-approval pauses, instead of timing out at exactly the wallclock budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)