### PR TITLE
feat: accept either Anthropic or OpenRouter key; DeepSeek by default on OpenRouter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,9 @@ ANTHROPIC_API_KEY=sk-ant-api03-...
 
 # OpenRouter (recommended - 200+ models including DeepSeek, Qwen, Llama, MiniMax)
 # OPENROUTER_API_KEY=sk-or-v1-...
+# With ONLY an OpenRouter key set (no ANTHROPIC_API_KEY, no SWE_DEFAULT_RUNTIME),
+# SWE-AF auto-selects the open_code runtime and defaults to
+# openrouter/deepseek/deepseek-v4-flash. Override the model with SWE_DEFAULT_MODEL.
 
 # OpenAI API-platform billing for OpenAI models and Codex api_key mode.
 # OPENAI_API_KEY=sk-...

--- a/agentfield-package.yaml
+++ b/agentfield-package.yaml
@@ -12,12 +12,24 @@ agent_node:
   default_port: 8003
 
 user_environment:
-  required:
-    - name: ANTHROPIC_API_KEY
-      description: Anthropic API key used by the SWE harness
-      type: secret
-      scope: global
+  require_one_of:
+    # SWE-AF runs on either Claude (Anthropic) or open models via OpenRouter.
+    # Provide one. With only an OpenRouter key it auto-selects the open_code
+    # runtime and defaults to openrouter/deepseek/deepseek-v4-flash.
+    - id: llm_provider
+      description: an LLM provider key
+      options:
+        - name: ANTHROPIC_API_KEY
+          description: Anthropic API key (Claude)
+          type: secret
+          scope: global
+        - name: OPENROUTER_API_KEY
+          description: OpenRouter API key (DeepSeek/Qwen/Llama/… — 200+ models)
+          type: secret
+          scope: global
   optional:
+    - name: SWE_DEFAULT_MODEL
+      description: Override the model id for every role (e.g. openrouter/deepseek/deepseek-v4-flash)
     - name: AGENTFIELD_SERVER
       description: Control-plane URL
       default: http://localhost:8080

--- a/swe_af/execution/schemas.py
+++ b/swe_af/execution/schemas.py
@@ -560,16 +560,39 @@ def _runtime_to_provider(runtime: str) -> Literal["claude", "opencode", "codex"]
     return runtime_to_harness_provider(runtime)  # type: ignore[return-value]
 
 
+# Default model for the auto-selected OpenRouter path (see _openrouter_only_env).
+_OPENROUTER_AUTO_DEFAULT_MODEL = "openrouter/deepseek/deepseek-v4-flash"
+
+
+def _openrouter_only_env() -> bool:
+    """Whether the deployer implicitly chose the OpenRouter runtime.
+
+    True when no explicit ``SWE_DEFAULT_RUNTIME`` is set, no Anthropic key is
+    present, but an ``OPENROUTER_API_KEY`` is — i.e. the user "went with
+    OpenRouter" without spelling out a runtime. In that case SWE-AF defaults to
+    the ``open_code`` runtime and to ``_OPENROUTER_AUTO_DEFAULT_MODEL``. Setting
+    ``SWE_DEFAULT_RUNTIME`` (to anything) opts out and preserves the explicit
+    runtime's own defaults.
+    """
+    if os.getenv("SWE_DEFAULT_RUNTIME", "").strip():
+        return False
+    if os.getenv("ANTHROPIC_API_KEY", "").strip():
+        return False
+    return bool(os.getenv("OPENROUTER_API_KEY", "").strip())
+
+
 def _default_runtime() -> Literal["claude_code", "open_code", "codex"]:
     """Default runtime, honoring the ``SWE_DEFAULT_RUNTIME`` env var.
 
     Lets the deployer pick the runtime without every caller having to pass
-    a config. Falls back to ``claude_code`` when unset; logs and falls back
-    when the env value isn't a valid runtime.
+    a config. When ``SWE_DEFAULT_RUNTIME`` is unset, auto-selects ``open_code``
+    if only an OpenRouter key is present (see ``_openrouter_only_env``),
+    otherwise ``claude_code``. Logs and falls back to ``claude_code`` when the
+    env value isn't a valid runtime.
     """
     value = os.getenv("SWE_DEFAULT_RUNTIME", "").strip()
     if not value:
-        return "claude_code"
+        return "open_code" if _openrouter_only_env() else "claude_code"
     if value in RUNTIME_VALUES:
         return value  # type: ignore[return-value]
     logging.getLogger(__name__).warning(
@@ -698,6 +721,11 @@ def resolve_runtime_models(
         # Choose the codex base default by auth mode (see _codex_default_model).
         codex_model = _codex_default_model()
         base = {field: codex_model for field in base}
+    elif runtime == "open_code" and _openrouter_only_env():
+        # OpenRouter was auto-selected (an OpenRouter key, no explicit runtime):
+        # default to DeepSeek. Explicit open_code deployers keep their own base
+        # default; SWE_DEFAULT_MODEL / models overrides still win over this.
+        base = {field: _OPENROUTER_AUTO_DEFAULT_MODEL for field in base}
     resolved: dict[str, str] = {field: base[field] for field in field_names}
 
     env_default = _default_model_from_env()

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import os
 import unittest
 from unittest import mock
@@ -11,8 +12,36 @@ from swe_af.execution.schemas import (
     BuildConfig,
     ExecutionConfig,
     ROLE_TO_MODEL_FIELD,
+    _default_runtime,
     resolve_runtime_models,
 )
+
+# Env vars that steer provider/runtime/model selection. Tests clear them so the
+# result never depends on the developer's ambient shell.
+_PROVIDER_ENV_KEYS = (
+    "ANTHROPIC_API_KEY",
+    "OPENROUTER_API_KEY",
+    "SWE_DEFAULT_RUNTIME",
+    "SWE_DEFAULT_MODEL",
+    "AI_MODEL",
+    "HARNESS_MODEL",
+)
+
+
+@contextlib.contextmanager
+def _provider_env(**overrides: str):
+    """Run with the provider-selection env vars cleared, then apply overrides."""
+    saved = {k: os.environ.get(k) for k in _PROVIDER_ENV_KEYS}
+    for k in _PROVIDER_ENV_KEYS:
+        os.environ.pop(k, None)
+    os.environ.update(overrides)
+    try:
+        yield
+    finally:
+        for k in _PROVIDER_ENV_KEYS:
+            os.environ.pop(k, None)
+            if saved[k] is not None:
+                os.environ[k] = saved[k]
 
 
 class TestResolveRuntimeModels(unittest.TestCase):
@@ -25,7 +54,9 @@ class TestResolveRuntimeModels(unittest.TestCase):
         self.assertEqual(resolved["qa_synthesizer_model"], "haiku")
 
     def test_open_code_defaults(self) -> None:
-        resolved = resolve_runtime_models(runtime="open_code", models=None)
+        # No provider env set → not the auto-OpenRouter path → minimax base default.
+        with _provider_env():
+            resolved = resolve_runtime_models(runtime="open_code", models=None)
         for field in ALL_MODEL_FIELDS:
             self.assertEqual(resolved[field], "openrouter/minimax/minimax-m2.5")
 
@@ -61,10 +92,65 @@ class TestBuildConfig(unittest.TestCase):
         self.assertEqual(cfg.ai_provider, "claude")
 
     def test_open_code_runtime_provider(self) -> None:
-        cfg = BuildConfig(runtime="open_code")
-        self.assertEqual(cfg.ai_provider, "opencode")
-        resolved = cfg.resolved_models()
+        with _provider_env():
+            cfg = BuildConfig(runtime="open_code")
+            self.assertEqual(cfg.ai_provider, "opencode")
+            resolved = cfg.resolved_models()
         self.assertEqual(resolved["coder_model"], "openrouter/minimax/minimax-m2.5")
+
+
+class TestOpenRouterAutoSelection(unittest.TestCase):
+    """When only an OpenRouter key is present (no explicit runtime), SWE-AF
+    auto-selects the open_code runtime and defaults to DeepSeek."""
+
+    def test_openrouter_only_auto_selects_open_code(self) -> None:
+        with _provider_env(OPENROUTER_API_KEY="sk-or-x"):
+            self.assertEqual(_default_runtime(), "open_code")
+
+    def test_anthropic_key_keeps_claude_code(self) -> None:
+        with _provider_env(ANTHROPIC_API_KEY="sk-ant"):
+            self.assertEqual(_default_runtime(), "claude_code")
+
+    def test_both_keys_keep_claude_code(self) -> None:
+        # Anthropic present → claude_code even if OpenRouter is also set.
+        with _provider_env(ANTHROPIC_API_KEY="sk-ant", OPENROUTER_API_KEY="sk-or"):
+            self.assertEqual(_default_runtime(), "claude_code")
+
+    def test_no_keys_default_claude_code(self) -> None:
+        with _provider_env():
+            self.assertEqual(_default_runtime(), "claude_code")
+
+    def test_explicit_runtime_overrides_autoselect(self) -> None:
+        # Explicit SWE_DEFAULT_RUNTIME wins over key-based auto-selection.
+        with _provider_env(OPENROUTER_API_KEY="sk-or", SWE_DEFAULT_RUNTIME="claude_code"):
+            self.assertEqual(_default_runtime(), "claude_code")
+
+    def test_auto_openrouter_defaults_to_deepseek(self) -> None:
+        with _provider_env(OPENROUTER_API_KEY="sk-or"):
+            resolved = resolve_runtime_models(runtime="open_code", models=None)
+        for field in ALL_MODEL_FIELDS:
+            self.assertEqual(resolved[field], "openrouter/deepseek/deepseek-v4-flash")
+
+    def test_explicit_open_code_keeps_minimax(self) -> None:
+        # A deployer who explicitly sets open_code keeps the runtime's own
+        # default even with an OpenRouter key present.
+        with _provider_env(OPENROUTER_API_KEY="sk-or", SWE_DEFAULT_RUNTIME="open_code"):
+            resolved = resolve_runtime_models(runtime="open_code", models=None)
+        for field in ALL_MODEL_FIELDS:
+            self.assertEqual(resolved[field], "openrouter/minimax/minimax-m2.5")
+
+    def test_swe_default_model_overrides_auto_deepseek(self) -> None:
+        with _provider_env(OPENROUTER_API_KEY="sk-or", SWE_DEFAULT_MODEL="openrouter/qwen/qwen-3"):
+            resolved = resolve_runtime_models(runtime="open_code", models=None)
+        for field in ALL_MODEL_FIELDS:
+            self.assertEqual(resolved[field], "openrouter/qwen/qwen-3")
+
+    def test_build_config_auto_openrouter_end_to_end(self) -> None:
+        with _provider_env(OPENROUTER_API_KEY="sk-or"):
+            cfg = BuildConfig()
+            self.assertEqual(cfg.runtime, "open_code")
+            resolved = cfg.resolved_models()
+        self.assertEqual(resolved["coder_model"], "openrouter/deepseek/deepseek-v4-flash")
 
     def test_to_execution_config_dict_roundtrips(self) -> None:
         cfg = BuildConfig(runtime="open_code", models={"coder": "deepseek/deepseek-chat"})


### PR DESCRIPTION
## Summary

Lets SWE-AF run on **either** an Anthropic key **or** an OpenRouter key, and makes the OpenRouter path work with zero extra config — provide only an `OPENROUTER_API_KEY` and it runs DeepSeek out of the box.

## Changes

**Manifest (`agentfield-package.yaml`)** — the two provider keys move into a `require_one_of` group, so `af install` / `af run` require *at least one* of `ANTHROPIC_API_KEY` / `OPENROUTER_API_KEY` (prompting for one and storing it encrypted) instead of forcing an Anthropic key. Adds optional `SWE_DEFAULT_MODEL`.

**Runtime auto-selection (`swe_af/execution/schemas.py`)** — SWE-AF previously chose its runtime only from `SWE_DEFAULT_RUNTIME` (default `claude_code`), so an OpenRouter-only user still hit the `claude_code` runtime and failed. Now, when `SWE_DEFAULT_RUNTIME` is unset:
- an Anthropic key → `claude_code` (unchanged),
- only an OpenRouter key → `open_code`.

On that auto-selected OpenRouter path the model base default is **`openrouter/deepseek/deepseek-v4-flash`**. This is scoped to the auto path only:
- `SWE_DEFAULT_MODEL` / `AI_MODEL` / `HARNESS_MODEL` and per-role `models` overrides still win (base defaults are lowest precedence);
- an **explicit** `SWE_DEFAULT_RUNTIME=open_code` keeps today's `openrouter/minimax/minimax-m2.5` default — existing open_code deployers are unaffected.

## Behaviour matrix

| Env | Runtime | Default model |
| --- | --- | --- |
| `ANTHROPIC_API_KEY` set | `claude_code` | sonnet/haiku (unchanged) |
| `OPENROUTER_API_KEY` only | `open_code` | `openrouter/deepseek/deepseek-v4-flash` |
| `OPENROUTER_API_KEY` + `SWE_DEFAULT_RUNTIME=open_code` | `open_code` | `openrouter/minimax/minimax-m2.5` (unchanged) |
| `OPENROUTER_API_KEY` + `SWE_DEFAULT_MODEL=…` | `open_code` | `…` (override wins) |

## Tests

New `TestOpenRouterAutoSelection` covering the full matrix (auto-select open_code, Anthropic/both/none → claude_code, explicit-runtime override, DeepSeek auto default, minimax preserved for explicit open_code, `SWE_DEFAULT_MODEL` override, end-to-end `BuildConfig`). The two existing open_code tests are made hermetic against ambient provider env. `make check` green: **1027 passed, 1 skipped**.

## Dependency

The `require_one_of` manifest field is consumed by the AgentField CLI added in Agent-Field/agentfield#729 — installing/running with an `af` built before that will ignore the group. The runtime/model behaviour here is independent and works regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
