### PR TITLE
feat: require GH_TOKEN at install (alongside the LLM key)

### DIFF
--- a/agentfield-package.yaml
+++ b/agentfield-package.yaml
@@ -27,6 +27,15 @@ user_environment:
           description: OpenRouter API key (DeepSeek/Qwen/Llama/… — 200+ models)
           type: secret
           scope: global
+  required:
+    # SWE-AF's core loop clones a repo, pushes a branch, and opens a pull
+    # request — all of which need GitHub write access. `gh`/`git` read this
+    # token for authentication (see prompts/github_pr.py). Required so setup
+    # prompts for it up front rather than failing partway through a build.
+    - name: GH_TOKEN
+      description: GitHub token (repo scope) for cloning repos and opening pull requests
+      type: secret
+      scope: global
   optional:
     - name: SWE_DEFAULT_MODEL
       description: Override the model id for every role (e.g. openrouter/deepseek/deepseek-v4-flash)
@@ -35,10 +44,6 @@ user_environment:
       default: http://localhost:8080
     - name: AGENTFIELD_API_KEY
       description: Control-plane API key (if auth is enabled)
-      type: secret
-      scope: global
-    - name: GH_TOKEN
-      description: GitHub token for cloning repos / opening PRs
       type: secret
       scope: global
     - name: NODE_ID


### PR DESCRIPTION
## Summary

SWE-AF's whole point is the delivery loop: **clone a repo → push a branch → open a pull request** — all of which need GitHub write access. The agent shells out to `git push` / `gh pr create`, which authenticate from `GH_TOKEN` (see `prompts/github_pr.py`: *"The `GH_TOKEN` environment variable is already set for authentication"*).

But `GH_TOKEN` was declared **optional**, so `af install` / `af run` never prompted for it — a user could set up the node with just an LLM key and only discover the token was missing once a `build` reached the push/PR step and failed.

## Change

Move `GH_TOKEN` from `optional` to `required`, right next to the `require_one_of` LLM-provider key:

```yaml
user_environment:
  require_one_of:
    - id: llm_provider          # ANTHROPIC_API_KEY or OPENROUTER_API_KEY
      ...
  required:
    - name: GH_TOKEN            # repo scope — clone + push + open PRs
      type: secret
      scope: global
  optional:
    - SWE_DEFAULT_MODEL / AGENTFIELD_SERVER / AGENTFIELD_API_KEY / NODE_ID
```

Now setup prompts for the token up front and stores it encrypted, so the two things a SWE-AF node actually needs — **an LLM key and a GitHub token** — are both required at install time.

Planning-only reasoners (`plan` and friends) don't touch GitHub, but the node's reason for existing is delivering PRs, so a token is a genuine setup requirement rather than an optional extra.

## Verification

Parsed through the AgentField manifest loader (`packages.ParsePackageMetadata`): `required=[GH_TOKEN]`, `require_one_of=1` group, `optional=4` — GH_TOKEN loads as a required secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)