### PR TITLE
docs: document `af install` into an AgentField setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,23 @@ This is the core factory-control behavior: control agents supervise worker agent
 
 ## Quick Start
 
+### Install into AgentField (`af install`)
+
+Already running an [AgentField](https://github.com/Agent-Field/agentfield) control plane? Install SWE-AF straight from GitHub — no clone, no local Python setup:
+
+```bash
+af install https://github.com/Agent-Field/SWE-AF
+af run swe-planner
+```
+
+`af install` clones the repo, provisions an isolated Python environment, and registers the `swe-planner` node with your control plane. On first `af run` you're prompted for the required secrets — an LLM provider key (`ANTHROPIC_API_KEY` **or** `OPENROUTER_API_KEY`) plus `GH_TOKEN` — which are stored encrypted and reused across every node, so you enter each only once. Then kick off a build:
+
+```bash
+af call swe-planner.build --in '{"goal": "Add JWT auth", "repo_url": "https://github.com/user/my-repo"}'
+```
+
+New to AgentField? Install the control plane first with `curl -fsSL https://agentfield.ai/install.sh | bash`, or use the Railway / local options below.
+
 ### Deploy with Railway (fastest)
 
 [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/swe-af)


### PR DESCRIPTION
Adds an **Install into AgentField** subsection at the top of Quick Start, documenting the one-command install path for users who already run an [AgentField](https://github.com/Agent-Field/agentfield) control plane:

```bash
af install https://github.com/Agent-Field/SWE-AF
af run <node>
af call <node>.<reasoner> --in '{...}'
```

Explains that `af install` clones the repo, provisions an isolated env, and registers the node; required secrets (e.g. `OPENROUTER_API_KEY`) are prompted once on first `af run`, stored encrypted, and reused across every node. Existing Railway/Docker/local instructions are unchanged. Verified against v0.1.105 (this exact flow installs and runs out of the box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)