### PR TITLE
fix(codex): auth-aware default model — fixes codex empty builds (#82 Gap 3)

### DIFF
--- a/swe_af/execution/fatal_error.py
+++ b/swe_af/execution/fatal_error.py
@@ -32,6 +32,12 @@ _FATAL_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
         r"account.{0,10}is disabled",
         r"unauthorized",
         r"quota.{0,20}exceeded",
+        # Codex model/auth mismatches: retrying with the same model + auth mode
+        # fails identically. Treating these as fatal surfaces the real reason
+        # (instead of a silent empty build that burns the retry cap) — e.g. the
+        # default `-codex` model under ChatGPT-account auth (#82 Gap 3).
+        r"not supported when using codex with a chatgpt account",
+        r"requires a newer version of codex",
     )
 )
 

--- a/swe_af/execution/schemas.py
+++ b/swe_af/execution/schemas.py
@@ -507,6 +507,14 @@ _LEGACY_TOP_LEVEL_EQUIVALENTS: dict[str, str] = {
     **{field: f"models.{role}" for field, role in _MODEL_FIELD_TO_ROLE.items()},
 }
 
+# Codex model defaults are auth-mode dependent. The ``-codex`` models (e.g.
+# ``gpt-5.3-codex``) are only available with OpenAI API-key auth — they return
+# HTTP 400 "not supported when using Codex with a ChatGPT account" under
+# ChatGPT-account login, which fails in ~3s and (pre-fix) cascaded into an empty
+# build. So the base default is chosen by ``_codex_default_model()`` below.
+_CODEX_API_KEY_MODEL = "gpt-5.3-codex"   # OpenAI API-key auth (api_key mode)
+_CODEX_CHATGPT_MODEL = "gpt-5.5"         # ChatGPT-account auth (-codex blocked)
+
 _RUNTIME_BASE_MODELS: dict[str, dict[str, str]] = {
     "claude_code": {
         **{field: "sonnet" for field in ALL_MODEL_FIELDS},
@@ -516,9 +524,36 @@ _RUNTIME_BASE_MODELS: dict[str, dict[str, str]] = {
         **{field: "openrouter/minimax/minimax-m2.5" for field in ALL_MODEL_FIELDS},
     },
     "codex": {
-        **{field: "gpt-5.3-codex" for field in ALL_MODEL_FIELDS},
+        **{field: _CODEX_API_KEY_MODEL for field in ALL_MODEL_FIELDS},
     },
 }
+
+
+def _codex_uses_chatgpt_auth() -> bool:
+    """Whether codex will authenticate via a ChatGPT account (not an API key).
+
+    Mirrors the Codex CLI's own auth selection and the ``SWE_CODEX_AUTH_MODE``
+    contract documented in ``.env.example``:
+
+    - ``api_key``  → always API-key auth.
+    - ``chatgpt``  → always ChatGPT-account login.
+    - ``auto`` (default) → API key when ``OPENAI_API_KEY`` is set, else ChatGPT.
+
+    Matters because the ``-codex`` models are unavailable under ChatGPT-account
+    auth, so the default model must differ between the two.
+    """
+    mode = os.getenv("SWE_CODEX_AUTH_MODE", "auto").strip().lower()
+    if mode == "api_key":
+        return False
+    if mode == "chatgpt":
+        return True
+    # auto
+    return not os.getenv("OPENAI_API_KEY", "").strip()
+
+
+def _codex_default_model() -> str:
+    """Base codex model for the active auth mode (overridable per role/env)."""
+    return _CODEX_CHATGPT_MODEL if _codex_uses_chatgpt_auth() else _CODEX_API_KEY_MODEL
 
 
 def _runtime_to_provider(runtime: str) -> Literal["claude", "opencode", "codex"]:
@@ -659,6 +694,10 @@ def resolve_runtime_models(
     flat_models = _validate_flat_models(models)
 
     base = _RUNTIME_BASE_MODELS[runtime]
+    if runtime == "codex":
+        # Choose the codex base default by auth mode (see _codex_default_model).
+        codex_model = _codex_default_model()
+        base = {field: codex_model for field in base}
     resolved: dict[str, str] = {field: base[field] for field in field_names}
 
     env_default = _default_model_from_env()

--- a/swe_af/fast/schemas.py
+++ b/swe_af/fast/schemas.py
@@ -14,13 +14,23 @@ from swe_af.runtime.providers import RUNTIME_VALUES
 
 _CLAUDE_CODE_DEFAULT = "haiku"
 _OPEN_CODE_DEFAULT = "qwen/qwen-2.5-coder-32b-instruct"
-_CODEX_DEFAULT = "gpt-5.3-codex"
 
 _RUNTIME_DEFAULTS: dict[str, str] = {
     "claude_code": _CLAUDE_CODE_DEFAULT,
     "open_code": _OPEN_CODE_DEFAULT,
-    "codex": _CODEX_DEFAULT,
+    # codex is resolved dynamically (auth-mode dependent); see _runtime_default().
 }
+
+
+def _runtime_default(runtime: str) -> str:
+    """Default model for a runtime. Codex is auth-mode dependent: the ``-codex``
+    models are blocked under ChatGPT-account auth, so fall back to a
+    ChatGPT-compatible model there (see ``schemas._codex_default_model``)."""
+    if runtime == "codex":
+        from swe_af.execution.schemas import _codex_default_model  # noqa: PLC0415
+
+        return _codex_default_model()
+    return _RUNTIME_DEFAULTS[runtime]
 
 # All four roles resolved by fast_resolve_models()
 _FAST_ROLES: tuple[str, ...] = ("pm_model", "coder_model", "verifier_model", "git_model")
@@ -150,7 +160,7 @@ def fast_resolve_models(config: FastBuildConfig) -> dict[str, str]:
         ValueError: If ``config.models`` contains a key that is not ``"default"``
             and not one of the four known role names.
     """
-    runtime_default = _RUNTIME_DEFAULTS[config.runtime]
+    runtime_default = _runtime_default(config.runtime)
 
     resolved: dict[str, str] = {role: runtime_default for role in _FAST_ROLES}
 

--- a/swe_af/reasoners/execution_agents.py
+++ b/swe_af/reasoners/execution_agents.py
@@ -1002,6 +1002,7 @@ async def run_coder(
 
     provider = runtime_to_harness_adapter(ai_provider)
 
+    harness_error = ""
     try:
         result = await router.harness(
             task_prompt,
@@ -1025,17 +1026,31 @@ async def run_coder(
             out = result.parsed.model_dump()
             out["iteration_id"] = iteration_id
             return out
+        # Harness returned but produced no parseable CoderResult. Surface the
+        # underlying error (e.g. a codex model/auth 400) so the empty result
+        # carries *why* instead of a bare "Coder agent failed".
+        harness_error = (
+            getattr(result, "error_message", "") or "no structured output returned"
+        )
+        router.note(
+            f"Coder produced no result: {issue_name}: {harness_error}",
+            tags=["coder", "error"],
+        )
     except FatalHarnessError:
         raise  # Non-retryable — propagate immediately
     except Exception as e:
+        harness_error = str(e)
         router.note(
             f"Coder agent failed: {issue_name}: {e}",
             tags=["coder", "error"],
         )
 
+    summary = f"Coder agent failed for {issue_name}"
+    if harness_error:
+        summary += f": {harness_error}"
     return CoderResult(
         files_changed=[],
-        summary=f"Coder agent failed for {issue_name}",
+        summary=summary,
         complete=False,
         iteration_id=iteration_id,
     ).model_dump()

--- a/tests/fast/test_app.py
+++ b/tests/fast/test_app.py
@@ -495,15 +495,27 @@ class TestBuildEdgeCases:
         assert _runtime_to_provider("other") == "opencode"
 
 
-def test_fast_build_config_accepts_codex_runtime() -> None:
+def test_fast_build_config_accepts_codex_runtime(monkeypatch) -> None:
     from swe_af.fast.schemas import FastBuildConfig, fast_resolve_models
 
+    # API-key auth: -codex models are available.
+    monkeypatch.setenv("SWE_CODEX_AUTH_MODE", "api_key")
     cfg = FastBuildConfig(runtime="codex")
     resolved = fast_resolve_models(cfg)
     assert resolved["pm_model"] == "gpt-5.3-codex"
     assert resolved["coder_model"] == "gpt-5.3-codex"
     assert resolved["verifier_model"] == "gpt-5.3-codex"
     assert resolved["git_model"] == "gpt-5.3-codex"
+
+
+def test_fast_codex_chatgpt_auth_uses_non_codex_model(monkeypatch) -> None:
+    # ChatGPT-account auth: -codex models 400, so fall back to gpt-5.5 (#82 Gap 3).
+    from swe_af.fast.schemas import FastBuildConfig, fast_resolve_models
+
+    monkeypatch.setenv("SWE_CODEX_AUTH_MODE", "chatgpt")
+    monkeypatch.setenv("OPENAI_API_KEY", "")
+    resolved = fast_resolve_models(FastBuildConfig(runtime="codex"))
+    assert all(m == "gpt-5.5" for m in resolved.values()), resolved
 
 
 class TestBuildNonFatalPaths:

--- a/tests/test_fatal_error.py
+++ b/tests/test_fatal_error.py
@@ -50,6 +50,9 @@ class TestIsFatalError:
             "billing suspended",
             "Quota exceeded for this model",
             "quota has been exceeded",
+            # Codex model/auth mismatches (#82 Gap 3) — non-retryable.
+            "The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account.",
+            "The 'gpt-5.5' model requires a newer version of Codex. Please upgrade.",
         ],
     )
     def test_fatal_patterns_detected(self, message: str) -> None:

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -138,17 +138,44 @@ class TestDefaultRuntimeFromEnv(unittest.TestCase):
 
 class TestCodexRuntimeConfig(unittest.TestCase):
     def test_codex_runtime_provider_and_defaults(self) -> None:
-        cfg = BuildConfig(runtime="codex")
-        self.assertEqual(cfg.ai_provider, "codex")
-        resolved = cfg.resolved_models()
-        for field in ALL_MODEL_FIELDS:
-            self.assertEqual(resolved[field], "gpt-5.3-codex")
+        # API-key auth: the -codex models are available, so that's the default.
+        with mock.patch.dict(os.environ, {"SWE_CODEX_AUTH_MODE": "api_key"}):
+            cfg = BuildConfig(runtime="codex")
+            self.assertEqual(cfg.ai_provider, "codex")
+            resolved = cfg.resolved_models()
+            for field in ALL_MODEL_FIELDS:
+                self.assertEqual(resolved[field], "gpt-5.3-codex")
 
     def test_codex_execution_config_provider_and_defaults(self) -> None:
-        cfg = ExecutionConfig(runtime="codex")
-        self.assertEqual(cfg.ai_provider, "codex")
-        self.assertEqual(cfg.coder_model, "gpt-5.3-codex")
-        self.assertEqual(cfg.verifier_model, "gpt-5.3-codex")
+        with mock.patch.dict(os.environ, {"SWE_CODEX_AUTH_MODE": "api_key"}):
+            cfg = ExecutionConfig(runtime="codex")
+            self.assertEqual(cfg.ai_provider, "codex")
+            self.assertEqual(cfg.coder_model, "gpt-5.3-codex")
+            self.assertEqual(cfg.verifier_model, "gpt-5.3-codex")
+
+    def test_codex_chatgpt_auth_uses_non_codex_model(self) -> None:
+        # ChatGPT-account auth: the -codex models 400, so the default must be a
+        # ChatGPT-compatible model (#82 Gap 3 root cause).
+        with mock.patch.dict(
+            os.environ, {"SWE_CODEX_AUTH_MODE": "chatgpt", "OPENAI_API_KEY": ""}
+        ):
+            resolved = BuildConfig(runtime="codex").resolved_models()
+            for field in ALL_MODEL_FIELDS:
+                self.assertEqual(resolved[field], "gpt-5.5")
+            self.assertEqual(ExecutionConfig(runtime="codex").coder_model, "gpt-5.5")
+
+    def test_codex_auto_auth_follows_openai_api_key_presence(self) -> None:
+        # auto: API key present -> -codex; absent -> ChatGPT-compatible.
+        with mock.patch.dict(
+            os.environ, {"SWE_CODEX_AUTH_MODE": "auto", "OPENAI_API_KEY": "sk-test"}
+        ):
+            self.assertEqual(
+                ExecutionConfig(runtime="codex").coder_model, "gpt-5.3-codex"
+            )
+        with mock.patch.dict(
+            os.environ, {"SWE_CODEX_AUTH_MODE": "auto", "OPENAI_API_KEY": ""}
+        ):
+            self.assertEqual(ExecutionConfig(runtime="codex").coder_model, "gpt-5.5")
 
     def test_env_codex_runtime_overrides_default(self) -> None:
         with mock.patch.dict(os.environ, {"SWE_DEFAULT_RUNTIME": "codex"}):


### PR DESCRIPTION
## Summary

Root-causes and fixes the codex empty-builds observation in #82 (Gap 3). It is **not** a structured-output problem — it's a **model/auth mismatch**, confirmed live.

SWE-AF defaulted every codex role to **`gpt-5.3-codex`**. The `-codex` models are only available with OpenAI **API-key** auth — under **ChatGPT-account** auth they return:

```
HTTP 400 invalid_request_error:
"The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account."
```

…in **~3 seconds**. The coder turned that fast error into `files_changed: []` → "Coder agent failed" → the foundation issue failed → cascade → empty build. That's the reporter's exact symptom (~9–11s, codex-only; `claude_code` fine, because it never touched codex).

## Fix

**1. Auth-aware codex default model** (`schemas.py`, `fast/schemas.py`)
Resolve the codex base model by auth mode instead of a constant:
- **API-key** auth (`SWE_CODEX_AUTH_MODE=api_key`, or `auto` with `OPENAI_API_KEY` set) → `gpt-5.3-codex` (unchanged).
- **ChatGPT-account** auth (`chatgpt`, or `auto` with no key) → `gpt-5.5` (a ChatGPT-compatible model).
Explicit overrides (`models.default` / per-role / `SWE_DEFAULT_MODEL`) still win.

**2. Codex model/auth errors are fatal + surfaced** (`fatal_error.py`, `execution_agents.py`)
A model/auth 400 is non-retryable, so:
- `check_fatal_harness_error` now matches "not supported when using Codex with a ChatGPT account" and "requires a newer version of Codex" → raises `FatalHarnessError` with the real message, short-circuiting the retry cap.
- `run_coder` includes the underlying `error_message` in the `CoderResult` summary when no result parses, so an empty result always carries **why** (the reporter saw a bare "Coder agent failed" with no reason).

## Validation Contract

- ChatGPT-auth codex default = `gpt-5.5`; API-key-auth codex default = `gpt-5.3-codex`; explicit overrides win; `claude_code`/`open_code` unaffected.
- A codex "model not supported on ChatGPT account" / "needs newer CLI" error is fatal (no silent retry) and its message reaches the build output.

## Test Plan — verified live (codex CLI 0.142.4, ChatGPT auth)

- [x] `gpt-5.3-codex` → 400 "not supported … ChatGPT account" in **3s**; resolved **`gpt-5.5`** wrote a real `hello.py` in **8s**.
- [x] `resolve_runtime_models` / `fast_resolve_models` return `gpt-5.5` under chatgpt env, `gpt-5.3-codex` under api_key env (new unit tests).
- [x] New fatal-pattern tests for both codex error strings.
- [x] Full `make check` on py3.12: **1010 passed, 1 skipped**.

## Scope

SWE-AF-only; independent of #84 (Gaps 1 & 2) and of the agentfield SDK — no cross-repo dependency. Tip for ChatGPT-plan users: `gpt-5.5` runs at high reasoning effort (slower per call); set `models.coder` or `SWE_DEFAULT_MODEL` to override if you want lower latency.

Refs #82 (Gap 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)