### PR TITLE
feat(hitl): generic ask_user_via_form capability for selected reasoners

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     # "Unknown message type: rate_limit_event" during streaming.
     "claude-agent-sdk==0.1.20",
     # HITL plan-approval gate (auto-enabled when HAX_API_KEY is set).
-    "hax-sdk>=0.2.0",
+    "hax-sdk>=0.2.4",
     "python-dotenv>=1.0",
 ]
 

--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -5,7 +5,7 @@
 agentfield>=0.1.84
 pydantic>=2.0
 claude-agent-sdk==0.1.20
-hax-sdk>=0.2.0
+hax-sdk>=0.2.4
 python-dotenv>=1.0
 # cryptography 48.0.0 currently crashes with SIGILL on some Linux/aarch64
 # Docker hosts when AgentField imports Ed25519 for DID registration.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@
 agentfield>=0.1.84
 pydantic>=2.0
 claude-agent-sdk==0.1.20
-hax-sdk>=0.2.0
+hax-sdk>=0.2.4
 python-dotenv>=1.0

--- a/swe_af/execution/schemas.py
+++ b/swe_af/execution/schemas.py
@@ -16,6 +16,7 @@ from pydantic import (
     field_validator,
     model_validator,
 )
+from swe_af.hitl.ask_user import AskUserForm
 from swe_af.runtime.providers import RUNTIME_VALUES, runtime_to_harness_provider
 
 # Global default for all agent max_turns. Change this one value to adjust everywhere.
@@ -214,6 +215,8 @@ class IssueAdvisorDecision(BaseModel):
     # Always
     downstream_impact: str = ""
     summary: str = ""
+    # HITL — see swe_af/hitl/ for semantics
+    ask_user_form: AskUserForm | None = None
 
 
 class IssueResult(BaseModel):
@@ -266,6 +269,8 @@ class ReplanDecision(BaseModel):
     skipped_issue_names: list[str] = []
     new_issues: list[dict] = []
     summary: str = ""
+    # HITL — see swe_af/hitl/ for semantics
+    ask_user_form: AskUserForm | None = None
 
 
 class DAGState(BaseModel):

--- a/swe_af/hitl/__init__.py
+++ b/swe_af/hitl/__init__.py
@@ -1,0 +1,26 @@
+"""HITL (human-in-the-loop) primitives layered on the Hax SDK."""
+
+from swe_af.hitl.ask_user import (
+    AskUserForm,
+    AskUserFormField,
+    AskUserResponse,
+    approval_webhook_url,
+    build_form_builder,
+    build_hax_client_from_env,
+    format_prior_user_responses,
+    request_user_input_and_pause,
+)
+from swe_af.hitl.wrapper import AskUserBudget, run_with_ask_user
+
+__all__ = [
+    "AskUserForm",
+    "AskUserFormField",
+    "AskUserResponse",
+    "AskUserBudget",
+    "approval_webhook_url",
+    "build_form_builder",
+    "build_hax_client_from_env",
+    "format_prior_user_responses",
+    "request_user_input_and_pause",
+    "run_with_ask_user",
+]

--- a/swe_af/hitl/ask_user.py
+++ b/swe_af/hitl/ask_user.py
@@ -1,0 +1,511 @@
+"""LLM-facing ``ask_user_via_form`` primitive.
+
+Reasoners that may want to clarify something with the human user emit an
+``AskUserForm`` as part of their structured output. The wrapper in
+``swe_af.hitl.wrapper`` detects the field, calls into this module to build a
+Hax form, issues ``app.pause()``, and resumes once the user submits.
+
+The full workflow is paused (potentially for hours / days) while the form is
+outstanding — same mechanism as the existing Phase 1.5 plan-approval gate in
+``swe_af.app``. The reasoner's own time budget does not accrue during the
+pause because agentfield's pause-clock handles the wait separately.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from typing import TYPE_CHECKING, Any, Literal
+
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from hax import HaxClient
+
+
+def build_hax_client_from_env() -> HaxClient | None:
+    """Construct a ``HaxClient`` from ``HAX_API_KEY`` / ``HAX_SDK_URL`` env vars.
+
+    Returns ``None`` when ``HAX_API_KEY`` is unset or empty — callers should
+    treat that as "HAX disabled" and short-circuit any ask-user logic.
+    """
+    api_key = os.environ.get("HAX_API_KEY", "").strip()
+    if not api_key:
+        return None
+    from hax import HaxClient
+
+    return HaxClient(
+        api_key=api_key,
+        base_url=os.environ.get("HAX_SDK_URL", "http://localhost:3000") + "/api/v1",
+    )
+
+
+def approval_webhook_url(app: Any) -> str | None:
+    """Resolve the control-plane webhook URL used for ``app.pause`` callbacks.
+
+    Mirrors the URL the existing Phase 1.5 plan-approval gate uses
+    (``{cp_base_url}/api/v1/webhooks/approval-response``). Returns ``None``
+    when neither the app nor the env supplies a control-plane URL.
+    """
+    cp_base = (
+        getattr(app, "agentfield_server", None)
+        or os.environ.get("AGENTFIELD_SERVER")
+        or ""
+    ).rstrip("/")
+    if not cp_base:
+        return None
+    return f"{cp_base}/api/v1/webhooks/approval-response"
+
+
+FieldType = Literal[
+    "input",
+    "number",
+    "textarea",
+    "select",
+    "radio",
+    "checkbox",
+    "checkbox_group",
+    "switch",
+    "slider",
+    "date",
+]
+
+
+class AskUserFormField(BaseModel):
+    """One field in a form the agent is constructing for the user."""
+
+    id: str = Field(
+        description=(
+            "Unique identifier for this field; becomes the key in the "
+            "submitted values dict the reasoner sees on the next invocation."
+        )
+    )
+    type: FieldType = Field(
+        description=(
+            "Field widget. 'input' = single-line text; 'textarea' = multi-line; "
+            "'select' / 'radio' / 'checkbox_group' require an `options` list; "
+            "'checkbox' / 'switch' = boolean; 'number' / 'slider' = numeric; "
+            "'date' = ISO date."
+        )
+    )
+    label: str = Field(description="Label shown above the field in the form.")
+    description: str | None = Field(
+        default=None,
+        description="Optional helper text shown below the label.",
+    )
+    required: bool = Field(default=False)
+    placeholder: str | None = Field(
+        default=None,
+        description="Placeholder for input/textarea/number/select widgets.",
+    )
+    default_value: Any | None = Field(
+        default=None,
+        description="Pre-filled value if the user submits without changing it.",
+    )
+    options: list[dict[str, str]] | None = Field(
+        default=None,
+        description=(
+            "Required for 'select', 'radio', 'checkbox_group'. Each entry is "
+            "{'value': ..., 'label': ...}. The submitted value is the 'value' "
+            "string (or a list of them for checkbox_group)."
+        ),
+    )
+    min: float | None = Field(
+        default=None,
+        description="Minimum value for 'number' / 'slider'.",
+    )
+    max: float | None = Field(
+        default=None,
+        description="Maximum value for 'number' / 'slider'.",
+    )
+    step: float | None = Field(
+        default=None,
+        description="Step increment for 'number' / 'slider'.",
+    )
+
+
+class AskUserForm(BaseModel):
+    """A form the agent wants the user to fill out before continuing."""
+
+    title: str = Field(
+        description=(
+            "Short title displayed at the top of the form. "
+            "Visible to the user as the question summary."
+        )
+    )
+    description: str | None = Field(
+        default=None,
+        description=(
+            "Optional longer-form context for why the agent is asking. "
+            "Render as the form's subtitle."
+        ),
+    )
+    fields: list[AskUserFormField] = Field(
+        min_length=1,
+        description="At least one field. Use 'radio' or 'select' for multiple-choice asks.",
+    )
+    submit_label: str = Field(
+        default="Submit",
+        description="Submit button label.",
+    )
+
+
+class AskUserResponse(BaseModel):
+    """What the wrapper hands back to the reasoner on re-invocation."""
+
+    status: Literal["submitted", "timeout", "cancelled", "error"]
+    values: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Submitted form values keyed by field id. Empty on non-submit outcomes.",
+    )
+    feedback: str | None = Field(
+        default=None,
+        description="Free-text feedback from the user, if any.",
+    )
+    error: str | None = Field(
+        default=None,
+        description="Populated only on status='error'.",
+    )
+
+
+def format_prior_user_responses(prior: list[dict] | None) -> str:
+    """Render ``prior_user_responses`` as a markdown block for the LLM prompt.
+
+    When the wrapper re-invokes a reasoner after a paused ask, it stuffs
+    accumulated responses into ``prior_user_responses``. The reasoner must
+    surface them to the LLM so the LLM doesn't repeat questions already
+    answered.
+    """
+    if not prior:
+        return ""
+    lines = ["## Prior Clarification From User", ""]
+    for idx, entry in enumerate(prior, start=1):
+        question = entry.get("question", "(no title)")
+        status = entry.get("status", "unknown")
+        lines.append(f"### Question {idx}: {question}")
+        lines.append(f"_Status: {status}_")
+        values = entry.get("values") or {}
+        if values:
+            lines.append("")
+            lines.append("Values submitted by user:")
+            for key, val in values.items():
+                lines.append(f"- **{key}**: {val}")
+        feedback = entry.get("feedback")
+        if feedback:
+            lines.append("")
+            lines.append(f"User feedback: {feedback}")
+        lines.append("")
+    lines.append(
+        "USE THESE PRIOR ANSWERS. DO NOT RE-ASK THE SAME QUESTIONS. Only "
+        "emit `ask_user_form` if you need DIFFERENT clarification not already "
+        "covered above."
+    )
+    return "\n".join(lines)
+
+
+def _field_to_form_builder_call(form: Any, field: AskUserFormField) -> None:
+    """Invoke the right FormBuilder method for one ``AskUserFormField``."""
+    common: dict[str, Any] = {"label": field.label}
+    if field.description is not None:
+        common["description"] = field.description
+    if field.required:
+        common["required"] = True
+    if field.placeholder is not None:
+        common["placeholder"] = field.placeholder
+    if field.default_value is not None:
+        common["default_value"] = field.default_value
+
+    ftype = field.type
+
+    if ftype == "input":
+        form.input(field.id, **common)
+    elif ftype == "textarea":
+        form.textarea(field.id, **common)
+    elif ftype == "number":
+        kwargs = dict(common)
+        if field.min is not None:
+            kwargs["min"] = field.min
+        if field.max is not None:
+            kwargs["max"] = field.max
+        if field.step is not None:
+            kwargs["step"] = field.step
+        form.number(field.id, **kwargs)
+    elif ftype == "slider":
+        if field.min is None or field.max is None:
+            raise ValueError(
+                f"slider field '{field.id}' requires both min and max"
+            )
+        kwargs = dict(common)
+        kwargs["min"] = field.min
+        kwargs["max"] = field.max
+        if field.step is not None:
+            kwargs["step"] = field.step
+        form.slider(field.id, **kwargs)
+    elif ftype == "select":
+        if not field.options:
+            raise ValueError(f"select field '{field.id}' requires options")
+        form.select(field.id, options=field.options, **common)
+    elif ftype == "radio":
+        if not field.options:
+            raise ValueError(f"radio field '{field.id}' requires options")
+        form.radio_group(field.id, options=field.options, **common)
+    elif ftype == "checkbox_group":
+        if not field.options:
+            raise ValueError(
+                f"checkbox_group field '{field.id}' requires options"
+            )
+        form.checkbox_group(field.id, options=field.options, **common)
+    elif ftype == "checkbox":
+        common.pop("placeholder", None)
+        form.checkbox(field.id, checkbox_label=field.label, **common)
+    elif ftype == "switch":
+        common.pop("placeholder", None)
+        form.switch(field.id, switch_label=field.label, **common)
+    elif ftype == "date":
+        form.date(field.id, **common)
+    else:
+        raise ValueError(f"unsupported AskUserFormField type: {ftype}")
+
+
+def build_form_builder(spec: AskUserForm) -> Any:
+    """Translate an ``AskUserForm`` spec into a ``hax.FormBuilder`` instance.
+
+    Imports ``hax`` lazily so this module is importable in environments without
+    the SDK installed (mirrors the existing pattern in ``swe_af.app``).
+    """
+    from hax import FormBuilder
+
+    form = FormBuilder().title(spec.title)
+    if spec.description is not None:
+        form.description(spec.description)
+    if spec.submit_label and spec.submit_label != "Submit":
+        form.submit_label(spec.submit_label)
+
+    for field in spec.fields:
+        _field_to_form_builder_call(form, field)
+
+    return form
+
+
+HAX_CREATE_REQUEST_TIMEOUT_SECONDS = 120.0
+
+
+async def _create_hax_form_request_with_timeout(
+    *,
+    app: Any,
+    hax_client: HaxClient,
+    form: Any,
+    title: str,
+    description: str | None,
+    expires_in_seconds: int,
+    user_id: str | None,
+    webhook_url: str | None,
+    metadata: dict[str, Any] | None,
+    timeout_seconds: float = HAX_CREATE_REQUEST_TIMEOUT_SECONDS,
+) -> Any:
+    """Submit a hax-sdk form-builder request with a hard timeout.
+
+    Mirrors ``swe_af.app._create_hax_request_with_timeout`` but for form-builder
+    requests routed through ``hax_client.create_request(type='form-builder', ...)``
+    so we can also pass ``user_id`` (``create_form_request`` itself doesn't expose
+    it). Returns the ``CreatedRequest`` from hax-sdk; the caller passes
+    ``request.id`` and ``request.url`` to ``app.pause``.
+    """
+    app.note(
+        f"ask_user: submitting hax form-builder request ({title!r})",
+        tags=["ask_user", "hax", "create_form_request"],
+    )
+
+    kwargs: dict[str, Any] = {
+        "type": "form-builder",
+        "payload": form.to_payload(),
+        "title": title,
+        "expires_in_seconds": expires_in_seconds,
+    }
+    if description is not None:
+        kwargs["description"] = description
+    if user_id is not None:
+        kwargs["user_id"] = user_id
+    if webhook_url is not None:
+        kwargs["webhook_url"] = webhook_url
+    if metadata is not None:
+        kwargs["metadata"] = metadata
+
+    try:
+        created = await asyncio.wait_for(
+            asyncio.to_thread(hax_client.create_request, **kwargs),
+            timeout=timeout_seconds,
+        )
+    except asyncio.TimeoutError as exc:
+        app.note(
+            f"ask_user: hax create_request timed out after {timeout_seconds}s",
+            tags=["ask_user", "hax", "timeout"],
+        )
+        raise RuntimeError(
+            f"hax-sdk create_request (form-builder) timed out after "
+            f"{timeout_seconds}s; hax-sdk is likely wedged."
+        ) from exc
+    except Exception as exc:
+        app.note(
+            f"ask_user: hax create_request raised "
+            f"{type(exc).__name__}: {exc}",
+            tags=["ask_user", "hax", "error"],
+        )
+        raise
+    app.note(
+        f"ask_user: hax form request created (request_id={created.id})",
+        tags=["ask_user", "hax", "submitted"],
+    )
+    return created
+
+
+def _extract_values_from_raw(raw: Any) -> dict[str, Any]:
+    """Find the form values dict inside an ApprovalResult.raw_response payload."""
+    if not isinstance(raw, dict):
+        return {}
+    direct = raw.get("values")
+    if isinstance(direct, dict):
+        return dict(direct)
+    response_obj = raw.get("response")
+    if isinstance(response_obj, dict):
+        inner = response_obj.get("values")
+        if isinstance(inner, dict):
+            return dict(inner)
+    return {}
+
+
+def _parse_approval_result_to_response(approval_result: Any) -> AskUserResponse:
+    """Convert an agentfield ``ApprovalResult`` into ``AskUserResponse``.
+
+    Mapping:
+      decision='approved'        → status='submitted'
+      decision='request_changes' → status='submitted' (form was filled out)
+      decision='rejected'        → status='cancelled'
+      decision='expired'         → status='timeout'
+      decision='error'           → status='error'
+      anything else              → status='error' (defensive)
+
+    Form values are pulled from ``raw_response['values']`` or
+    ``raw_response['response']['values']`` if present, with a final fallback
+    to parsing ``feedback`` as JSON.
+    """
+    decision = getattr(approval_result, "decision", None) or ""
+    feedback = getattr(approval_result, "feedback", "") or None
+    raw = getattr(approval_result, "raw_response", None)
+
+    if decision == "rejected":
+        return AskUserResponse(status="cancelled", feedback=feedback)
+    if decision == "expired":
+        return AskUserResponse(status="timeout", feedback=feedback)
+    if decision == "error":
+        return AskUserResponse(
+            status="error",
+            feedback=feedback,
+            error=feedback or "agentfield reported decision=error",
+        )
+
+    values = _extract_values_from_raw(raw)
+    if not values and feedback:
+        try:
+            parsed = json.loads(feedback)
+            if isinstance(parsed, dict):
+                values = parsed
+        except (ValueError, TypeError):
+            pass
+
+    if decision in {"approved", "request_changes", "submitted"}:
+        return AskUserResponse(
+            status="submitted",
+            values=values,
+            feedback=feedback,
+        )
+
+    return AskUserResponse(
+        status="error",
+        values=values,
+        feedback=feedback,
+        error=f"unknown decision: {decision!r}",
+    )
+
+
+async def request_user_input_and_pause(
+    *,
+    app: Any,
+    spec: AskUserForm,
+    hax_client: HaxClient,
+    expires_in_hours: float = 24,
+    user_id: str | None = None,
+    execution_id: str | None = None,
+    webhook_url: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> AskUserResponse:
+    """Build a Hax form, pause the workflow, return the human's response.
+
+    Pause duration is bounded by ``expires_in_hours`` (default 24h). The
+    workflow is genuinely suspended on the control plane while the form is
+    outstanding — the reasoner's own time budget does not accrue.
+    """
+    try:
+        form = build_form_builder(spec)
+    except Exception as exc:
+        app.note(
+            f"ask_user: failed to build form from spec: {exc}",
+            tags=["ask_user", "form_builder", "error"],
+        )
+        return AskUserResponse(
+            status="error",
+            error=f"Failed to build form from spec: {exc}",
+        )
+
+    try:
+        created = await _create_hax_form_request_with_timeout(
+            app=app,
+            hax_client=hax_client,
+            form=form,
+            title=spec.title,
+            description=spec.description,
+            expires_in_seconds=int(expires_in_hours * 3600),
+            user_id=user_id,
+            webhook_url=webhook_url,
+            metadata=metadata,
+        )
+    except Exception as exc:
+        return AskUserResponse(
+            status="error",
+            error=f"create_form_request failed: {exc}",
+        )
+
+    pause_kwargs: dict[str, Any] = {
+        "approval_request_id": created.id,
+        "approval_request_url": created.url,
+        "expires_in_hours": expires_in_hours,
+    }
+    if execution_id:
+        pause_kwargs["execution_id"] = execution_id
+
+    try:
+        approval_result = await app.pause(**pause_kwargs)
+    except asyncio.TimeoutError:
+        app.note(
+            "ask_user: pause expired without human response",
+            tags=["ask_user", "pause", "timeout"],
+        )
+        return AskUserResponse(status="timeout")
+    except Exception as exc:
+        app.note(
+            f"ask_user: pause raised {type(exc).__name__}: {exc}",
+            tags=["ask_user", "pause", "error"],
+        )
+        return AskUserResponse(
+            status="error",
+            error=f"pause failed: {exc}",
+        )
+
+    response = _parse_approval_result_to_response(approval_result)
+    app.note(
+        f"ask_user: response received "
+        f"(status={response.status}, {len(response.values)} value(s))",
+        tags=["ask_user", "hax", "response", response.status],
+    )
+    return response

--- a/swe_af/hitl/wrapper.py
+++ b/swe_af/hitl/wrapper.py
@@ -1,0 +1,162 @@
+"""Reasoner-call wrapper that handles the ``ask_user_via_form`` loop.
+
+A reasoner participates in ask-user by declaring an optional
+``ask_user_form: AskUserForm | None = None`` field on its output schema.
+
+When the reasoner emits a non-None value, this wrapper:
+
+1. Builds a Hax form from the spec, calls ``app.pause()``, and waits for the
+   human's response.
+2. Re-invokes the same reasoner with the user's answers appended to a
+   ``prior_user_responses`` kwarg.
+3. Repeats until the reasoner emits ``ask_user_form=None`` or budget /
+   iteration cap is reached.
+
+When Hax is disabled (``hax_client is None``) or the per-build budget is
+exhausted, the wrapper still calls the reasoner once but strips any
+``ask_user_form`` from the result so downstream code never sees an unfulfilled
+ask.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
+
+from pydantic import BaseModel, Field
+
+from swe_af.hitl.ask_user import (
+    AskUserForm,
+    AskUserResponse,
+    request_user_input_and_pause,
+)
+
+if TYPE_CHECKING:
+    from hax import HaxClient
+
+
+class AskUserBudget(BaseModel):
+    """Per-build cap on ``ask_user_via_form`` invocations across all reasoners."""
+
+    remaining: int = Field(
+        default=5,
+        description=(
+            "Number of ask-user invocations left in this build() execution. "
+            "Shared across all wrapped reasoner call sites. When 0, the "
+            "wrapper refuses to issue further pauses."
+        ),
+    )
+
+
+class PriorUserResponse(BaseModel):
+    """One entry in the ``prior_user_responses`` list passed to a reasoner."""
+
+    question: str
+    status: str
+    values: dict[str, Any] = Field(default_factory=dict)
+    feedback: str | None = None
+
+
+def _clear_ask_user_form(result: BaseModel) -> BaseModel:
+    """Return a copy of ``result`` with ``ask_user_form`` set to None if present."""
+    if hasattr(result, "ask_user_form"):
+        try:
+            return result.model_copy(update={"ask_user_form": None})
+        except Exception:
+            return result
+    return result
+
+
+def _extract_ask_user_form(result: BaseModel) -> AskUserForm | None:
+    """Pull the ``ask_user_form`` field off a reasoner output, if present and populated."""
+    raw = getattr(result, "ask_user_form", None)
+    if raw is None:
+        return None
+    if isinstance(raw, AskUserForm):
+        return raw
+    if isinstance(raw, dict):
+        return AskUserForm.model_validate(raw)
+    return AskUserForm.model_validate(raw)
+
+
+async def run_with_ask_user(
+    *,
+    reasoner_fn: Callable[..., Awaitable[BaseModel]],
+    reasoner_kwargs: dict[str, Any],
+    app: Any,
+    hax_client: HaxClient | None,
+    budget: AskUserBudget,
+    expires_in_hours: float = 24,
+    user_id: str | None = None,
+    execution_id: str | None = None,
+    webhook_url: str | None = None,
+    max_iterations: int = 3,
+    note_label: str | None = None,
+) -> BaseModel:
+    """Call ``reasoner_fn`` with the ask-user pause/resume loop applied.
+
+    Returns the final reasoner output with ``ask_user_form`` cleared.
+    """
+    label = note_label or getattr(reasoner_fn, "__name__", "reasoner")
+    kwargs = dict(reasoner_kwargs)
+    kwargs.setdefault("prior_user_responses", [])
+
+    for iteration in range(max_iterations + 1):
+        result = await reasoner_fn(**kwargs)
+        spec = _extract_ask_user_form(result)
+
+        if spec is None:
+            return result
+
+        if hax_client is None:
+            app.note(
+                f"{label}: LLM emitted ask_user_form but HAX is disabled — "
+                f"ignoring and proceeding with current decision",
+                tags=["ask_user", "skipped", "hax_disabled"],
+            )
+            return _clear_ask_user_form(result)
+
+        if budget.remaining <= 0:
+            app.note(
+                f"{label}: ask_user budget exhausted (remaining=0) — "
+                f"ignoring further asks and proceeding",
+                tags=["ask_user", "skipped", "budget_exhausted"],
+            )
+            return _clear_ask_user_form(result)
+
+        if iteration >= max_iterations:
+            app.note(
+                f"{label}: ask_user max_iterations ({max_iterations}) "
+                f"reached without converging — proceeding",
+                tags=["ask_user", "skipped", "max_iterations"],
+            )
+            return _clear_ask_user_form(result)
+
+        budget.remaining -= 1
+        app.note(
+            f"{label}: pausing for ask_user_via_form "
+            f"(iteration {iteration}, budget_remaining={budget.remaining})",
+            tags=["ask_user", "pause", label],
+        )
+
+        response: AskUserResponse = await request_user_input_and_pause(
+            app=app,
+            spec=spec,
+            hax_client=hax_client,
+            expires_in_hours=expires_in_hours,
+            user_id=user_id,
+            execution_id=execution_id,
+            webhook_url=webhook_url,
+        )
+
+        prior = list(kwargs.get("prior_user_responses") or [])
+        prior.append(
+            PriorUserResponse(
+                question=spec.title,
+                status=response.status,
+                values=response.values,
+                feedback=response.feedback,
+            ).model_dump()
+        )
+        kwargs["prior_user_responses"] = prior
+
+    return _clear_ask_user_form(result)

--- a/swe_af/prompts/issue_advisor.py
+++ b/swe_af/prompts/issue_advisor.py
@@ -8,6 +8,7 @@ split, accept with debt, or escalate to the outer replanner).
 from __future__ import annotations
 
 from swe_af.execution.schemas import WorkspaceManifest
+from swe_af.hitl.ask_user import format_prior_user_responses
 from swe_af.prompts._utils import workspace_context_block
 
 SYSTEM_PROMPT = """\
@@ -84,7 +85,39 @@ You have read-only access to the codebase:
 - READ files to inspect source code and the worktree
 - GLOB to find files by pattern
 - GREP to search for patterns
-- BASH for read-only commands (ls, git log, git diff, test runs, etc.)\
+- BASH for read-only commands (ls, git log, git diff, test runs, etc.)
+
+## Asking the User for Clarification (`ask_user_form`)
+
+When you genuinely cannot judge between two valid actions, emit
+``ask_user_form`` alongside your best-guess action. The orchestrator pauses
+the ENTIRE workflow on the control plane, shows the user a form, and
+re-invokes you once they submit. Their answers arrive in
+``prior_user_responses`` on the next call.
+
+When to ask:
+- Choosing between RETRY_MODIFIED and ACCEPT_WITH_DEBT and the trade-off
+  hinges on the user's risk tolerance.
+- Multiple acceptance criteria are failing and you don't know which ones the
+  user considers acceptable as debt.
+- Considering ESCALATE_TO_REPLAN but unsure whether the user wants to keep
+  iterating at all.
+
+When NOT to ask:
+- The right action is obvious from the failure context.
+- ``prior_user_responses`` already covers this question — USE the existing
+  answer, do not re-ask.
+- You're just looking for confirmation. Bias toward deciding.
+
+Pausing stops the build until the human responds (potentially hours/days).
+Be parsimonious. Each ask should genuinely change the decision.
+
+Form construction (when used):
+- ``title``: one-sentence question, plain English.
+- ``description`` (optional): brief context for why you're asking.
+- ``fields``: typically ONE radio or select field with 2-3 concrete options
+  matching your candidate actions.
+- Leave ``ask_user_form`` as ``null`` (default) when you can decide on your own.\
 """
 
 
@@ -99,6 +132,7 @@ def issue_advisor_task_prompt(
     previous_adaptations: list[dict] | None = None,
     worktree_path: str = "",
     workspace_manifest: WorkspaceManifest | None = None,
+    prior_user_responses: list[dict] | None = None,
 ) -> str:
     """Build the task prompt for the Issue Advisor agent.
 
@@ -120,6 +154,10 @@ def issue_advisor_task_prompt(
     ws_block = workspace_context_block(workspace_manifest)
     if ws_block:
         sections.append(ws_block)
+
+    prior_block = format_prior_user_responses(prior_user_responses)
+    if prior_block:
+        sections.append(prior_block)
 
     # Budget awareness
     remaining = max_advisor_invocations - advisor_invocation

--- a/swe_af/prompts/product_manager.py
+++ b/swe_af/prompts/product_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from swe_af.execution.schemas import WorkspaceManifest
+from swe_af.hitl.ask_user import format_prior_user_responses
 from swe_af.prompts._utils import workspace_context_block
 
 SYSTEM_PROMPT = """\
@@ -62,7 +63,36 @@ Your PRD will be executed by autonomous AI coding agents, not human developers.
   into a parallel execution graph.
 - **Interface-first requirements**: When multiple components interact, specify
   the interface contract (function signatures, types, error variants) in your
-  acceptance criteria. Parallel agents implement to this contract independently.\
+  acceptance criteria. Parallel agents implement to this contract independently.
+
+## Asking the User for Clarification (`ask_user_form`)
+
+If the goal is **fundamentally ambiguous** — multiple plausible interpretations
+would yield very different PRDs — emit ``ask_user_form`` instead of guessing.
+The orchestrator pauses the ENTIRE workflow on the control plane, shows the
+user the form, and re-invokes you with their answers in
+``prior_user_responses``. You can then write the real PRD.
+
+When to ask:
+- The goal references multiple features/pages/components and priority is unclear.
+- The goal's success criteria are unstated and you cannot infer them safely from
+  the codebase.
+- Two architecturally different interpretations are plausible and choosing one
+  forecloses the other.
+
+When NOT to ask:
+- For style preferences, tone, or embellishment — those are not your concern.
+- For details you can reasonably assume and document under ``assumptions``.
+- When ``prior_user_responses`` already covers the ambiguity — USE the existing
+  answer; never re-ask the same question.
+
+On the iteration where you emit ``ask_user_form``, fill the other PRD fields
+with minimal placeholders — they will be discarded. On the next invocation
+(with ``prior_user_responses`` populated), produce the real PRD with
+``ask_user_form`` set to ``null``.
+
+Pausing stops the build until the human responds (potentially hours/days).
+Be parsimonious — one focused question, then commit.\
 """
 
 
@@ -72,12 +102,21 @@ def product_manager_prompts(
     repo_path: str,
     prd_path: str,
     additional_context: str = "",
+    prior_user_responses: list[dict] | None = None,
 ) -> tuple[str, str]:
     """Return (system_prompt, task_prompt) for the product manager.
 
     Returns:
         Tuple of (system_prompt, task_prompt)
     """
+    prior_block = format_prior_user_responses(prior_user_responses)
+    if prior_block:
+        additional_context = (
+            f"{prior_block}\n\n{additional_context}"
+            if additional_context
+            else prior_block
+        )
+
     context_block = ""
     if additional_context:
         context_block = f"\n## Additional Context\n{additional_context}\n"
@@ -120,6 +159,7 @@ def pm_task_prompt(
     prd_path: str,
     additional_context: str = "",
     workspace_manifest: WorkspaceManifest | None = None,
+    prior_user_responses: list[dict] | None = None,
 ) -> str:
     """Build the task prompt for the product manager agent.
 
@@ -129,6 +169,7 @@ def pm_task_prompt(
         prd_path: Path where the PRD should be written.
         additional_context: Optional additional context.
         workspace_manifest: Optional multi-repo workspace manifest.
+        prior_user_responses: Accumulated answers from prior ask_user pauses.
 
     Returns:
         Task prompt string.
@@ -138,6 +179,7 @@ def pm_task_prompt(
         repo_path=repo_path,
         prd_path=prd_path,
         additional_context=additional_context,
+        prior_user_responses=prior_user_responses,
     )
     ws_block = workspace_context_block(workspace_manifest)
     if ws_block:

--- a/swe_af/prompts/replanner.py
+++ b/swe_af/prompts/replanner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from swe_af.execution.schemas import DAGState, IssueResult
+from swe_af.hitl.ask_user import format_prior_user_responses
 
 SYSTEM_PROMPT = """\
 You are a senior Engineering Manager responding to execution failures in an
@@ -68,7 +69,34 @@ You must return a JSON object conforming to the ReplanDecision schema. Be precis
 - Previous replan attempts (if any) are shown in the context. Do NOT repeat
   an approach that already failed.
 - Keep modifications minimal. The more you change, the higher the risk of
-  introducing new failures. Prefer targeted fixes over wholesale restructuring.\
+  introducing new failures. Prefer targeted fixes over wholesale restructuring.
+
+## Asking the User for Clarification (`ask_user_form`)
+
+When the right action depends on a project-level judgment only the user can
+make, emit ``ask_user_form`` alongside your best-guess action. The
+orchestrator pauses the ENTIRE workflow on the control plane and re-invokes
+you with the user's answers in ``prior_user_responses``.
+
+When to ask:
+- You are considering **ABORT**. The user almost always wants to know first
+  — abandoning a build is a project-level decision, not yours alone.
+- The choice between **REDUCE_SCOPE** and **MODIFY_DAG** hinges on the user's
+  appetite for partial delivery vs. continued investment in restructuring.
+
+When NOT to ask:
+- Routine **CONTINUE** or **MODIFY_DAG** decisions — those are yours to make.
+- ``prior_user_responses`` already covers this question. USE the existing
+  answer; never re-ask.
+
+Pausing stops the build until the human responds (hours/days). Be
+parsimonious — only ask when the decision genuinely needs human input.
+
+Form construction (when used):
+- ``title``: one-sentence question (e.g. "Abort or continue with reduced scope?").
+- ``description`` (optional): the concrete trade-off in 1-2 sentences.
+- ``fields``: typically ONE radio with 2-3 options matching your candidate actions.
+- Leave ``ask_user_form`` as ``null`` (default) when you can decide on your own.\
 """
 
 
@@ -77,6 +105,7 @@ def replanner_task_prompt(
     failed_issues: list[IssueResult],
     escalation_notes: list[dict] | None = None,
     adaptation_history: list[dict] | None = None,
+    prior_user_responses: list[dict] | None = None,
 ) -> str:
     """Build the task prompt for the replanner agent.
 
@@ -85,6 +114,10 @@ def replanner_task_prompt(
     context), and what remains.
     """
     sections: list[str] = []
+
+    prior_block = format_prior_user_responses(prior_user_responses)
+    if prior_block:
+        sections.append(prior_block)
 
     # --- Original Plan ---
     sections.append("## Original Plan Summary")

--- a/swe_af/reasoners/execution_agents.py
+++ b/swe_af/reasoners/execution_agents.py
@@ -217,6 +217,7 @@ async def run_issue_advisor(
     permission_mode: str = "",
     ai_provider: str = "claude",
     workspace_manifest: dict | None = None,
+    prior_user_responses: list[dict] | None = None,
 ) -> dict:
     """Analyze a coding loop failure and decide how to adapt.
 
@@ -231,23 +232,32 @@ async def run_issue_advisor(
 
     ws_manifest = _maybe_workspace_manifest(workspace_manifest)
 
-    task_prompt = issue_advisor_task_prompt(
-        issue=issue,
-        original_issue=original_issue,
-        failure_result=failure_result,
-        iteration_history=iteration_history,
-        dag_state_summary=dag_state_summary,
-        advisor_invocation=advisor_invocation,
-        max_advisor_invocations=max_advisor_invocations,
-        previous_adaptations=previous_adaptations,
-        worktree_path=worktree_path,
-        workspace_manifest=ws_manifest,
-    )
-
     cwd = worktree_path or dag_state_summary.get("repo_path", ".")
     provider = runtime_to_harness_adapter(ai_provider)
 
-    try:
+    from swe_af.hitl import (  # noqa: PLC0415
+        AskUserBudget,
+        approval_webhook_url,
+        build_hax_client_from_env,
+        run_with_ask_user,
+    )
+
+    async def _invoke_advisor(
+        prior_user_responses: list[dict] | None,
+    ) -> IssueAdvisorDecision | None:
+        task_prompt = issue_advisor_task_prompt(
+            issue=issue,
+            original_issue=original_issue,
+            failure_result=failure_result,
+            iteration_history=iteration_history,
+            dag_state_summary=dag_state_summary,
+            advisor_invocation=advisor_invocation,
+            max_advisor_invocations=max_advisor_invocations,
+            previous_adaptations=previous_adaptations,
+            worktree_path=worktree_path,
+            workspace_manifest=ws_manifest,
+            prior_user_responses=prior_user_responses,
+        )
         result = await router.harness(
             task_prompt,
             system_prompt=ISSUE_ADVISOR_SYSTEM_PROMPT,
@@ -260,12 +270,25 @@ async def run_issue_advisor(
             permission_mode=permission_mode or None,
         )
         check_fatal_harness_error(result)
-        if result.parsed is not None:
+        return result.parsed
+
+    try:
+        initial_prior = list(prior_user_responses or [])
+        parsed = await run_with_ask_user(
+            reasoner_fn=_invoke_advisor,
+            reasoner_kwargs={"prior_user_responses": initial_prior},
+            app=router,
+            hax_client=build_hax_client_from_env(),
+            budget=AskUserBudget(remaining=2),
+            webhook_url=approval_webhook_url(router),
+            note_label="issue_advisor",
+        )
+        if parsed is not None:
             router.note(
-                f"Issue advisor decision: {result.parsed.action.value} — {result.parsed.summary}",
+                f"Issue advisor decision: {parsed.action.value} — {parsed.summary}",
                 tags=["issue_advisor", "complete"],
             )
-            return result.parsed.model_dump()
+            return parsed.model_dump()
     except FatalHarnessError:
         raise  # Non-retryable — propagate immediately
     except Exception as e:
@@ -300,6 +323,7 @@ async def run_replanner(
     permission_mode: str = "",
     ai_provider: str = "claude",
     escalation_notes: list[dict] | None = None,
+    prior_user_responses: list[dict] | None = None,
 ) -> dict:
     """Invoke the replanner to decide how to handle unrecoverable failures.
 
@@ -315,21 +339,30 @@ async def run_replanner(
         tags=["replanner", "start"],
     )
 
-    task_prompt = replanner_task_prompt(
-        state,
-        failures,
-        escalation_notes=escalation_notes,
-        adaptation_history=state.adaptation_history
-        if hasattr(state, "adaptation_history")
-        else [],
-    )
-
     log_dir = os.path.join(state.artifacts_dir, "logs") if state.artifacts_dir else None
     provider = runtime_to_harness_adapter(ai_provider)
 
-    current_prompt = task_prompt
-    for attempt in range(2):
-        try:
+    from swe_af.hitl import (  # noqa: PLC0415
+        AskUserBudget,
+        approval_webhook_url,
+        build_hax_client_from_env,
+        run_with_ask_user,
+    )
+
+    async def _invoke_replanner(
+        prior_user_responses: list[dict] | None,
+    ) -> ReplanDecision | None:
+        task_prompt = replanner_task_prompt(
+            state,
+            failures,
+            escalation_notes=escalation_notes,
+            adaptation_history=state.adaptation_history
+            if hasattr(state, "adaptation_history")
+            else [],
+            prior_user_responses=prior_user_responses,
+        )
+        current_prompt = task_prompt
+        for attempt in range(2):
             result = await router.harness(
                 current_prompt,
                 system_prompt=REPLANNER_SYSTEM_PROMPT,
@@ -342,7 +375,6 @@ async def run_replanner(
                 permission_mode=permission_mode or None,
             )
             check_fatal_harness_error(result)
-            # Log raw response for debugging (even on parse failure)
             if log_dir:
                 raw_log = os.path.join(
                     log_dir, f"replanner_{state.replan_count}_raw_{attempt}.txt"
@@ -350,15 +382,8 @@ async def run_replanner(
                 os.makedirs(log_dir, exist_ok=True)
                 with open(raw_log, "w") as f:
                     f.write(getattr(result, "text", "") or "(empty)")
-
             if result.parsed is not None:
-                router.note(
-                    f"Replan decision: {result.parsed.action.value} — {result.parsed.summary}",
-                    tags=["replanner", "complete"],
-                )
-                return result.parsed.model_dump()
-
-            # Parse failed — retry with tighter prompt
+                return result.parsed
             router.note(
                 f"Replanner produced unparseable output (attempt {attempt + 1}): "
                 f"{(getattr(result, 'text', '') or '')[:500]}",
@@ -369,13 +394,32 @@ async def run_replanner(
                 "Output ONLY valid JSON conforming to the ReplanDecision schema.\n\n"
                 + task_prompt
             )
-        except FatalHarnessError:
-            raise  # Non-retryable — propagate immediately
-        except Exception as e:
+        return None
+
+    try:
+        initial_prior = list(prior_user_responses or [])
+        parsed = await run_with_ask_user(
+            reasoner_fn=_invoke_replanner,
+            reasoner_kwargs={"prior_user_responses": initial_prior},
+            app=router,
+            hax_client=build_hax_client_from_env(),
+            budget=AskUserBudget(remaining=2),
+            webhook_url=approval_webhook_url(router),
+            note_label="replanner",
+        )
+        if parsed is not None:
             router.note(
-                f"Replanner agent failed (attempt {attempt + 1}): {e}",
-                tags=["replanner", "error"],
+                f"Replan decision: {parsed.action.value} — {parsed.summary}",
+                tags=["replanner", "complete"],
             )
+            return parsed.model_dump()
+    except FatalHarnessError:
+        raise  # Non-retryable — propagate immediately
+    except Exception as e:
+        router.note(
+            f"Replanner agent failed: {e}",
+            tags=["replanner", "error"],
+        )
 
     # Pitfall 5 fix: fall back to CONTINUE, not ABORT
     # Skip downstream of failed issues but don't kill the pipeline

--- a/swe_af/reasoners/pipeline.py
+++ b/swe_af/reasoners/pipeline.py
@@ -166,6 +166,7 @@ async def run_product_manager(
     permission_mode: str = "",
     ai_provider: str = "claude",
     workspace_manifest: dict | None = None,
+    prior_user_responses: list[dict] | None = None,
 ) -> dict:
     """Run the product manager agent to scope a goal into a PRD."""
     router.note("PM starting", tags=["pm", "start"])
@@ -181,35 +182,59 @@ async def run_product_manager(
         repo_path=repo_path,
         prd_path=paths["prd"],
         additional_context=additional_context,
+        prior_user_responses=prior_user_responses,
     )
     ws_manifest = (
         WorkspaceManifest(**workspace_manifest) if workspace_manifest else None
     )
-    task_prompt = pm_task_prompt(
-        goal=goal,
-        repo_path=repo_path,
-        prd_path=paths["prd"],
-        additional_context=additional_context,
-        workspace_manifest=ws_manifest,
-    )
     provider = runtime_to_harness_adapter(ai_provider)
-    result = await router.harness(
-        prompt=task_prompt,
-        schema=PRD,
-        provider=provider,
-        model=model,
-        max_turns=max_turns,
-        tools=["Read", "Write", "Glob", "Grep", "Bash"],
-        permission_mode=permission_mode or None,
-        system_prompt=system_prompt,
-        cwd=repo_path,
+
+    from swe_af.hitl import (  # noqa: PLC0415
+        AskUserBudget,
+        approval_webhook_url,
+        build_hax_client_from_env,
+        run_with_ask_user,
     )
-    check_fatal_harness_error(result)
-    if result.parsed is None:
+
+    async def _invoke_pm(prior_user_responses: list[dict] | None) -> PRD | None:
+        task_prompt = pm_task_prompt(
+            goal=goal,
+            repo_path=repo_path,
+            prd_path=paths["prd"],
+            additional_context=additional_context,
+            workspace_manifest=ws_manifest,
+            prior_user_responses=prior_user_responses,
+        )
+        result = await router.harness(
+            prompt=task_prompt,
+            schema=PRD,
+            provider=provider,
+            model=model,
+            max_turns=max_turns,
+            tools=["Read", "Write", "Glob", "Grep", "Bash"],
+            permission_mode=permission_mode or None,
+            system_prompt=system_prompt,
+            cwd=repo_path,
+        )
+        check_fatal_harness_error(result)
+        return result.parsed
+
+    initial_prior = list(prior_user_responses or [])
+    parsed = await run_with_ask_user(
+        reasoner_fn=_invoke_pm,
+        reasoner_kwargs={"prior_user_responses": initial_prior},
+        app=router,
+        hax_client=build_hax_client_from_env(),
+        budget=AskUserBudget(remaining=2),
+        webhook_url=approval_webhook_url(router),
+        note_label="product_manager",
+    )
+
+    if parsed is None:
         raise RuntimeError("Product manager failed to produce a valid PRD")
 
     router.note("PM complete", tags=["pm", "complete"])
-    return result.parsed.model_dump()
+    return parsed.model_dump()
 
 
 @router.reasoner()

--- a/swe_af/reasoners/schemas.py
+++ b/swe_af/reasoners/schemas.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pydantic import BaseModel
 
+from swe_af.hitl.ask_user import AskUserForm
+
 
 class PRD(BaseModel):
     """Product Requirements Document produced by the product manager."""
@@ -15,6 +17,7 @@ class PRD(BaseModel):
     out_of_scope: list[str]
     assumptions: list[str] = []
     risks: list[str] = []
+    ask_user_form: AskUserForm | None = None  # see swe_af/hitl/ for semantics
 
 
 class ArchitectureComponent(BaseModel):

--- a/tests/test_ask_user.py
+++ b/tests/test_ask_user.py
@@ -1,0 +1,408 @@
+"""Unit tests for the ``swe_af.hitl`` ask-user-via-form primitive."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from swe_af.hitl.ask_user import (
+    AskUserForm,
+    AskUserFormField,
+    _parse_approval_result_to_response,
+    build_form_builder,
+    request_user_input_and_pause,
+)
+from swe_af.hitl.wrapper import AskUserBudget, run_with_ask_user
+
+
+def _approval_result(
+    *,
+    decision: str = "approved",
+    feedback: str | None = None,
+    raw_response: dict | None = None,
+):
+    """Build a stand-in for ``agentfield.client.ApprovalResult``."""
+    obj = MagicMock()
+    obj.decision = decision
+    obj.feedback = feedback or ""
+    obj.raw_response = raw_response
+    return obj
+
+
+def _silent_app() -> MagicMock:
+    """An app stub that swallows ``.note(...)`` calls and exposes an async ``.pause``."""
+    app = MagicMock()
+    app.note = MagicMock()
+    app.pause = AsyncMock()
+    return app
+
+
+# ---------------------------------------------------------------------------
+# build_form_builder
+# ---------------------------------------------------------------------------
+
+
+def test_build_form_builder_input_field():
+    spec = AskUserForm(
+        title="Need clarification",
+        fields=[
+            AskUserFormField(
+                id="reason", type="input", label="Why?", required=True
+            ),
+        ],
+    )
+    payload = build_form_builder(spec).to_payload()
+    assert payload["title"] == "Need clarification"
+    fields = payload["fields"]
+    assert len(fields) == 1
+    assert fields[0]["type"] == "input"
+    assert fields[0]["id"] == "reason"
+    assert fields[0]["label"] == "Why?"
+    assert fields[0]["required"] is True
+
+
+def test_build_form_builder_select_with_options():
+    spec = AskUserForm(
+        title="Pick one",
+        fields=[
+            AskUserFormField(
+                id="choice",
+                type="select",
+                label="Choice",
+                options=[
+                    {"value": "a", "label": "Option A"},
+                    {"value": "b", "label": "Option B"},
+                ],
+            ),
+        ],
+    )
+    payload = build_form_builder(spec).to_payload()
+    field = payload["fields"][0]
+    assert field["type"] == "select"
+    assert field["options"] == [
+        {"value": "a", "label": "Option A"},
+        {"value": "b", "label": "Option B"},
+    ]
+
+
+def test_build_form_builder_all_supported_types_smoke():
+    spec = AskUserForm(
+        title="All types",
+        fields=[
+            AskUserFormField(id="i", type="input", label="i"),
+            AskUserFormField(id="t", type="textarea", label="t"),
+            AskUserFormField(id="n", type="number", label="n", min=0, max=10),
+            AskUserFormField(
+                id="sl", type="slider", label="sl", min=0, max=100, step=5
+            ),
+            AskUserFormField(
+                id="s", type="select", label="s",
+                options=[{"value": "x", "label": "X"}],
+            ),
+            AskUserFormField(
+                id="r", type="radio", label="r",
+                options=[{"value": "x", "label": "X"}],
+            ),
+            AskUserFormField(
+                id="cg", type="checkbox_group", label="cg",
+                options=[{"value": "x", "label": "X"}],
+            ),
+            AskUserFormField(id="c", type="checkbox", label="c"),
+            AskUserFormField(id="sw", type="switch", label="sw"),
+            AskUserFormField(id="d", type="date", label="d"),
+        ],
+    )
+    payload = build_form_builder(spec).to_payload()
+    types = [f["type"] for f in payload["fields"]]
+    assert types == [
+        "input", "textarea", "number", "slider", "select",
+        "radio-group", "checkbox-group", "checkbox", "switch", "date",
+    ]
+
+
+def test_build_form_builder_select_without_options_raises():
+    spec = AskUserForm(
+        title="Bad",
+        fields=[AskUserFormField(id="x", type="select", label="x")],
+    )
+    with pytest.raises(ValueError, match="select field 'x' requires options"):
+        build_form_builder(spec)
+
+
+# ---------------------------------------------------------------------------
+# _parse_approval_result_to_response
+# ---------------------------------------------------------------------------
+
+
+def test_parse_approved_with_values_in_raw_response():
+    raw = {"values": {"reason": "bug", "priority": "high"}}
+    out = _parse_approval_result_to_response(
+        _approval_result(decision="approved", raw_response=raw)
+    )
+    assert out.status == "submitted"
+    assert out.values == {"reason": "bug", "priority": "high"}
+
+
+def test_parse_approved_with_values_in_raw_response_nested():
+    raw = {"response": {"values": {"a": 1}}}
+    out = _parse_approval_result_to_response(
+        _approval_result(decision="approved", raw_response=raw)
+    )
+    assert out.status == "submitted"
+    assert out.values == {"a": 1}
+
+
+def test_parse_rejected_maps_to_cancelled():
+    out = _parse_approval_result_to_response(
+        _approval_result(decision="rejected", feedback="not now")
+    )
+    assert out.status == "cancelled"
+    assert out.feedback == "not now"
+
+
+def test_parse_expired_maps_to_timeout():
+    out = _parse_approval_result_to_response(
+        _approval_result(decision="expired")
+    )
+    assert out.status == "timeout"
+
+
+def test_parse_request_changes_maps_to_submitted():
+    raw = {"values": {"x": "y"}}
+    out = _parse_approval_result_to_response(
+        _approval_result(decision="request_changes", raw_response=raw)
+    )
+    assert out.status == "submitted"
+    assert out.values == {"x": "y"}
+
+
+# ---------------------------------------------------------------------------
+# request_user_input_and_pause
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_request_user_input_submitted_path():
+    spec = AskUserForm(
+        title="Question",
+        fields=[AskUserFormField(id="x", type="input", label="X")],
+    )
+    hax_client = MagicMock()
+    created = MagicMock(id="req-1", url="https://hax/r/req-1")
+    hax_client.create_request = MagicMock(return_value=created)
+
+    app = _silent_app()
+    app.pause.return_value = _approval_result(
+        decision="approved", raw_response={"values": {"x": "yes"}}
+    )
+
+    out = await request_user_input_and_pause(
+        app=app, spec=spec, hax_client=hax_client, expires_in_hours=1
+    )
+    assert out.status == "submitted"
+    assert out.values == {"x": "yes"}
+    # The form payload sent to hax-sdk had type='form-builder'
+    call_kwargs = hax_client.create_request.call_args.kwargs
+    assert call_kwargs["type"] == "form-builder"
+    assert call_kwargs["title"] == "Question"
+    # app.pause was called with the created request's id and url
+    app.pause.assert_awaited_once()
+    pause_kwargs = app.pause.await_args.kwargs
+    assert pause_kwargs["approval_request_id"] == "req-1"
+    assert pause_kwargs["approval_request_url"] == "https://hax/r/req-1"
+
+
+@pytest.mark.asyncio
+async def test_request_user_input_timeout_when_pause_times_out():
+    spec = AskUserForm(
+        title="Q", fields=[AskUserFormField(id="x", type="input", label="X")]
+    )
+    hax_client = MagicMock()
+    hax_client.create_request = MagicMock(
+        return_value=MagicMock(id="r", url="u")
+    )
+    app = _silent_app()
+    app.pause.side_effect = asyncio.TimeoutError()
+
+    out = await request_user_input_and_pause(
+        app=app, spec=spec, hax_client=hax_client, expires_in_hours=1
+    )
+    assert out.status == "timeout"
+
+
+@pytest.mark.asyncio
+async def test_request_user_input_cancelled_on_rejected_decision():
+    spec = AskUserForm(
+        title="Q", fields=[AskUserFormField(id="x", type="input", label="X")]
+    )
+    hax_client = MagicMock()
+    hax_client.create_request = MagicMock(
+        return_value=MagicMock(id="r", url="u")
+    )
+    app = _silent_app()
+    app.pause.return_value = _approval_result(
+        decision="rejected", feedback="user said no"
+    )
+
+    out = await request_user_input_and_pause(
+        app=app, spec=spec, hax_client=hax_client, expires_in_hours=1
+    )
+    assert out.status == "cancelled"
+    assert out.feedback == "user said no"
+
+
+# ---------------------------------------------------------------------------
+# run_with_ask_user wrapper
+# ---------------------------------------------------------------------------
+
+
+def _result(action: str, ask: AskUserForm | None = None):
+    """Build a stand-in for a reasoner output schema with ``ask_user_form``."""
+    m = MagicMock()
+    m.action = action
+    m.ask_user_form = ask
+    m.model_copy = lambda update: _result(
+        m.action, update.get("ask_user_form", ask)
+    )
+    return m
+
+
+@pytest.mark.asyncio
+async def test_wrapper_no_ask_passthrough():
+    reasoner_fn = AsyncMock(return_value=_result("DONE"))
+    app = _silent_app()
+
+    out = await run_with_ask_user(
+        reasoner_fn=reasoner_fn,
+        reasoner_kwargs={},
+        app=app,
+        hax_client=MagicMock(),
+        budget=AskUserBudget(remaining=3),
+    )
+    assert out.action == "DONE"
+    reasoner_fn.assert_awaited_once()
+    app.pause.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_wrapper_hax_disabled_clears_field_and_returns():
+    spec = AskUserForm(
+        title="Q", fields=[AskUserFormField(id="x", type="input", label="X")]
+    )
+    reasoner_fn = AsyncMock(return_value=_result("ASKING", ask=spec))
+    app = _silent_app()
+
+    out = await run_with_ask_user(
+        reasoner_fn=reasoner_fn,
+        reasoner_kwargs={},
+        app=app,
+        hax_client=None,  # HAX disabled
+        budget=AskUserBudget(remaining=5),
+    )
+    assert out.ask_user_form is None
+    reasoner_fn.assert_awaited_once()
+    app.pause.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_wrapper_budget_exhausted_clears_field_no_pause():
+    spec = AskUserForm(
+        title="Q", fields=[AskUserFormField(id="x", type="input", label="X")]
+    )
+    reasoner_fn = AsyncMock(return_value=_result("ASKING", ask=spec))
+    app = _silent_app()
+    budget = AskUserBudget(remaining=0)
+
+    out = await run_with_ask_user(
+        reasoner_fn=reasoner_fn,
+        reasoner_kwargs={},
+        app=app,
+        hax_client=MagicMock(),
+        budget=budget,
+    )
+    assert out.ask_user_form is None
+    reasoner_fn.assert_awaited_once()
+    app.pause.assert_not_called()
+    assert budget.remaining == 0
+
+
+@pytest.mark.asyncio
+async def test_wrapper_one_ask_round_then_no_ask():
+    spec = AskUserForm(
+        title="Pick",
+        fields=[AskUserFormField(id="x", type="input", label="X")],
+    )
+    # First call returns ask, second returns final.
+    reasoner_fn = AsyncMock(
+        side_effect=[
+            _result("ASKING", ask=spec),
+            _result("FINAL", ask=None),
+        ]
+    )
+
+    hax_client = MagicMock()
+    hax_client.create_request = MagicMock(
+        return_value=MagicMock(id="req-99", url="https://hax/r/req-99")
+    )
+
+    app = _silent_app()
+    app.pause.return_value = _approval_result(
+        decision="approved", raw_response={"values": {"x": "answer"}}
+    )
+
+    budget = AskUserBudget(remaining=5)
+    out = await run_with_ask_user(
+        reasoner_fn=reasoner_fn,
+        reasoner_kwargs={"prior_user_responses": []},
+        app=app,
+        hax_client=hax_client,
+        budget=budget,
+    )
+
+    assert out.action == "FINAL"
+    assert out.ask_user_form is None
+    assert reasoner_fn.await_count == 2
+    second_call = reasoner_fn.await_args_list[1]
+    prior = second_call.kwargs["prior_user_responses"]
+    assert len(prior) == 1
+    assert prior[0]["question"] == "Pick"
+    assert prior[0]["status"] == "submitted"
+    assert prior[0]["values"] == {"x": "answer"}
+    assert budget.remaining == 4
+
+
+@pytest.mark.asyncio
+async def test_wrapper_max_iterations_clears_field_after_exhaust():
+    spec = AskUserForm(
+        title="Q",
+        fields=[AskUserFormField(id="x", type="input", label="X")],
+    )
+    # Reasoner ALWAYS asks again.
+    reasoner_fn = AsyncMock(return_value=_result("ASKING", ask=spec))
+
+    hax_client = MagicMock()
+    hax_client.create_request = MagicMock(
+        return_value=MagicMock(id="r", url="u")
+    )
+
+    app = _silent_app()
+    app.pause.return_value = _approval_result(
+        decision="approved", raw_response={"values": {"x": "yes"}}
+    )
+
+    budget = AskUserBudget(remaining=10)  # large; max_iterations is the cap
+    out = await run_with_ask_user(
+        reasoner_fn=reasoner_fn,
+        reasoner_kwargs={"prior_user_responses": []},
+        app=app,
+        hax_client=hax_client,
+        budget=budget,
+        max_iterations=3,
+    )
+    assert out.ask_user_form is None
+    # First 3 iterations pause; the 4th iteration call hits max_iterations
+    # check before pausing and returns the cleared result.
+    assert app.pause.await_count == 3
+    assert budget.remaining == 10 - 3


### PR DESCRIPTION
## Summary

Generalizes the existing Phase 1.5 plan-approval gate into a reusable
`ask_user_via_form` substrate. Three reasoners (`run_product_manager`,
`run_issue_advisor`, `run_replanner`) can now emit an `ask_user_form`
field in their structured output; when populated, the workflow pauses
on the control plane (real `app.pause`, hours/days if needed) until the
user submits, then re-invokes the reasoner with the answers in
`prior_user_responses`.

## Why

The existing HITL surface is exactly one moment — Phase 1.5 plan approval.
Everywhere else the agent silently picks a default when the right
answer hinges on user judgment (which failing acceptance criteria are
acceptable as debt? abort or reduce scope? which of multiple plausible
goal interpretations?). This adds an opt-in way for the LLM itself to
escalate those cases.

## What's in this PR

**New substrate — `swe_af/hitl/`:**
- `AskUserForm` / `AskUserFormField` — Pydantic spec the LLM emits. Covers
  all FormBuilder field types (input, textarea, number, slider, select,
  radio, checkbox, checkbox_group, switch, date).
- `build_form_builder(spec)` — translates the spec into `hax.FormBuilder`.
- `request_user_input_and_pause(...)` — sends form via `create_request(type="form-builder")`
  (wrapped with the same 120s hard timeout the plan-approval gate uses),
  then `await app.pause(...)`, then parses the response into `AskUserResponse`.
- `run_with_ask_user(...)` — generic reasoner wrapper that loops on
  `ask_user_form` output, threading `prior_user_responses` back into each
  subsequent invocation. Budget-capped (`AskUserBudget`) and max-iteration-capped.
- `format_prior_user_responses(prior)` — renders accumulated answers as
  a markdown block so the LLM doesn't re-ask questions already answered.
- `build_hax_client_from_env()` / `approval_webhook_url(app)` — env-driven
  plumbing so each reasoner self-configures.

**Initial allowlist (each reasoner gets `ask_user_form` schema field + prompt guidance):**
- `run_product_manager` — for fundamentally ambiguous goals where two
  interpretations would yield very different PRDs.
- `run_issue_advisor` — for RETRY_MODIFIED vs ACCEPT_WITH_DEBT trade-offs
  and which failing acceptance criteria are acceptable as debt.
- `run_replanner` — for ABORT (project-level judgment) and REDUCE_SCOPE
  vs MODIFY_DAG (user's appetite for partial delivery).

Each reasoner caps itself at 2 ask iterations per invocation. Across a
build, total asks are bounded by call-site count (each reasoner
invocation has its own budget — cross-reasoner sharing wasn't feasible
because `run_issue_advisor` / `run_replanner` are invoked across
reasoner boundaries via `app.call()`).

**Dependency bump:** `hax-sdk>=0.2.0` → `>=0.2.4` in
`requirements.txt`, `requirements-docker.txt`, and `pyproject.toml`.
Docker pip cache keys on the constraint string; without the floor bump,
cached layers keep installing whatever was first resolved. `FormBuilder`
and `create_form_request` were already in 0.2.0; this is purely cache
invalidation.

## What this PR does NOT change

- The existing Phase 1.5 plan-approval gate (`type="plan-review-v2"`).
  Stays as-is; runs alongside the new substrate.
- Default behavior when `HAX_API_KEY` is unset. `build_hax_client_from_env`
  returns `None`; the wrapper short-circuits. Pipeline behavior is
  identical to `main`.
- Tool calls to the Claude Code harness. We kept the schema-output path
  (LLM emits `ask_user_form` in its structured response) rather than
  migrating to mid-turn tool calls, because the workflow pause is
  durable (hours/days) and a mid-turn tool would have to hold the LLM
  conversation open across that interval.

## Test plan

- [x] `python -m pytest tests/test_ask_user.py` — 17/17 pass locally
- [x] `python -m pytest tests/test_hax_create_request_timeout.py` — 52/52 still pass
- [x] `ruff check swe_af/hitl/ tests/test_ask_user.py <touched reasoner/prompt/schema files>` — clean
- [x] No regressions across 162 planner/advisor/replanner/dag tests
- [x] Verified ruff error count vs `origin/main` — net zero new findings
- [ ] CI green on this PR
- [ ] Manual smoke test with `HAX_API_KEY` set: LLM emits `ask_user_form`, form renders in Hub, submit, reasoner resumes with answers in `prior_user_responses` (deferred to follow-up — requires a live Hax + control plane)

## Files touched

- `requirements.txt`, `requirements-docker.txt`, `pyproject.toml` — pin bump
- `swe_af/hitl/{__init__,ask_user,wrapper}.py` — new
- `tests/test_ask_user.py` — new
- `swe_af/reasoners/schemas.py` — `PRD.ask_user_form` field
- `swe_af/execution/schemas.py` — `IssueAdvisorDecision.ask_user_form`, `ReplanDecision.ask_user_form`
- `swe_af/reasoners/pipeline.py` — `run_product_manager` runs through `run_with_ask_user`
- `swe_af/reasoners/execution_agents.py` — `run_issue_advisor` and `run_replanner` likewise
- `swe_af/prompts/{product_manager,issue_advisor,replanner}.py` — when-to-ask guidance + `prior_user_responses` threading

🤖 Generated with [Claude Code](https://claude.com/claude-code)