### PR TITLE
docs: lead quickstart with `af call`, keep curl as HTTP alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ SWE-AF is a first step toward **autonomous software engineering factories**, sca
 
 ## One-Call DX
 
-Trigger it with the `af` CLI (requires af ≥ 0.1.86) — it streams live progress and prints the result:
+Trigger it with the `af` CLI (requires af ≥ 0.1.87) — it streams live progress and prints the result:
 
 ```bash
 af call swe-planner.build --in '{

--- a/README.md
+++ b/README.md
@@ -39,6 +39,22 @@ SWE-AF is a first step toward **autonomous software engineering factories**, sca
 
 ## One-Call DX
 
+Trigger it with the `af` CLI (requires af ≥ 0.1.86) — it streams live progress and prints the result:
+
+```bash
+af call swe-planner.build --in '{
+  "goal": "Refactor and harden auth + billing flows",
+  "repo_url": "https://github.com/user/my-project",
+  "config": {
+    "runtime": "claude_code",
+    "models": { "default": "sonnet", "coder": "opus", "qa": "opus" },
+    "enable_learning": true
+  }
+}'
+```
+
+Prefer raw HTTP? Hit the API directly with curl:
+
 ```bash
 curl -X POST http://localhost:8080/api/v1/execute/async/swe-planner.build \
   -H "Content-Type: application/json" \


### PR DESCRIPTION
## What

Lead the README quickstart with the `af call` CLI command, keeping the existing `curl` example right below as the raw-HTTP alternative.

## Why

The `af` CLI now ships a human trigger surface (`af call` / `af ls` / `af tail`), released in **af 0.1.86** (agentfield #605). `af call <node>.<reasoner> --in '{...}'` streams live progress and prints the result in a single command — a friction-free first-run experience compared to `curl` to an async endpoint and then polling for the result. Curl stays documented for anyone who prefers raw HTTP.

Verified `af call` / `af ls` / `af tail` end-to-end against a freshly installed af 0.1.86 before opening these.