### PR TITLE
Attribute HITL plan-review requests to SWE-AF via sender manifest

### DIFF
--- a/swe_af/app.py
+++ b/swe_af/app.py
@@ -773,6 +773,10 @@ async def build(
                     "title": title,
                     "description": "Review the proposed implementation plan before execution begins",
                     "payload": hax_payload,
+                    "sender": {
+                        "key": os.getenv("HAX_SENDER_KEY", os.getenv("HAX_SENDER_NAME") or NODE_ID),
+                        "display_name": os.getenv("HAX_SENDER_NAME") or NODE_ID,
+                    },
                     "webhook_url": f"{cp_base_url}/api/v1/webhooks/approval-response",
                     "expires_in_seconds": cfg.approval_expires_in_hours * 3600,
                 }


### PR DESCRIPTION
## Summary

SWE-AF created `plan-review-v2` HITL requests through the `hax` Python SDK without passing a `sender`, so the hax-sdk hub rendered them as **"Unknown sender"**.

This adds a `sender` manifest to the request kwargs in `swe_af/app.py` (where `hax_create_kwargs` is built), attributing the request to the agent node:

```python
"sender": {
    "key": os.getenv("HAX_SENDER_KEY", os.getenv("HAX_SENDER_NAME") or NODE_ID),
    "display_name": os.getenv("HAX_SENDER_NAME") or NODE_ID,
},
```

- Defaults to the node's own identity (`NODE_ID`, default `swe-planner`).
- Env-overridable via `HAX_SENDER_KEY` and `HAX_SENDER_NAME`.
- The `hax` SDK normalizes a plain `{key, display_name}` dict into the wire `SenderManifest`, so a dict is sufficient.

## Scope

Single file, minimal change: `swe_af/app.py` only.

## Gates

`make check` (= `pytest tests/ -x -q` + `compileall swe_af/`) run locally on Python 3.12 (matching CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)