### PR TITLE
chore(deps): bump agentfield floor to 0.1.83

### DIFF
--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -2,7 +2,7 @@
 #
 # Same runtime dependencies as requirements.txt.
 
-agentfield>=0.1.82
+agentfield>=0.1.83
 pydantic>=2.0
 claude-agent-sdk==0.1.20
 hax-sdk>=0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 #
 # Install: python -m pip install -r requirements.txt
 
-agentfield>=0.1.82
+agentfield>=0.1.83
 pydantic>=2.0
 claude-agent-sdk==0.1.20
 hax-sdk>=0.2.0


### PR DESCRIPTION
## Summary

Bumps the agentfield SDK floor from `>=0.1.82` to `>=0.1.83` in both `requirements.txt` and `requirements-docker.txt`. Picks up the cancellation-skips-sync-fallback fix shipped in [agentfield#566](https://github.com/Agent-Field/agentfield/pull/566): a cancelled awaited child no longer triggers a silent sync-fallback re-execution.

Both files bumped — leaving the Docker-side pin at 0.1.82 would keep restoring the cached `pip install` layer and ship 0.1.82 even after 0.1.83 is on PyPI.

## Test plan

- [x] CI green (Docker build pulls 0.1.83)
- [ ] After merge, a fresh deploy logs `agentfield==0.1.83` (or newer) in the install step

🤖 Generated with [Claude Code](https://claude.com/claude-code)