### PR TITLE
fix(build): provide test DB for DB-forcing checks + report failed for empty builds (#82)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,19 @@ ANTHROPIC_API_KEY=sk-ant-api03-...
 # Only needed if using repo_url + enable_github_pr
 GH_TOKEN=ghp_...
 
+# --- Optional: Build-time test database ---
+
+# An ephemeral Postgres (the `build-db` service in docker-compose.yml) is wired
+# in by default so target-repo integration tests that *force* a database — e.g.
+# `REQUIRE_TEST_DB=1 npm run test:integration` — can connect instead of failing
+# with pg-pool ECONNREFUSED and cascading the build. It ships empty; the target
+# repo's own integration global-setup migrates it, so the factory stays
+# repo-agnostic. Override the default DSN or the build-db credentials here:
+# DATABASE_URL_TEST=postgres://builder:builder@build-db:5432/buildtest
+# BUILD_DB_USER=builder
+# BUILD_DB_PASSWORD=builder
+# BUILD_DB_NAME=buildtest
+
 # --- Optional: AgentField server ---
 
 # Override the control plane URL (default: http://control-plane:8080 in Docker,

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -8,6 +8,20 @@
 #   - .env file with ANTHROPIC_API_KEY (and optionally GH_TOKEN)
 
 services:
+  # Ephemeral Postgres for build-time integration checks (see docker-compose.yml
+  # for the full rationale). Repo-agnostic, throwaway, one shared DB.
+  build-db:
+    image: postgres:16
+    environment:
+      - POSTGRES_USER=${BUILD_DB_USER:-builder}
+      - POSTGRES_PASSWORD=${BUILD_DB_PASSWORD:-builder}
+      - POSTGRES_DB=${BUILD_DB_NAME:-buildtest}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${BUILD_DB_USER:-builder} -d ${BUILD_DB_NAME:-buildtest}"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+
   swe-agent:
     build:
       context: .
@@ -23,6 +37,7 @@ services:
       - SWE_DEFAULT_MODEL=${SWE_DEFAULT_MODEL:-}
       - SWE_CODEX_AUTH_MODE=${SWE_CODEX_AUTH_MODE:-auto}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - DATABASE_URL_TEST=${DATABASE_URL_TEST:-postgres://builder:builder@build-db:5432/buildtest}
     ports:
       - "8003:8003"
     volumes:
@@ -30,6 +45,9 @@ services:
       - ${HOME}/.codex:/root/.codex
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    depends_on:
+      build-db:
+        condition: service_healthy
 
 volumes:
   workspaces:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,27 @@ services:
     volumes:
       - agentfield-data:/data
 
+  # Ephemeral Postgres for build-time integration checks. Repo-agnostic: it
+  # ships an empty database and the *target repo's own* integration global-setup
+  # migrates it, so the factory needs no schema knowledge. Tests that hard-require
+  # a DB (e.g. REQUIRE_TEST_DB=1 …) can connect via DATABASE_URL_TEST instead of
+  # failing at the connection layer (pg-pool ECONNREFUSED) and cascading.
+  #
+  # The data is intentionally throwaway (no volume). One shared DB means
+  # DB-dependent builds should run one at a time; per-build databases would be
+  # the next step if concurrent DB builds are needed.
+  build-db:
+    image: postgres:16
+    environment:
+      - POSTGRES_USER=${BUILD_DB_USER:-builder}
+      - POSTGRES_PASSWORD=${BUILD_DB_PASSWORD:-builder}
+      - POSTGRES_DB=${BUILD_DB_NAME:-buildtest}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${BUILD_DB_USER:-builder} -d ${BUILD_DB_NAME:-buildtest}"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+
   swe-agent:
     build:
       context: .
@@ -23,13 +44,17 @@ services:
       - SWE_DEFAULT_MODEL=${SWE_DEFAULT_MODEL:-}
       - SWE_CODEX_AUTH_MODE=${SWE_CODEX_AUTH_MODE:-auto}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - DATABASE_URL_TEST=${DATABASE_URL_TEST:-postgres://builder:builder@build-db:5432/buildtest}
     ports:
       - "8003:8003"
     volumes:
       - workspaces:/workspaces
       - ${HOME}/.codex:/root/.codex
     depends_on:
-      - control-plane
+      control-plane:
+        condition: service_started
+      build-db:
+        condition: service_healthy
     deploy:
       replicas: 1  # Scale with: docker compose up --scale swe-agent=3
 
@@ -54,13 +79,17 @@ services:
       - SWE_DEFAULT_RUNTIME=${SWE_DEFAULT_RUNTIME:-claude_code}
       - SWE_DEFAULT_MODEL=${SWE_DEFAULT_MODEL:-}
       - SWE_CODEX_AUTH_MODE=${SWE_CODEX_AUTH_MODE:-auto}
+      - DATABASE_URL_TEST=${DATABASE_URL_TEST:-postgres://builder:builder@build-db:5432/buildtest}
     ports:
       - "8004:8004"
     volumes:
       - workspaces:/workspaces
       - ${HOME}/.codex:/root/.codex
     depends_on:
-      - control-plane
+      control-plane:
+        condition: service_started
+      build-db:
+        condition: service_healthy
 
 volumes:
   agentfield-data:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,9 @@ version = "0.1.0"
 description = "Autonomous SWE agent node for AgentField"
 requires-python = ">=3.12"
 dependencies = [
-    "agentfield>=0.1.82",
+    # >=0.1.96 ships ReasonerFailed, which build() raises so an empty build
+    # reports `failed` (not `succeeded`) with its result preserved (#82 Gap 2).
+    "agentfield>=0.1.96",
     "pydantic>=2.0",
     # Compatibility pin: newer SDK builds have surfaced
     # "Unknown message type: rate_limit_event" during streaming.

--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -2,7 +2,7 @@
 #
 # Same runtime dependencies as requirements.txt.
 
-agentfield>=0.1.84
+agentfield>=0.1.96
 pydantic>=2.0
 claude-agent-sdk==0.1.20
 hax-sdk>=0.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 #
 # Install: python -m pip install -r requirements.txt
 
-agentfield>=0.1.84
+agentfield>=0.1.96
 pydantic>=2.0
 claude-agent-sdk==0.1.20
 hax-sdk>=0.2.4

--- a/swe_af/app.py
+++ b/swe_af/app.py
@@ -22,6 +22,20 @@ from swe_af.reasoners.pipeline import _assign_sequence_numbers, _compute_levels,
 from swe_af.reasoners.schemas import PlanResult, ReviewResult
 
 from agentfield import Agent
+
+try:
+    # Added in a later agentfield SDK release. When present, raising it makes a
+    # reasoner report `failed` to the control plane while preserving its
+    # structured result. The fallback keeps SWE-AF importable against older SDKs
+    # — raising the shim still flips the execution to `failed` via the SDK's
+    # generic exception path (the result just isn't carried onto the record).
+    from agentfield import ReasonerFailed  # type: ignore
+except ImportError:  # pragma: no cover - exercised only on older agentfield SDKs
+    class ReasonerFailed(Exception):  # type: ignore[no-redef]
+        def __init__(self, message: str, *, result=None, error_details=None) -> None:
+            super().__init__(message)
+            self.result = result
+            self.error_details = error_details
 from swe_af.execution.envelope import unwrap_call_result as _unwrap
 from swe_af.execution.schemas import (
     BuildConfig,
@@ -453,6 +467,22 @@ async def _create_hax_request_with_timeout(
         tags=["build", "approval", "hax", "submitted"],
     )
     return hax_request
+
+
+def _is_empty_build(success: bool, ever_completed: int, ever_merged: int) -> bool:
+    """Decide whether a finished build shipped nothing and must report failed.
+
+    A build is "empty" when verification did not pass AND the build never
+    completed an issue or merged a branch across its original run and every
+    fix cycle. Such a build implemented nothing real (at most a cosmetic diff
+    like a lone .gitignore change), so it must surface as a failed execution
+    rather than `succeeded`.
+
+    A build that completed at least one issue or merged at least one branch is
+    NOT empty even when verification later failed — it shipped real code and an
+    open PR worth surfacing, so it returns normally (a partial success).
+    """
+    return not success and ever_completed == 0 and ever_merged == 0
 
 
 @app.reasoner()
@@ -945,6 +975,16 @@ async def build(
             workspace_manifest=manifest.model_dump() if manifest else None,
         ), "execute")
 
+        # High-water mark of work the build ever shipped. The verify/fix loop
+        # below reassigns ``dag_result`` to each fix-execution's state, so the
+        # final ``dag_result`` reflects only the last (fix) run — a fix cycle
+        # that completes/merges nothing would otherwise erase evidence that the
+        # original build merged real code. Track the max across all executions
+        # so the "empty build" guard at the end can't false-fail a build that
+        # genuinely shipped something.
+        ever_completed = len(dag_result.get("completed_issues", []) or [])
+        ever_merged = len(dag_result.get("merged_branches", []) or [])
+
         # Refresh manifest with git_init_result populated by _init_all_repos() in
         # the DAG executor.  Must happen before the verify/fix loop which can
         # overwrite dag_result with fix-execution results (no workspace_manifest).
@@ -1033,6 +1073,12 @@ async def build(
                     git_config=git_config,
                     workspace_manifest=manifest.model_dump() if manifest else None,
                 ), "execute_fixes")
+                ever_completed = max(
+                    ever_completed, len(dag_result.get("completed_issues", []) or [])
+                )
+                ever_merged = max(
+                    ever_merged, len(dag_result.get("merged_branches", []) or [])
+                )
                 continue  # Re-verify
             else:
                 app.note("No fixable issues generated — accepting with debt", tags=["build", "verify"])
@@ -1330,7 +1376,7 @@ async def build(
             except Exception:
                 pass  # non-blocking
 
-        return BuildResult(
+        build_result = BuildResult(
             plan_result=plan_result,
             dag_state=dag_result,
             verification=verification,
@@ -1340,6 +1386,21 @@ async def build(
             pr_results=pr_results,
             ci_gate_results=ci_gate_results,
         ).model_dump()
+
+        # An empty build — verification failed AND nothing was ever completed
+        # or merged across the original run and every fix cycle — must not
+        # surface as a succeeded execution. Returning the result (even with
+        # success=False) makes the control plane record `succeeded`, so a
+        # fully-failed build reads as green. Raise ReasonerFailed instead: it
+        # flips the execution to `failed` while still preserving the structured
+        # BuildResult (debt, DAG state, any cosmetic PR) on the record.
+        if _is_empty_build(success, ever_completed, ever_merged):
+            raise ReasonerFailed(
+                f"Build failed: 0/{total} issues completed, no branches merged",
+                result=build_result,
+            )
+
+        return build_result
 
     finally:
         if _scope_id:

--- a/tests/test_empty_build_guard.py
+++ b/tests/test_empty_build_guard.py
@@ -1,0 +1,53 @@
+"""Validation contract for the empty-build guard in ``build()`` (issue #82, Gap 2).
+
+Behavior under test (caller-observable, not implementation):
+
+- A build that did NOT pass verification and never completed an issue or merged
+  a branch (across the original run and every fix cycle) shipped nothing real,
+  so the execution must be reported as failed — not surfaced as ``succeeded``.
+- A build that completed at least one issue, or merged at least one branch, has
+  shipped real code (and an open PR worth surfacing); it must NOT be flagged
+  empty even when verification later failed.
+- A build that passed verification is never empty.
+
+``build()`` enforces this by raising ``ReasonerFailed`` when ``_is_empty_build``
+is true, which the agentfield SDK maps to a ``failed`` execution status while
+preserving the structured ``BuildResult``.
+"""
+
+import pytest
+
+from swe_af.app import _is_empty_build
+
+
+@pytest.mark.parametrize(
+    ("success", "ever_completed", "ever_merged", "expected_empty"),
+    [
+        # Verification failed and nothing was ever shipped → empty (must fail).
+        (False, 0, 0, True),
+        # Verification failed but an issue completed → real work shipped.
+        (False, 1, 0, False),
+        # Verification failed but a branch merged (e.g. fix cycle merged) → shipped.
+        (False, 0, 1, False),
+        (False, 3, 2, False),
+        # Verification passed → never empty, regardless of counts.
+        (True, 0, 0, False),
+        (True, 5, 4, False),
+    ],
+)
+def test_empty_build_truth_table(success, ever_completed, ever_merged, expected_empty):
+    assert _is_empty_build(success, ever_completed, ever_merged) is expected_empty
+
+
+def test_reporter_scenario_is_empty():
+    """The exact shape from issue #82: 0 completed, 0 merged, verification failed
+    (12 skipped, 1 failed foundation issue, all acceptance criteria → debt).
+    Only a lone .gitignore change reached the base — nothing was implemented."""
+    assert _is_empty_build(success=False, ever_completed=0, ever_merged=0) is True
+
+
+def test_partial_build_with_debt_is_not_empty():
+    """A build that completed some issues but failed verification (and accrued
+    debt) is a partial success with an open PR — it must keep returning normally
+    so the execution stays succeeded and the rich result surfaces."""
+    assert _is_empty_build(success=False, ever_completed=2, ever_merged=2) is False


### PR DESCRIPTION
## Summary

Fixes the two reporter-proposed gaps in #82.

### Gap 1 — DB-forcing build checks had no reachable database

The build container had no database, so a target-repo check that *hard-requires* Postgres (e.g. `REQUIRE_TEST_DB=1 npm run test:integration -- …migration….test.js`, or any test that errors-on-connect instead of skipping) failed at the connection layer (`pg-pool ECONNREFUSED`) and could never go green. For a **foundation issue** this fails unrecoverably and cascades — every dependent issue is skipped, nothing merges, and the build comes back empty.

Add a generic, ephemeral `postgres:16` **`build-db`** service to both compose files and wire `DATABASE_URL_TEST` into `swe-agent` and `swe-fast` (gated on a healthy DB). It ships empty and the **target repo's own** integration `global-setup` migrates it, so the factory stays repo-agnostic. Throwaway by design (no volume); one shared DB means DB-dependent builds should run one at a time (per-build DBs would be the next step).

### Gap 2 — a build that completes zero issues surfaced as `succeeded`

The control plane records an execution as `succeeded` whenever `build()` **returns** — even a `BuildResult` with `success=False`. So a fully-failed build (foundation issue fails → cascade → only a cosmetic `.gitignore` diff) read as green.

`build()` now tracks a high-water mark of work shipped (`ever_completed`/`ever_merged`) across the original run **and every fix cycle** (the verify/fix loop reassigns `dag_result`, so the final state alone can't tell whether real code ever merged). When verification failed **and** nothing was ever completed or merged, it raises `ReasonerFailed` (carrying the `BuildResult`) so the execution reports `failed` while preserving the structured result. Partial builds that shipped ≥1 issue or branch still return normally.

## Validation Contract (Gap 2)

- 0 completed **and** 0 merged **and** verification failed → reported **failed** (empty build).
- ≥1 issue completed **or** ≥1 branch merged → **not** empty, returns normally even if verification failed (real code + open PR worth surfacing).
- Verification passed → never empty.

## Changes Made

- `docker-compose.yml`, `docker-compose.local.yml`: add `build-db` (healthchecked) + `DATABASE_URL_TEST` wiring + `depends_on: service_healthy`.
- `.env.example`: document `DATABASE_URL_TEST` and `BUILD_DB_*`.
- `swe_af/app.py`: `_is_empty_build()` predicate; high-water-mark tracking; raise `ReasonerFailed` on empty build.
- Defensive `ReasonerFailed` import — SWE-AF stays importable against agentfield SDKs that predate it (shim still flips status to `failed` via the generic path; full **result-preservation** needs Agent-Field/agentfield#697 released).

## Test Plan

- [x] `docker compose -f docker-compose.yml config` / `-f docker-compose.local.yml config` parse; rendered config shows `build-db`, healthcheck, and `DATABASE_URL_TEST` on both build nodes.
- [x] New `tests/test_empty_build_guard.py` — truth table + the exact reporter scenario + partial-build-not-empty.
- [x] Full `make check` on py3.12 (CI's pinned version): **1013 passed, 1 skipped**.

## Dependency / follow-up

Full-fidelity Gap 2 (failed status **with** the structured result preserved) needs the SDK change in **Agent-Field/agentfield#697**. Once that releases, a follow-up should bump the `agentfield` floor in `requirements*.txt` / `pyproject.toml` (Docker layer caching keys off the constraint string, so the floor must change to pull the new release).

Closes #82 (Gaps 1 & 2). The codex empty-builds observation (Gap 3) is a separate, runtime-specific investigation that needs codex creds to reproduce end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)