### PR TITLE
fix(pm + codex): force JSON instance output instead of schema definit…

### DIFF
--- a/config/opencode/config.json
+++ b/config/opencode/config.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "openai": {
+      "models": {
+        "nolimitz/qwen3.6-35b": { "name": "Qwen3.6 35B" },
+        "nolimitz/qwythos-9b":  { "name": "Qwythos 9B"  }
+      }
+    }
+  }
+}

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -18,16 +18,18 @@ services:
       - NODE_ID=swe-planner
       - PORT=8003
       # Callback URL for control plane to reach this agent
-      - AGENT_CALLBACK_URL=http://localhost:8003
+      - AGENT_CALLBACK_URL=http://192.168.1.50:8003
       - SWE_DEFAULT_RUNTIME=${SWE_DEFAULT_RUNTIME:-claude_code}
       - SWE_DEFAULT_MODEL=${SWE_DEFAULT_MODEL:-}
       - SWE_CODEX_AUTH_MODE=${SWE_CODEX_AUTH_MODE:-auto}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - OPENAI_BASE_URL=https://ai-gateway.nolimitz.io/v1
     ports:
       - "8003:8003"
     volumes:
       - workspaces:/workspaces
       - ${HOME}/.codex:/root/.codex
+      - ./config/opencode:/root/.config/opencode
     extra_hosts:
       - "host.docker.internal:host-gateway"
 

--- a/swe_af/prompts/product_manager.py
+++ b/swe_af/prompts/product_manager.py
@@ -121,6 +121,9 @@ def product_manager_prompts(
     if additional_context:
         context_block = f"\n## Additional Context\n{additional_context}\n"
 
+    from pathlib import Path  # noqa: PLC0415
+    output_path = str(Path(repo_path) / ".agentfield_output.json")
+
     task = f"""\
 ## Goal
 {goal}
@@ -143,6 +146,24 @@ Produce a PRD for this goal. Read the codebase first — understand the current
 state deeply before defining what needs to change.
 
 Write your full PRD to: {prd_path}
+
+After writing the markdown PRD, you MUST also write a JSON file to: {output_path}
+
+CRITICAL: Write a JSON INSTANCE with real values — NOT a schema definition.
+Do NOT output anything that starts with {{"$defs"}} or contains Pydantic schema keys.
+
+The file must have exactly this structure, with actual content substituted in:
+{{
+  "validated_description": "<one sentence describing what needs to be built>",
+  "acceptance_criteria": ["<testable condition 1>", "<testable condition 2>"],
+  "must_have": ["<required feature 1>", "<required feature 2>"],
+  "nice_to_have": ["<optional feature 1>"],
+  "out_of_scope": ["<explicitly excluded item 1>"],
+  "assumptions": [],
+  "risks": []
+}}
+
+Use your Write tool to write {output_path} with valid JSON. No markdown fences, no schema keys.
 
 The bar: an engineering team of autonomous agents can execute this PRD without
 asking a single clarifying question. Every acceptance criterion is a test they

--- a/swe_af/runtime/codex_harness_patch.py
+++ b/swe_af/runtime/codex_harness_patch.py
@@ -4,6 +4,7 @@ import asyncio
 import contextvars
 import json
 import os
+import re as _re
 from pathlib import Path
 from typing import Any
 
@@ -121,6 +122,32 @@ def apply_codex_harness_patch() -> None:
         return
 
     _ORIGINAL_BUILD_PROMPT_SUFFIX = _schema.build_prompt_suffix
+
+    _orig_followup = _schema.build_followup_prompt
+
+    def _patched_followup_prompt(error_message: str, cwd: str, schema: Any = None) -> str:
+        prompt = _orig_followup(error_message, cwd, schema)
+        return _re.sub(
+            r"The JSON MUST conform to this schema:\n.*?\n\n",
+            (
+                "Write a JSON object with real values to the output file.\n"
+                "Do NOT output schema definitions ($defs, type: object, etc.).\n\n"
+                "Required fields (fill in real content):\n"
+                '  "validated_description": "<one sentence describing what needs to be built>"\n'
+                '  "acceptance_criteria": ["<testable condition>", ...]\n'
+                '  "must_have": ["<required feature>", ...]\n'
+                '  "nice_to_have": ["<optional feature>", ...]\n'
+                '  "out_of_scope": ["<excluded item>", ...]\n'
+                '  "assumptions": []\n'
+                '  "risks": []\n'
+                "\n"
+            ),
+            prompt,
+            flags=_re.DOTALL,
+        )
+
+    _schema.build_followup_prompt = _patched_followup_prompt
+    _runner.build_followup_prompt = _patched_followup_prompt
 
     def build_prompt_suffix_with_schema_file(schema: Any, cwd: str) -> str:
         """Use Codex-native structured output instead of AgentField's Write-tool suffix.


### PR DESCRIPTION
Title: fix(pm + codex): force JSON instance output instead of schema definitions

Body:
## Summary
- Fixes a bug where the product manager and codex harness were emitting Pydantic schema definitions (`$defs`, `type: object`, etc.) instead of real JSON content
- Patches `build_followup_prompt` in the codex harness to replace the schema instruction block with plain-English field-level guidance on retry
- Adds an explicit `.agentfield_output.json` write step to the PM prompt with a concrete example structure and a hard warning against schema output

## Changes
- `swe_af/prompts/product_manager.py` — explicit JSON instance output step added to PM prompt
- `swe_af/runtime/codex_harness_patch.py` — `build_followup_prompt` patched to guide real-value output on retry
- `docker-compose.local.yml` — LAN IP callback URL, custom AI gateway (`OPENAI_BASE_URL`), opencode config mount, API key moved back to env-var reference
- `config/opencode/config.json` — opencode provider config with nolimitz gateway model aliases

## Test plan
- [ ] Trigger a PM task and confirm `.agentfield_output.json` contains real values, not schema keys
- [ ] Trigger a codex retry and confirm the follow-up prompt guides real content output
- [ ] Verify `docker compose -f docker-compose.local.yml up` starts cleanly with `OPENAI_API_KEY` set in `.env`