### PR TITLE
DO NOT MERGE YET: isolate SWE-AF resume recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Most agent frameworks wrap a single coder loop. SWE-AF is a coordinated engineer
 - **Agent-scale parallelism** — dependency-level scheduling + isolated git worktrees allow large fan-out without branch collisions.
 - **Fleet-scale orchestration** — many SWE-AF nodes can run continuously in parallel via AgentField, driving thousands of agent invocations across concurrent builds.
 - **Explicit compromise tracking** — when scope is relaxed, debt is typed, severity-rated, and propagated.
-- **Long-run reliability** — checkpointed execution supports `resume_build` after crashes or interruptions.
+- **Long-run reliability** — checkpointed execution supports `resume_execute` for DAG-only recovery and `resume_build` for full build recovery through verification, finalization, PR creation, and CI gating.
 
 ## In Action
 
@@ -623,7 +623,10 @@ POST /api/v1/execute/async/swe-planner.plan
 # Execute a prebuilt plan
 POST /api/v1/execute/async/swe-planner.execute
 
-# Resume after interruption
+# Resume DAG execution after interruption
+POST /api/v1/execute/async/swe-planner.resume_execute
+
+# Resume full build after interruption
 POST /api/v1/execute/async/swe-planner.resume_build
 ```
 

--- a/swe_af/app.py
+++ b/swe_af/app.py
@@ -9,6 +9,7 @@ Exposes:
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import subprocess
 import uuid
@@ -57,6 +58,8 @@ app = Agent(
 )
 
 app.include_router(router)
+
+BUILD_STATE_FILENAME = "build_state.json"
 
 
 # ---------------------------------------------------------------------------
@@ -483,6 +486,607 @@ def _is_empty_build(success: bool, ever_completed: int, ever_merged: int) -> boo
     open PR worth surfacing, so it returns normally (a partial success).
     """
     return not success and ever_completed == 0 and ever_merged == 0
+
+
+def _absolute_artifacts_dir(repo_path: str, artifacts_dir: str) -> str:
+    if os.path.isabs(artifacts_dir):
+        return artifacts_dir
+    return os.path.join(os.path.abspath(repo_path), artifacts_dir)
+
+
+def _build_state_path(repo_path: str, artifacts_dir: str) -> str:
+    return os.path.join(_absolute_artifacts_dir(repo_path, artifacts_dir), BUILD_STATE_FILENAME)
+
+
+def _save_build_state(repo_path: str, artifacts_dir: str, state: dict) -> None:
+    path = _build_state_path(repo_path, artifacts_dir)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fp:
+        json.dump(state, fp, indent=2)
+
+
+def _load_build_state(repo_path: str, artifacts_dir: str) -> dict:
+    path = _build_state_path(repo_path, artifacts_dir)
+    if not os.path.exists(path):
+        return {}
+    with open(path, encoding="utf-8") as fp:
+        return json.load(fp)
+
+
+def _build_config_from_saved_state(
+    stored_config: dict,
+    overrides: dict | None = None,
+) -> BuildConfig:
+    data = dict(stored_config or {})
+    data.update(overrides or {})
+
+    # BuildConfig normalizes repo_url into repos, so model_dump() may contain
+    # both fields. Rehydrate through the canonical multi-repo form.
+    if data.get("repo_url") and data.get("repos"):
+        data.pop("repo_url")
+
+    return BuildConfig(**data) if data else BuildConfig()
+
+
+def _checkpoint_path(repo_path: str, artifacts_dir: str) -> str:
+    return os.path.join(_absolute_artifacts_dir(repo_path, artifacts_dir), "execution", "checkpoint.json")
+
+
+def _load_execution_checkpoint(repo_path: str, artifacts_dir: str) -> dict:
+    path = _checkpoint_path(repo_path, artifacts_dir)
+    if not os.path.exists(path):
+        raise RuntimeError(f"No checkpoint found at {path}. Cannot resume.")
+    with open(path, encoding="utf-8") as fp:
+        return json.load(fp)
+
+
+def _plan_result_from_checkpoint(checkpoint: dict) -> dict:
+    artifacts_dir = checkpoint.get("artifacts_dir", "")
+    return {
+        "prd": {},
+        "architecture": {},
+        "review": {},
+        "issues": checkpoint.get("all_issues", []),
+        "levels": checkpoint.get("levels", []),
+        "file_conflicts": [],
+        "artifacts_dir": artifacts_dir,
+        "rationale": checkpoint.get("original_plan_summary", ""),
+    }
+
+
+def _git_config_from_checkpoint(checkpoint: dict) -> dict | None:
+    integration_branch = checkpoint.get("git_integration_branch", "")
+    if not integration_branch:
+        return None
+    return {
+        "integration_branch": integration_branch,
+        "original_branch": checkpoint.get("git_original_branch", ""),
+        "initial_commit_sha": checkpoint.get("git_initial_commit", ""),
+        "mode": checkpoint.get("git_mode", ""),
+        "remote_url": checkpoint.get("git_remote_url", ""),
+        "remote_default_branch": checkpoint.get("git_remote_default_branch", ""),
+    }
+
+
+def _read_plan_docs(plan_result: dict) -> tuple[str, str]:
+    plan_dir = os.path.join(plan_result.get("artifacts_dir", ""), "plan")
+    docs: dict[str, str] = {"prd.md": "", "architecture.md": ""}
+    for name in docs:
+        path = os.path.join(plan_dir, name)
+        if os.path.isfile(path):
+            try:
+                with open(path, encoding="utf-8") as fp:
+                    docs[name] = fp.read()
+            except OSError:
+                pass
+    return docs["prd.md"], docs["architecture.md"]
+
+
+def _resume_incomplete_summary(result: dict) -> str:
+    """Return a short failure summary when a resumed DAG is still incomplete."""
+    failed = result.get("failed_issues", []) or []
+    skipped = result.get("skipped_issues", []) or []
+    if not failed and not skipped:
+        return ""
+
+    failed_names = [
+        item.get("issue_name", "<unknown>") if isinstance(item, dict) else str(item)
+        for item in failed
+    ]
+    skipped_names = [
+        item.get("issue_name", "<unknown>") if isinstance(item, dict) else str(item)
+        for item in skipped
+    ]
+    completed = len(result.get("completed_issues", []) or [])
+    total = len(result.get("all_issues", []) or [])
+    parts = [f"Resume incomplete: {completed}/{total} issues completed"]
+    if failed_names:
+        parts.append(f"failed={failed_names}")
+    if skipped_names:
+        parts.append(f"skipped={skipped_names}")
+    return "; ".join(parts)
+
+
+def _existing_pr_for_branch(repo_path: str, branch: str, base_branch: str) -> dict:
+    """Return an open PR for branch when one already exists, else empty dict."""
+    if not branch:
+        return {}
+    cmd = [
+        "gh", "pr", "list",
+        "--head", branch,
+        "--base", base_branch,
+        "--state", "open",
+        "--json", "url,number",
+        "--limit", "1",
+    ]
+    res = subprocess.run(cmd, cwd=repo_path, capture_output=True, text=True)
+    if res.returncode != 0:
+        return {}
+    try:
+        matches = json.loads(res.stdout or "[]")
+    except json.JSONDecodeError:
+        return {}
+    if not matches:
+        return {}
+    first = matches[0]
+    return {
+        "success": True,
+        "pr_url": first.get("url", ""),
+        "pr_number": first.get("number", 0),
+    }
+
+
+def _push_existing_pr_branch(repo_path: str, branch: str) -> None:
+    if not branch:
+        return
+    subprocess.run(
+        ["git", "push", "origin", branch],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _append_plan_docs_to_pr(
+    *,
+    repo_path: str,
+    pr_number: int,
+    prd_markdown: str,
+    architecture_markdown: str,
+) -> None:
+    if not pr_number or not (prd_markdown or architecture_markdown):
+        return
+    current_body = subprocess.run(
+        ["gh", "pr", "view", str(pr_number), "--json", "body", "--jq", ".body"],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+    if (
+        "PRD (Product Requirements Document)" in current_body
+        or "Architecture</summary>" in current_body
+    ):
+        return
+
+    plan_sections = "\n\n---\n"
+    if prd_markdown:
+        plan_sections += (
+            "\n<details><summary>📋 PRD (Product Requirements Document)"
+            "</summary>\n\n"
+            + prd_markdown
+            + "\n\n</details>\n"
+        )
+    if architecture_markdown:
+        plan_sections += (
+            "\n<details><summary>🏗️ Architecture</summary>\n\n"
+            + architecture_markdown
+            + "\n\n</details>\n"
+        )
+
+    subprocess.run(
+        ["gh", "pr", "edit", str(pr_number), "--body", current_body + plan_sections],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+async def _continue_build_tail(
+    *,
+    goal: str,
+    repo_path: str,
+    artifacts_dir: str,
+    cfg: BuildConfig,
+    resolved: dict[str, str],
+    plan_result: dict,
+    dag_result: dict,
+    git_config: dict | None,
+    manifest: WorkspaceManifest | None,
+    ever_completed: int,
+    ever_merged: int,
+    build_state: dict | None = None,
+) -> dict:
+    """Run the post-DAG build tail shared by build() and resume_build()."""
+    build_state = dict(build_state or {})
+    if manifest and dag_result.get("workspace_manifest"):
+        manifest = WorkspaceManifest(**dag_result["workspace_manifest"])
+
+    exec_config = cfg.to_execution_config_dict()
+    verification = build_state.get("verification")
+    for cycle in range(cfg.max_verify_fix_cycles + 1):
+        app.note(f"Verification cycle {cycle}", tags=["build", "verify"])
+        verification = _unwrap(await app.call(
+            f"{NODE_ID}.run_verifier",
+            prd=plan_result.get("prd", {}),
+            repo_path=repo_path,
+            artifacts_dir=plan_result.get("artifacts_dir", artifacts_dir),
+            completed_issues=[r for r in dag_result.get("completed_issues", [])],
+            failed_issues=[r for r in dag_result.get("failed_issues", [])],
+            skipped_issues=dag_result.get("skipped_issues", []),
+            model=resolved["verifier_model"],
+            permission_mode=cfg.permission_mode,
+            ai_provider=cfg.ai_provider,
+            workspace_manifest=manifest.model_dump() if manifest else None,
+        ), "run_verifier")
+        build_state["verification"] = verification
+
+        if verification.get("passed", False) or cycle >= cfg.max_verify_fix_cycles:
+            break
+
+        failed_criteria = [
+            c for c in verification.get("criteria_results", [])
+            if not c.get("passed", True)
+        ]
+        if not failed_criteria:
+            app.note("Verification failed but no specific criteria failures found", tags=["build", "verify"])
+            break
+
+        app.note(
+            f"Verification failed ({len(failed_criteria)} criteria), "
+            f"{cfg.max_verify_fix_cycles - cycle} fix cycles remaining",
+            tags=["build", "verify", "retry"],
+        )
+        fix_result = _unwrap(await app.call(
+            f"{NODE_ID}.generate_fix_issues",
+            failed_criteria=failed_criteria,
+            dag_state=dag_result,
+            prd=plan_result.get("prd", {}),
+            artifacts_dir=plan_result.get("artifacts_dir", artifacts_dir),
+            model=resolved["verifier_model"],
+            permission_mode=cfg.permission_mode,
+            ai_provider=cfg.ai_provider,
+            workspace_manifest=manifest.model_dump() if manifest else None,
+        ), "generate_fix_issues")
+
+        for debt in fix_result.get("debt_items", []):
+            dag_result.setdefault("accumulated_debt", []).append({
+                "type": "unmet_acceptance_criterion",
+                "criterion": debt.get("criterion", ""),
+                "reason": debt.get("reason", ""),
+                "severity": debt.get("severity", "high"),
+            })
+
+        fix_issues = fix_result.get("fix_issues", [])
+        if not fix_issues:
+            app.note("No fixable issues generated — accepting with debt", tags=["build", "verify"])
+            break
+
+        fix_plan = {
+            "prd": plan_result.get("prd", {}),
+            "architecture": plan_result.get("architecture", {}),
+            "review": plan_result.get("review", {}),
+            "issues": fix_issues,
+            "levels": [[fi.get("name", f"fix-{i}") for i, fi in enumerate(fix_issues)]],
+            "file_conflicts": [],
+            "artifacts_dir": plan_result.get("artifacts_dir", artifacts_dir),
+            "rationale": f"Fix issues for verification cycle {cycle + 1}",
+        }
+        dag_result = _unwrap(await app.call(
+            f"{NODE_ID}.execute",
+            plan_result=fix_plan,
+            repo_path=repo_path,
+            config=exec_config,
+            git_config=git_config,
+            workspace_manifest=manifest.model_dump() if manifest else None,
+        ), "execute_fixes")
+        ever_completed = max(ever_completed, len(dag_result.get("completed_issues", []) or []))
+        ever_merged = max(ever_merged, len(dag_result.get("merged_branches", []) or []))
+        build_state["dag_result"] = dag_result
+
+    success = verification.get("passed", False) if verification else False
+    completed = len(dag_result.get("completed_issues", []))
+    total = len(dag_result.get("all_issues", []))
+    app.note(
+        f"Build {'succeeded' if success else 'completed with issues'}: "
+        f"{completed}/{total} issues, verification={'passed' if success else 'failed'}",
+        tags=["build", "complete"],
+    )
+
+    prd_markdown, architecture_markdown = _read_plan_docs(plan_result)
+
+    if manifest and len(manifest.repos) > 1:
+        app.note(
+            f"Phase 3b: Multi-repo finalization ({len(manifest.repos)} repos)",
+            tags=["build", "finalize", "multi-repo"],
+        )
+        for ws_repo in manifest.repos:
+            try:
+                finalize_result = _unwrap(await app.call(
+                    f"{NODE_ID}.run_repo_finalize",
+                    repo_path=ws_repo.absolute_path,
+                    artifacts_dir=plan_result.get("artifacts_dir", artifacts_dir),
+                    model=resolved["git_model"],
+                    permission_mode=cfg.permission_mode,
+                    ai_provider=cfg.ai_provider,
+                ), f"run_repo_finalize ({ws_repo.repo_name})")
+                if finalize_result.get("success"):
+                    app.note(
+                        f"Repo finalized ({ws_repo.repo_name}): {finalize_result.get('summary', '')}",
+                        tags=["build", "finalize", "complete"],
+                    )
+                else:
+                    app.note(
+                        f"Repo finalize incomplete ({ws_repo.repo_name}): {finalize_result.get('summary', '')}",
+                        tags=["build", "finalize", "warning"],
+                    )
+            except Exception as e:
+                app.note(
+                    f"Repo finalize failed for {ws_repo.repo_name} (non-blocking): {e}",
+                    tags=["build", "finalize", "error"],
+                )
+    else:
+        app.note("Phase 3b: Repo finalization", tags=["build", "finalize"])
+        try:
+            finalize_result = _unwrap(await app.call(
+                f"{NODE_ID}.run_repo_finalize",
+                repo_path=repo_path,
+                artifacts_dir=plan_result.get("artifacts_dir", artifacts_dir),
+                model=resolved["git_model"],
+                permission_mode=cfg.permission_mode,
+                ai_provider=cfg.ai_provider,
+            ), "run_repo_finalize")
+            if finalize_result.get("success"):
+                app.note(
+                    f"Repo finalized: {finalize_result.get('summary', '')}",
+                    tags=["build", "finalize", "complete"],
+                )
+            else:
+                app.note(
+                    f"Repo finalize incomplete: {finalize_result.get('summary', '')}",
+                    tags=["build", "finalize", "warning"],
+                )
+        except Exception as e:
+            app.note(
+                f"Repo finalize failed (non-blocking): {e}",
+                tags=["build", "finalize", "error"],
+            )
+
+    pr_results: list[RepoPRResult] = []
+    ci_gate_results: list[dict] = []
+    build_summary = (
+        f"{'Success' if success else 'Partial'}: {completed}/{total} issues completed"
+        + (f", verification: {verification.get('summary', '')}" if verification else "")
+    )
+
+    if manifest and len(manifest.repos) > 1:
+        app.note("Phase 4: Multi-repo Push + PRs", tags=["build", "github_pr", "multi-repo"])
+        for ws_repo in manifest.repos:
+            if not ws_repo.create_pr or not cfg.enable_github_pr:
+                continue
+            repo_git_init = ws_repo.git_init_result or {}
+            repo_remote_url = repo_git_init.get("remote_url", "") or ws_repo.repo_url
+            if not repo_remote_url:
+                continue
+            repo_integration_branch = repo_git_init.get("integration_branch", "")
+            if not repo_integration_branch:
+                continue
+            repo_base_branch = (
+                cfg.github_pr_base
+                or repo_git_init.get("remote_default_branch", "")
+                or "main"
+            )
+            try:
+                existing = _existing_pr_for_branch(
+                    ws_repo.absolute_path, repo_integration_branch, repo_base_branch
+                )
+                if existing:
+                    _push_existing_pr_branch(ws_repo.absolute_path, repo_integration_branch)
+                    pr_r = existing
+                else:
+                    pr_r = _unwrap(await app.call(
+                        f"{NODE_ID}.run_github_pr",
+                        repo_path=ws_repo.absolute_path,
+                        integration_branch=repo_integration_branch,
+                        base_branch=repo_base_branch,
+                        goal=goal,
+                        build_summary=build_summary,
+                        completed_issues=[
+                            r for r in dag_result.get("completed_issues", [])
+                            if not r.get("repo_name") or r.get("repo_name") == ws_repo.repo_name
+                        ],
+                        accumulated_debt=dag_result.get("accumulated_debt", []),
+                        artifacts_dir=plan_result.get("artifacts_dir", artifacts_dir),
+                        model=resolved["git_model"],
+                        permission_mode=cfg.permission_mode,
+                        ai_provider=cfg.ai_provider,
+                    ), "run_github_pr")
+                pr_results.append(RepoPRResult(
+                    repo_name=ws_repo.repo_name,
+                    repo_url=ws_repo.repo_url,
+                    success=pr_r.get("success", False),
+                    pr_url=pr_r.get("pr_url", ""),
+                    pr_number=pr_r.get("pr_number", 0),
+                    error_message=pr_r.get("error_message", ""),
+                ))
+                if pr_r.get("pr_url"):
+                    app.note(
+                        f"PR ready for {ws_repo.repo_name}: {pr_r.get('pr_url')}",
+                        tags=["build", "github_pr", "complete"],
+                    )
+                    if cfg.check_ci and pr_r.get("pr_number"):
+                        gate = await _run_ci_gate(
+                            repo_path=ws_repo.absolute_path,
+                            pr_number=pr_r.get("pr_number", 0),
+                            pr_url=pr_r.get("pr_url", ""),
+                            integration_branch=repo_integration_branch,
+                            base_branch=repo_base_branch,
+                            cfg=cfg,
+                            resolved_models=resolved,
+                            goal=goal,
+                            completed_issues=[
+                                r for r in dag_result.get("completed_issues", [])
+                                if not r.get("repo_name") or r.get("repo_name") == ws_repo.repo_name
+                            ],
+                        )
+                        ci_gate_results.append({"repo_name": ws_repo.repo_name, **gate})
+            except Exception as e:
+                pr_results.append(RepoPRResult(
+                    repo_name=ws_repo.repo_name,
+                    repo_url=ws_repo.repo_url,
+                    success=False,
+                    error_message=str(e),
+                ))
+                app.note(
+                    f"PR creation failed for {ws_repo.repo_name}: {e}",
+                    tags=["build", "github_pr", "error"],
+                )
+    else:
+        remote_url = git_config.get("remote_url", "") if git_config else ""
+        if remote_url and cfg.enable_github_pr:
+            app.note("Phase 4: Push + PR", tags=["build", "github_pr"])
+            base_branch = (
+                cfg.github_pr_base
+                or (git_config.get("remote_default_branch") if git_config else "")
+                or "main"
+            )
+            pr_url = ""
+            try:
+                existing = _existing_pr_for_branch(
+                    repo_path, git_config["integration_branch"], base_branch
+                )
+                pr_existed = bool(existing)
+                if existing:
+                    _push_existing_pr_branch(repo_path, git_config["integration_branch"])
+                    pr_result = existing
+                else:
+                    pr_result = _unwrap(await app.call(
+                        f"{NODE_ID}.run_github_pr",
+                        repo_path=repo_path,
+                        integration_branch=git_config["integration_branch"],
+                        base_branch=base_branch,
+                        goal=goal,
+                        build_summary=build_summary,
+                        completed_issues=dag_result.get("completed_issues", []),
+                        accumulated_debt=dag_result.get("accumulated_debt", []),
+                        artifacts_dir=plan_result.get("artifacts_dir", artifacts_dir),
+                        model=resolved["git_model"],
+                        permission_mode=cfg.permission_mode,
+                        ai_provider=cfg.ai_provider,
+                    ), "run_github_pr")
+                pr_url = pr_result.get("pr_url", "")
+                if pr_url:
+                    app.note(f"PR ready: {pr_url}", tags=["build", "github_pr", "complete"])
+                    if not pr_existed:
+                        try:
+                            _append_plan_docs_to_pr(
+                                repo_path=repo_path,
+                                pr_number=pr_result.get("pr_number", 0),
+                                prd_markdown=prd_markdown,
+                                architecture_markdown=architecture_markdown,
+                            )
+                            app.note(
+                                "Plan docs appended to PR body",
+                                tags=["build", "github_pr", "plan_docs"],
+                            )
+                        except subprocess.CalledProcessError as e:
+                            app.note(
+                                f"Failed to append plan docs to PR (non-fatal): {e}",
+                                tags=["build", "github_pr", "plan_docs", "warning"],
+                            )
+                else:
+                    app.note(
+                        f"PR creation failed: {pr_result.get('error_message', 'unknown')}",
+                        tags=["build", "github_pr", "error"],
+                    )
+                if pr_url:
+                    pr_results.append(RepoPRResult(
+                        repo_name=_repo_name_from_url(cfg.repo_url) if cfg.repo_url else "repo",
+                        repo_url=cfg.repo_url,
+                        success=True,
+                        pr_url=pr_url,
+                        pr_number=pr_result.get("pr_number", 0),
+                    ))
+                    if cfg.check_ci and pr_result.get("pr_number"):
+                        gate = await _run_ci_gate(
+                            repo_path=repo_path,
+                            pr_number=pr_result.get("pr_number", 0),
+                            pr_url=pr_url,
+                            integration_branch=git_config["integration_branch"],
+                            base_branch=base_branch,
+                            cfg=cfg,
+                            resolved_models=resolved,
+                            goal=goal,
+                            completed_issues=dag_result.get("completed_issues", []),
+                        )
+                        ci_gate_results.append({
+                            "repo_name": (
+                                _repo_name_from_url(cfg.repo_url)
+                                if cfg.repo_url else "repo"
+                            ),
+                            **gate,
+                        })
+            except Exception as e:
+                app.note(f"PR creation failed: {e}", tags=["build", "github_pr", "error"])
+
+    if manifest and manifest.workspace_root:
+        try:
+            import shutil
+            shutil.rmtree(manifest.workspace_root, ignore_errors=True)
+            app.note(
+                f"Workspace cleaned up: {manifest.workspace_root}",
+                tags=["build", "cleanup"],
+            )
+        except Exception:
+            pass
+
+    build_result = BuildResult(
+        plan_result=plan_result,
+        dag_state=dag_result,
+        verification=verification,
+        success=success,
+        summary=f"{'Success' if success else 'Partial'}: {completed}/{total} issues completed"
+                + (f", verification: {verification.get('summary', '')}" if verification else ""),
+        pr_results=pr_results,
+        ci_gate_results=ci_gate_results,
+    ).model_dump()
+
+    build_state.update({
+        "goal": goal,
+        "repo_path": repo_path,
+        "repo_url": cfg.repo_url,
+        "artifacts_dir": artifacts_dir,
+        "config": cfg.model_dump(),
+        "plan_result": plan_result,
+        "dag_result": dag_result,
+        "git_config": git_config,
+        "workspace_manifest": manifest.model_dump() if manifest else None,
+        "verification": verification,
+        "pr_results": [r.model_dump() for r in pr_results],
+        "ci_gate_results": ci_gate_results,
+        "build_result": build_result,
+    })
+    _save_build_state(repo_path, artifacts_dir, build_state)
+
+    if _is_empty_build(success, ever_completed, ever_merged):
+        raise ReasonerFailed(
+            f"Build failed: 0/{total} issues completed, no branches merged",
+            result=build_result,
+        )
+
+    return build_result
 
 
 @app.reasoner()
@@ -961,6 +1565,19 @@ async def build(
                     summary=f"Plan {approval_result.decision}: {reason}",
                 ).model_dump()
 
+        build_state = {
+            "goal": goal,
+            "repo_path": repo_path,
+            "repo_url": cfg.repo_url,
+            "artifacts_dir": artifacts_dir,
+            "config": cfg.model_dump(),
+            "build_id": build_id,
+            "plan_result": plan_result,
+            "git_config": git_config,
+            "workspace_manifest": manifest.model_dump() if manifest else None,
+        }
+        _save_build_state(repo_path, artifacts_dir, build_state)
+
         # 2. EXECUTE
         exec_config = cfg.to_execution_config_dict()
 
@@ -984,6 +1601,8 @@ async def build(
         # genuinely shipped something.
         ever_completed = len(dag_result.get("completed_issues", []) or [])
         ever_merged = len(dag_result.get("merged_branches", []) or [])
+        build_state["dag_result"] = dag_result
+        _save_build_state(repo_path, artifacts_dir, build_state)
 
         # Refresh manifest with git_init_result populated by _init_all_repos() in
         # the DAG executor.  Must happen before the verify/fix loop which can
@@ -1386,6 +2005,14 @@ async def build(
             pr_results=pr_results,
             ci_gate_results=ci_gate_results,
         ).model_dump()
+        build_state.update({
+            "dag_result": dag_result,
+            "verification": verification,
+            "pr_results": [r.model_dump() for r in pr_results],
+            "ci_gate_results": ci_gate_results,
+            "build_result": build_result,
+        })
+        _save_build_state(repo_path, artifacts_dir, build_state)
 
         # An empty build — verification failed AND nothing was ever completed
         # or merged across the original run and every fix cycle — must not
@@ -2060,60 +2687,109 @@ async def _post_thread_replies_and_resolve(
     return results
 
 
+async def _resume_execute_impl(
+    repo_path: str,
+    artifacts_dir: str = ".artifacts",
+    config: dict | None = None,
+    git_config: dict | None = None,
+) -> dict:
+    checkpoint = _load_execution_checkpoint(repo_path, artifacts_dir)
+    build_state = _load_build_state(repo_path, artifacts_dir)
+    plan_result = build_state.get("plan_result") or _plan_result_from_checkpoint(checkpoint)
+    effective_git_config = git_config or build_state.get("git_config") or _git_config_from_checkpoint(checkpoint)
+
+    app.note("Resuming DAG execution from checkpoint", tags=["execute", "resume"])
+
+    result = _unwrap(await app.call(
+        f"{NODE_ID}.execute",
+        plan_result=plan_result,
+        repo_path=repo_path,
+        config=config,
+        git_config=effective_git_config,
+        resume=True,
+    ), "execute")
+
+    incomplete = _resume_incomplete_summary(result)
+    if incomplete:
+        raise ReasonerFailed(incomplete, result=result)
+
+    return result
+
+
+@app.reasoner()
+async def resume_execute(
+    repo_path: str,
+    artifacts_dir: str = ".artifacts",
+    config: dict | None = None,
+    git_config: dict | None = None,
+) -> dict:
+    """Resume DAG execution only from ``.artifacts/execution/checkpoint.json``."""
+    return await _resume_execute_impl(
+        repo_path=repo_path,
+        artifacts_dir=artifacts_dir,
+        config=config,
+        git_config=git_config,
+    )
+
+
 @app.reasoner()
 async def resume_build(
     repo_path: str,
     artifacts_dir: str = ".artifacts",
     config: dict | None = None,
     git_config: dict | None = None,
+    goal: str = "",
+    repo_url: str = "",
 ) -> dict:
-    """Resume a crashed build from the last checkpoint.
+    """Resume DAG execution, then continue verifier/finalize/PR/CI build tail."""
+    checkpoint = _load_execution_checkpoint(repo_path, artifacts_dir)
+    build_state = _load_build_state(repo_path, artifacts_dir)
+    overrides = dict(config or {})
+    if repo_url:
+        overrides["repo_url"] = repo_url
+    cfg = _build_config_from_saved_state(build_state.get("config") or {}, overrides)
 
-    Loads the plan result from artifacts and calls execute with resume=True.
-    """
-    import json
+    effective_goal = goal or build_state.get("goal", "")
+    plan_result = build_state.get("plan_result") or _plan_result_from_checkpoint(checkpoint)
+    effective_git_config = git_config or build_state.get("git_config") or _git_config_from_checkpoint(checkpoint)
+    manifest_data = build_state.get("workspace_manifest") or checkpoint.get("workspace_manifest")
+    manifest = WorkspaceManifest(**manifest_data) if manifest_data else None
 
-    base = os.path.join(os.path.abspath(repo_path), artifacts_dir)
-
-    # Reconstruct plan_result from saved artifacts
-    plan_path = os.path.join(base, "execution", "checkpoint.json")
-    if not os.path.exists(plan_path):
-        raise RuntimeError(
-            f"No checkpoint found at {plan_path}. Cannot resume."
-        )
-
-    # Load the original plan artifacts to reconstruct plan_result
-    prd_path = os.path.join(base, "plan", "prd.md")
-    arch_path = os.path.join(base, "plan", "architecture.md")
-    rationale_path = os.path.join(base, "rationale.md")
-
-    # We need the plan_result dict — reconstruct from checkpoint's DAGState
-    with open(plan_path, "r") as f:
-        checkpoint = json.load(f)
-
-    plan_result = {
-        "prd": {},  # Not needed for resume — DAGState has summaries
-        "architecture": {},
-        "review": {},
-        "issues": checkpoint.get("all_issues", []),
-        "levels": checkpoint.get("levels", []),
-        "file_conflicts": [],
-        "artifacts_dir": checkpoint.get("artifacts_dir", base),
-        "rationale": checkpoint.get("original_plan_summary", ""),
-    }
-
-    app.note("Resuming build from checkpoint", tags=["build", "resume"])
-
-    result = await app.call(
-        f"{NODE_ID}.execute",
-        plan_result=plan_result,
+    app.note("Resuming full build from checkpoint", tags=["build", "resume"])
+    exec_config = cfg.to_execution_config_dict()
+    dag_result = await _resume_execute_impl(
         repo_path=repo_path,
-        config=config,
-        git_config=git_config,
-        resume=True,
+        artifacts_dir=artifacts_dir,
+        config=exec_config,
+        git_config=effective_git_config,
     )
+    build_state.update({
+        "goal": effective_goal,
+        "repo_path": repo_path,
+        "repo_url": cfg.repo_url,
+        "artifacts_dir": artifacts_dir,
+        "config": cfg.model_dump(),
+        "plan_result": plan_result,
+        "dag_result": dag_result,
+        "git_config": effective_git_config,
+        "workspace_manifest": manifest.model_dump() if manifest else None,
+    })
+    _save_build_state(repo_path, artifacts_dir, build_state)
 
-    return result
+    return await _continue_build_tail(
+        goal=effective_goal,
+        repo_path=repo_path,
+        artifacts_dir=artifacts_dir,
+        cfg=cfg,
+        resolved=cfg.resolved_models(),
+        plan_result=plan_result,
+        dag_result=dag_result,
+        git_config=effective_git_config,
+        manifest=manifest,
+        ever_completed=len(dag_result.get("completed_issues", []) or []),
+        ever_merged=len(dag_result.get("merged_branches", []) or []),
+        build_state=build_state,
+    )
 
 
 def main():

--- a/swe_af/app.py
+++ b/swe_af/app.py
@@ -535,6 +535,10 @@ def _checkpoint_path(repo_path: str, artifacts_dir: str) -> str:
 def _load_execution_checkpoint(repo_path: str, artifacts_dir: str) -> dict:
     path = _checkpoint_path(repo_path, artifacts_dir)
     if not os.path.exists(path):
+        build_state = _load_build_state(repo_path, artifacts_dir)
+        checkpoint = build_state.get("dag_result")
+        if checkpoint:
+            return checkpoint
         raise RuntimeError(f"No checkpoint found at {path}. Cannot resume.")
     with open(path, encoding="utf-8") as fp:
         return json.load(fp)
@@ -542,9 +546,26 @@ def _load_execution_checkpoint(repo_path: str, artifacts_dir: str) -> dict:
 
 def _plan_result_from_checkpoint(checkpoint: dict) -> dict:
     artifacts_dir = checkpoint.get("artifacts_dir", "")
+    prd_summary = checkpoint.get("prd_summary", "")
+    acceptance_criteria: list[str] = []
+    in_acceptance = False
+    for line in prd_summary.splitlines():
+        stripped = line.strip()
+        if stripped.lower().startswith("acceptance criteria:"):
+            in_acceptance = True
+            continue
+        if in_acceptance and stripped.startswith("- "):
+            acceptance_criteria.append(stripped[2:].strip())
+        elif in_acceptance and stripped:
+            in_acceptance = False
     return {
-        "prd": {},
-        "architecture": {},
+        "prd": {
+            "validated_description": prd_summary,
+            "acceptance_criteria": acceptance_criteria,
+        },
+        "architecture": {
+            "summary": checkpoint.get("architecture_summary", ""),
+        },
         "review": {},
         "issues": checkpoint.get("all_issues", []),
         "levels": checkpoint.get("levels", []),

--- a/swe_af/prompts/repo_finalize.py
+++ b/swe_af/prompts/repo_finalize.py
@@ -12,8 +12,8 @@ ready for a pull request or handoff.
 ## What "Production-Ready" Means
 
 Imagine a new team member cloning this repo for the first time. They should see:
-- Only intentional, purposeful files — no build artifacts, no tooling \
-  leftovers, no pipeline infrastructure
+- Only intentional, purposeful files — no build artifacts or tooling \
+  leftovers, while preserving SWE-AF handoff evidence under `.artifacts/`
 - A comprehensive .gitignore that prevents future accidents
 - A clean `git status` with no untracked debris
 - No broken symlinks or empty placeholder files that have outlived their \
@@ -27,8 +27,13 @@ Imagine a new team member cloning this repo for the first time. They should see:
    what's debris.
 2. **Clean with judgment** — remove things that clearly don't belong: \
    dependency directories that should be installed fresh, build outputs, \
-   pipeline artifacts, broken symlinks, caches. Don't remove anything \
-   you're unsure about — if in doubt, leave it and note it.
+   untracked pipeline scratch directories, broken symlinks, caches. Before \
+   removing any path, check whether it is tracked with `git ls-files -- \
+   <path>`. Never delete tracked files. Preserve SWE-AF handoff artifacts \
+   under `.artifacts/plan/`, `.artifacts/execution/`, \
+   `.artifacts/verification/`, and `.artifacts/build_state.json` even when \
+   they are untracked or ignored. Don't remove anything you're unsure about \
+   — if in doubt, leave it and note it.
 3. **Fortify the .gitignore** — ensure it covers the standard patterns for \
    this project's ecosystem. A good .gitignore is the repo's immune system.
 4. **Final commit** — stage and commit your cleanup work. This should be a \
@@ -40,6 +45,10 @@ Imagine a new team member cloning this repo for the first time. They should see:
 - Do NOT modify source code, tests, or documentation
 - Do NOT change the project's behavior in any way
 - Do NOT remove files you're uncertain about — only clear artifacts
+- Do NOT remove tracked files, including tracked generated verification fixtures
+- Do NOT remove SWE-AF handoff artifacts: `.artifacts/plan/`, \
+  `.artifacts/execution/`, `.artifacts/verification/`, or \
+  `.artifacts/build_state.json`, even when they are untracked or ignored
 - Do NOT restructure or reorganize the project
 
 ## Tools Available
@@ -61,9 +70,14 @@ def repo_finalize_task_prompt(repo_path: str) -> str:
     sections.append(
         "\n## Your Task\n"
         "1. Survey the directory tree to understand the project and its ecosystem.\n"
-        "2. Identify and remove clear artifacts: dependency dirs (node_modules, "
-        "__pycache__, .venv, etc.), build outputs, broken symlinks, pipeline "
-        "leftovers (.artifacts/, .worktrees/), caches.\n"
+        "2. Identify and remove clear untracked artifacts: dependency dirs "
+        "(node_modules, __pycache__, .venv, etc.), build outputs, broken "
+        "symlinks, untracked pipeline scratch directories, caches. Before "
+        "removing any path, run `git ls-files -- <path>` or equivalent and "
+        "preserve tracked files. Also preserve SWE-AF handoff artifacts under "
+        "`.artifacts/plan/`, `.artifacts/execution/`, "
+        "`.artifacts/verification/`, and `.artifacts/build_state.json` even "
+        "when untracked or ignored.\n"
         "3. Create or update `.gitignore` with standard patterns for the detected "
         "language/framework, plus `.artifacts/`, `.worktrees/`, `.env`, `.DS_Store`.\n"
         "4. Check `git status` — ensure the working tree is clean.\n"

--- a/tests/test_planner_execute.py
+++ b/tests/test_planner_execute.py
@@ -122,6 +122,48 @@ def test_build_config_saved_state_round_trips_normalized_repo_url():
     assert len(cfg.repos) == 1
 
 
+def test_plan_result_from_checkpoint_preserves_prd_summary_and_acceptance():
+    import swe_af.app as app_module
+
+    plan = app_module._plan_result_from_checkpoint({
+        "artifacts_dir": "/tmp/repo/.artifacts",
+        "prd_summary": (
+            "Build the thing.\n\nAcceptance Criteria:\n"
+            "- command one exits 0.\n"
+            "- command two exits 0.\n"
+        ),
+        "architecture_summary": "Use the intended architecture.",
+        "all_issues": [{"name": "one"}],
+        "levels": [["one"]],
+    })
+
+    assert plan["prd"]["validated_description"].startswith("Build the thing")
+    assert plan["prd"]["acceptance_criteria"] == [
+        "command one exits 0.",
+        "command two exits 0.",
+    ]
+    assert plan["architecture"]["summary"] == "Use the intended architecture."
+
+
+def test_load_execution_checkpoint_falls_back_to_build_state(tmp_path: Path):
+    import swe_af.app as app_module
+
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    expected = {
+        "repo_path": str(repo_path),
+        "all_issues": [{"name": "one"}],
+        "levels": [["one"]],
+    }
+    app_module._save_build_state(
+        str(repo_path),
+        ".artifacts",
+        {"dag_result": expected},
+    )
+
+    assert app_module._load_execution_checkpoint(str(repo_path), ".artifacts") == expected
+
+
 @pytest.mark.asyncio
 async def test_resume_execute_only_resumes_dag(tmp_path: Path):
     import swe_af.app as app_module

--- a/tests/test_planner_execute.py
+++ b/tests/test_planner_execute.py
@@ -11,7 +11,9 @@ discoverable and pass.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch, call as mock_call
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -47,6 +49,12 @@ def _make_plan_result(issues: list[dict] | None = None) -> dict:
     }
 
 
+def _write_checkpoint(repo_path: Path, checkpoint: dict) -> None:
+    checkpoint_path = repo_path / ".artifacts" / "execution" / "checkpoint.json"
+    checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
+    checkpoint_path.write_text(json.dumps(checkpoint), encoding="utf-8")
+
+
 def _make_dag_state(completed: list[str], failed: list[str]) -> DAGState:
     """Build a DAGState with given completed / failed issue names."""
     return DAGState(
@@ -68,6 +76,171 @@ def _make_dag_state(completed: list[str], failed: list[str]) -> DAGState:
             for name in failed
         ],
     )
+
+
+def test_resume_incomplete_summary_empty_for_finished_dag():
+    import swe_af.app as app_module
+
+    result = {
+        "all_issues": [{"name": "one"}],
+        "completed_issues": [{"issue_name": "one"}],
+        "failed_issues": [],
+        "skipped_issues": [],
+    }
+
+    assert app_module._resume_incomplete_summary(result) == ""
+
+
+def test_resume_incomplete_summary_flags_failed_and_skipped_dag():
+    import swe_af.app as app_module
+
+    result = {
+        "all_issues": [{"name": "one"}, {"name": "two"}, {"name": "three"}],
+        "completed_issues": [{"issue_name": "one"}],
+        "failed_issues": [{"issue_name": "two"}],
+        "skipped_issues": ["three"],
+    }
+
+    summary = app_module._resume_incomplete_summary(result)
+
+    assert "Resume incomplete: 1/3 issues completed" in summary
+    assert "failed=['two']" in summary
+    assert "skipped=['three']" in summary
+
+
+def test_build_config_saved_state_round_trips_normalized_repo_url():
+    import swe_af.app as app_module
+    from swe_af.execution.schemas import BuildConfig
+
+    saved_config = BuildConfig(
+        repo_url="https://github.com/example/repo.git",
+    ).model_dump()
+
+    cfg = app_module._build_config_from_saved_state(saved_config)
+
+    assert cfg.repo_url == "https://github.com/example/repo.git"
+    assert len(cfg.repos) == 1
+
+
+@pytest.mark.asyncio
+async def test_resume_execute_only_resumes_dag(tmp_path: Path):
+    import swe_af.app as app_module
+
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    plan_result = _make_plan_result()
+    completed_result = {
+        "all_issues": plan_result["issues"],
+        "completed_issues": [{"issue_name": "implement-feature"}],
+        "failed_issues": [],
+        "skipped_issues": [],
+        "merged_branches": ["feature-branch"],
+    }
+    _write_checkpoint(
+        repo_path,
+        {
+            "all_issues": plan_result["issues"],
+            "levels": plan_result["levels"],
+            "artifacts_dir": str(repo_path / ".artifacts"),
+            "git_integration_branch": "integration",
+        },
+    )
+
+    async def fake_call(target: str, **kwargs):
+        assert target == f"{app_module.NODE_ID}.execute"
+        assert kwargs["resume"] is True
+        return completed_result
+
+    with patch.object(app_module.app, "call", new=AsyncMock(side_effect=fake_call)):
+        result = await app_module.resume_execute(repo_path=str(repo_path))
+
+    assert result == completed_result
+
+
+@pytest.mark.asyncio
+async def test_resume_build_continues_full_tail(tmp_path: Path):
+    import swe_af.app as app_module
+
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    plan_result = _make_plan_result()
+    dag_result = {
+        "all_issues": plan_result["issues"],
+        "completed_issues": [{"issue_name": "implement-feature"}],
+        "failed_issues": [],
+        "skipped_issues": [],
+        "merged_branches": ["feature-branch"],
+        "accumulated_debt": [],
+    }
+    git_config = {
+        "integration_branch": "integration",
+        "original_branch": "main",
+        "initial_commit_sha": "abc123",
+        "mode": "existing",
+        "remote_url": "https://github.com/example/repo.git",
+        "remote_default_branch": "main",
+    }
+    _write_checkpoint(
+        repo_path,
+        {
+            "all_issues": plan_result["issues"],
+            "levels": plan_result["levels"],
+            "artifacts_dir": str(repo_path / ".artifacts"),
+            "git_integration_branch": "integration",
+        },
+    )
+    app_module._save_build_state(
+        str(repo_path),
+        ".artifacts",
+        {
+            "goal": "ship feature",
+            "repo_path": str(repo_path),
+            "repo_url": "https://github.com/example/repo.git",
+            "artifacts_dir": ".artifacts",
+            "config": {
+                "runtime": "codex",
+                "models": {"default": "gpt-5.5"},
+                "enable_github_pr": True,
+                "check_ci": False,
+            },
+            "plan_result": plan_result,
+            "git_config": git_config,
+        },
+    )
+
+    calls: list[str] = []
+
+    async def fake_call(target: str, **kwargs):
+        calls.append(target)
+        if target == f"{app_module.NODE_ID}.execute":
+            assert kwargs["resume"] is True
+            return dag_result
+        if target == f"{app_module.NODE_ID}.run_verifier":
+            return {"passed": True, "summary": "ok", "criteria_results": []}
+        if target == f"{app_module.NODE_ID}.run_repo_finalize":
+            return {"success": True, "summary": "clean"}
+        if target == f"{app_module.NODE_ID}.run_github_pr":
+            return {
+                "success": True,
+                "pr_url": "https://github.com/example/repo/pull/1",
+                "pr_number": 1,
+            }
+        raise AssertionError(f"unexpected call: {target}")
+
+    with (
+        patch.object(app_module.app, "call", new=AsyncMock(side_effect=fake_call)),
+        patch.object(app_module, "_existing_pr_for_branch", return_value={}),
+        patch.object(app_module, "_append_plan_docs_to_pr"),
+    ):
+        result = await app_module.resume_build(repo_path=str(repo_path))
+
+    assert result["success"] is True
+    assert calls == [
+        f"{app_module.NODE_ID}.execute",
+        f"{app_module.NODE_ID}.run_verifier",
+        f"{app_module.NODE_ID}.run_repo_finalize",
+        f"{app_module.NODE_ID}.run_github_pr",
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_repo_finalize_prompt.py
+++ b/tests/test_repo_finalize_prompt.py
@@ -1,0 +1,14 @@
+from swe_af.prompts.repo_finalize import SYSTEM_PROMPT, repo_finalize_task_prompt
+
+
+def test_repo_finalize_prompt_preserves_swe_af_handoff_artifacts():
+    prompt = repo_finalize_task_prompt("/tmp/repo")
+    combined = SYSTEM_PROMPT + "\n" + prompt
+
+    assert "git ls-files" in combined
+    assert "Never delete tracked files" in combined
+    assert ".artifacts/plan/" in combined
+    assert ".artifacts/execution/" in combined
+    assert ".artifacts/verification/" in combined
+    assert ".artifacts/build_state.json" in combined
+    assert "untracked or ignored" in combined


### PR DESCRIPTION
## Summary
- Adds `resume_execute` for DAG-only recovery.
- Makes `resume_build` continue the full build tail: verification, finalization, PR creation, and CI gate.
- Persists `.artifacts/build_state.json` and can recover from it when `execution/checkpoint.json` is gone.
- Teaches repo finalization to preserve SWE-AF handoff artifacts, even if untracked or ignored.

## Why
- A parent build can fail or time out after useful child DAG work has already completed.
- Resume needs enough durable state to continue deterministically instead of stopping after DAG execution.
- Final cleanup must not delete artifacts needed for resume, verification evidence, or handoff.

## Assumptions
- `resume_execute` should remain DAG-only.
- `resume_build` should be the full continuation endpoint.
- Existing config should still control PR and CI side effects.
- Draft only; needs maintainer review and broader testing before merge.

## Tested
- `AGENTFIELD_SERVER=http://localhost:9999 .venv/bin/python -m pytest tests/test_planner_execute.py tests/test_repo_finalize_prompt.py -q` (10 passed)
- `git diff --check origin/main...HEAD`
- Earlier local live recovery on a constrained OppClarity workspace reached 12/12 completed issues with verification passing and PR/CI disabled.

## Noted
- Direct Ruff on `swe_af/app.py` still reports upstream-existing E402 import-order findings around `load_dotenv()`.