### PR TITLE
chore: stamp config_version: v1 in agentfield-package.yaml

### DIFF
--- a/agentfield-package.yaml
+++ b/agentfield-package.yaml
@@ -1,3 +1,4 @@
+config_version: v1            # manifest schema version (omit = legacy v0)
 name: swe-planner
 version: 0.1.0
 description: SWE planning/execution agent node (plans and executes software-engineering tasks)


### PR DESCRIPTION
Now that the manifest format is versioned (`config_version`, added in the control plane), stamp SWE-AF's `agentfield-package.yaml` with the current schema version explicitly instead of relying on the implicit legacy default.

- **`config_version: v1`** — v1 is the current format; omitting the key means legacy `v0`. Being explicit future-proofs the manifest against format evolution and matches the guidance in `docs/installing-agent-nodes.md`.
- **No env changes.** SWE-AF already declares the intended install surface: `require_one_of` for the LLM provider (bring **either** an Anthropic **or** an OpenRouter key) plus a required `GH_TOKEN`.

Part of a sweep stamping `config_version: v1` across the agent-node manifests (pr-af, cloudsecurity-af, sec-af).

🤖 Generated with [Claude Code](https://claude.com/claude-code)