### PR TITLE
chore: bump agentfield pin to >=0.1.84

### DIFF
--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -2,7 +2,7 @@
 #
 # Same runtime dependencies as requirements.txt.
 
-agentfield>=0.1.83
+agentfield>=0.1.84
 pydantic>=2.0
 claude-agent-sdk==0.1.20
 hax-sdk>=0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 #
 # Install: python -m pip install -r requirements.txt
 
-agentfield>=0.1.83
+agentfield>=0.1.84
 pydantic>=2.0
 claude-agent-sdk==0.1.20
 hax-sdk>=0.2.0


### PR DESCRIPTION
Picks up agentfield 0.1.84 ([release](https://github.com/Agent-Field/agentfield/releases/tag/v0.1.84), [merged PR](https://github.com/Agent-Field/agentfield/pull/569)).

## What's in 0.1.84
INFO-level diagnostic logging on the cross-reasoner pause-propagation hot path. No behavior change; same imports, same control flow.

## Why this PR is needed
Docker `pip install` layers are cached against file contents — `>=0.1.83` already permits 0.1.84, but unless the constraint string itself changes, the cached layer with 0.1.83 keeps getting restored on rebuild. Bumped both `requirements.txt` AND `requirements-docker.txt` because the Dockerfile installs from the docker variant separately. Same playbook as the 0.1.82→0.1.83 round (PR #74).

## Test plan
- [ ] Merge → wait for Railway to redeploy
- [ ] `railway ssh --service SWE-AF "pip show agentfield"` returns 0.1.84