### PR TITLE
chore: track agentfield v0.1.108 (SDK re-pin + Python floor bump)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # Reproduce go/Dockerfile's sparse SDK clone; keep in sync with its AGENTFIELD_SDK_REF.
-      AGENTFIELD_SDK_REF: a99510564f31ea11e8cc24bcbc983acff578a700
+      AGENTFIELD_SDK_REF: 795bdd57b4dec884cfe93e16783e8f4bfb2a2a7f
       AGENTFIELD_REPO: https://github.com/Agent-Field/agentfield.git
       GOWORK: off
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # Reproduce go/Dockerfile's sparse SDK clone; keep in sync with its AGENTFIELD_SDK_REF.
-      AGENTFIELD_SDK_REF: 55ad55f3159234bcc354a4bc37abeaf616b252ca
+      AGENTFIELD_SDK_REF: a99510564f31ea11e8cc24bcbc983acff578a700
       AGENTFIELD_REPO: https://github.com/Agent-Field/agentfield.git
       GOWORK: off
     steps:

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -22,7 +22,7 @@ FROM golang:1.23-bookworm AS builder
 
 # Pinned AgentField SDK ref. Default = agentfield origin/main HEAD at port time
 # (v0.1.107-rc.1). Changing this string invalidates the clone layer below.
-ARG AGENTFIELD_SDK_REF=a99510564f31ea11e8cc24bcbc983acff578a700
+ARG AGENTFIELD_SDK_REF=795bdd57b4dec884cfe93e16783e8f4bfb2a2a7f
 ARG AGENTFIELD_REPO=https://github.com/Agent-Field/agentfield.git
 
 WORKDIR /src

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -22,7 +22,7 @@ FROM golang:1.23-bookworm AS builder
 
 # Pinned AgentField SDK ref. Default = agentfield origin/main HEAD at port time
 # (v0.1.107-rc.1). Changing this string invalidates the clone layer below.
-ARG AGENTFIELD_SDK_REF=55ad55f3159234bcc354a4bc37abeaf616b252ca
+ARG AGENTFIELD_SDK_REF=a99510564f31ea11e8cc24bcbc983acff578a700
 ARG AGENTFIELD_REPO=https://github.com/Agent-Field/agentfield.git
 
 WORKDIR /src

--- a/go/Makefile
+++ b/go/Makefile
@@ -39,7 +39,7 @@ run-fast:
 # AgentField SDK ref are overridable:
 #   make docker-build IMAGE=myrepo/swe-af-go:dev AGENTFIELD_SDK_REF=<sha>
 IMAGE ?= swe-af-go:latest
-AGENTFIELD_SDK_REF ?= 55ad55f3159234bcc354a4bc37abeaf616b252ca
+AGENTFIELD_SDK_REF ?= a99510564f31ea11e8cc24bcbc983acff578a700
 
 # Build the multi-stage Go image from the repo root.
 docker-build:

--- a/go/Makefile
+++ b/go/Makefile
@@ -39,7 +39,7 @@ run-fast:
 # AgentField SDK ref are overridable:
 #   make docker-build IMAGE=myrepo/swe-af-go:dev AGENTFIELD_SDK_REF=<sha>
 IMAGE ?= swe-af-go:latest
-AGENTFIELD_SDK_REF ?= a99510564f31ea11e8cc24bcbc983acff578a700
+AGENTFIELD_SDK_REF ?= 795bdd57b4dec884cfe93e16783e8f4bfb2a2a7f
 
 # Build the multi-stage Go image from the repo root.
 docker-build:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.12"
 dependencies = [
     # >=0.1.96 ships ReasonerFailed, which build() raises so an empty build
     # reports `failed` (not `succeeded`) with its result preserved (#82 Gap 2).
-    "agentfield>=0.1.96",
+    "agentfield>=0.1.108",
     "pydantic>=2.0",
     # Compatibility pin: newer SDK builds have surfaced
     # "Unknown message type: rate_limit_event" during streaming.

--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -2,7 +2,7 @@
 #
 # Same runtime dependencies as requirements.txt.
 
-agentfield>=0.1.96
+agentfield>=0.1.108
 pydantic>=2.0
 claude-agent-sdk==0.1.20
 hax-sdk>=0.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 #
 # Install: python -m pip install -r requirements.txt
 
-agentfield>=0.1.96
+agentfield>=0.1.108
 pydantic>=2.0
 claude-agent-sdk==0.1.20
 hax-sdk>=0.2.4


### PR DESCRIPTION
## Summary
Tracks the agentfield **v0.1.108** release across every place SWE-AF references it — both the Go SDK source pin and the Python dependency floors.

## Changes Made
- **Go SDK pin** (`.github/workflows/ci.yml`, `go/Dockerfile`, `go/Makefile`): `AGENTFIELD_SDK_REF` → `795bdd57` (the `v0.1.108` release commit on agentfield `main`). Context: #750 was squash-merged, so the previous pin lived only on a deletable PR branch; this pin is reachable from `main`/the release tag permanently. `sdk/go` content is byte-identical across old and new pins (verified empty diff).
- **Python floors** (`pyproject.toml`, `requirements.txt`, `requirements-docker.txt`): `agentfield>=0.1.96` → `>=0.1.108`, so Docker layer caches re-resolve the new release instead of restoring a stale cached install.

## Verification
- CI-style sparse-clone + fetch-by-SHA of the new pin reproduced locally; `GOWORK=off go build ./...` + `go vet` green against it
- Full Python suite in a fresh venv resolving **agentfield 0.1.108 from PyPI**: `1037 passed, 1 skipped`; `compileall` clean

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)