### PR TITLE
feat(go): af install via the //go subdirectory selector

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -166,14 +166,20 @@ authoritative set. The per-request build config JSON (`runtime`, `models`,
 budget/iteration knobs) is byte-identical to the Python node's — see the root
 [README](../README.md) and `.env.example` for the schema and examples.
 
-## Deployment: no `af install` (yet)
+## Deployment: `af install` via the subdirectory selector
 
-`af install <this repo>` installs the **Python** node: the only
-`agentfield-package.yaml` in this repository is the root one, which declares
-the Python entrypoint (`python -m swe_af`, node id `swe-planner`). There is no
-Go manifest, so the Go nodes deploy via **Docker image / compose / binary**.
-The upstream AgentField installer does support Go nodes (`language: go` +
-`entrypoint.build`), and a subdirectory selector (`af install <repo> --path go`)
-is in flight — once both are released, shipping a `go/agentfield-package.yaml`
-would make the Go node installable the same way. Until then: compose add-on or
-bare binary.
+This directory ships its own `agentfield-package.yaml` (node `swe-planner-go`),
+so the Go node installs like any other package — address the subdirectory with
+the installer's `//` selector:
+
+```bash
+af install https://github.com/Agent-Field/SWE-AF//go
+af run swe-planner-go       # builds bin/swe-planner at install time (needs Go)
+af uninstall swe-planner-go
+```
+
+The root manifest still installs the **Python** node (`swe-planner`); both can
+be installed side by side — the registry is keyed by manifest name. The SDK is
+pinned in `go.mod` by pseudo-version (the same commit the Dockerfile pins), so
+the module resolves without the dev workspace. Docker image / compose / bare
+binary remain the container deployment paths.

--- a/go/agentfield-package.yaml
+++ b/go/agentfield-package.yaml
@@ -1,0 +1,56 @@
+config_version: v1
+name: swe-planner-go                    # MUST differ from root "swe-planner" (installer registry is keyed by name)
+version: 0.1.0
+description: Autonomous SWE planning/execution agent node (Go port; 5 orchestrators + 25 role reasoners)
+author: Agent-Field
+language: go                            # explicit (also auto-detected from go.mod)
+
+entrypoint:
+  build: ./cmd/swe-planner
+  start: bin/swe-planner
+  healthcheck: /health
+
+agent_node:
+  node_id: swe-planner-go
+  default_port: 8005
+
+user_environment:
+  require_one_of:
+    # SWE-AF runs on either Claude (Anthropic) or open models via OpenRouter.
+    # Provide one. With only an OpenRouter key it auto-selects the open_code
+    # runtime.
+    - id: llm_provider
+      description: an LLM provider key
+      options:
+        - name: ANTHROPIC_API_KEY
+          description: Anthropic API key (Claude)
+          type: secret
+          scope: global
+        - name: OPENROUTER_API_KEY
+          description: OpenRouter API key (DeepSeek/Qwen/Llama/… — 200+ models)
+          type: secret
+          scope: global
+  required:
+    # The core loop clones a repo, pushes a branch, and opens a pull request —
+    # all of which need GitHub write access.
+    - name: GH_TOKEN
+      description: GitHub token (repo scope) for cloning repos and opening pull requests
+      type: secret
+      scope: global
+  optional:
+    - name: SWE_DEFAULT_RUNTIME
+      description: Coding runtime for every role (claude_code | open_code | codex)
+    - name: SWE_DEFAULT_MODEL
+      description: Override the model id for every role (e.g. openrouter/deepseek/deepseek-v4-flash)
+    - name: AGENTFIELD_SERVER
+      description: Control-plane URL
+      default: http://localhost:8080
+    - name: AGENTFIELD_API_KEY
+      description: Control-plane API key (if auth is enabled)
+      type: secret
+      scope: global
+  # NODE_ID and PORT are deliberately NOT declared here: the installer's
+  # runner assigns the port (injected as PORT) and the binary defaults the
+  # identity — a manifest default would override the runner's assignment,
+  # because resolved user_environment values are appended last to the
+  # process env.

--- a/go/go.mod
+++ b/go/go.mod
@@ -5,7 +5,7 @@ module github.com/Agent-Field/SWE-AF/go
 go 1.21
 
 require (
-	github.com/Agent-Field/agentfield/sdk/go v0.0.0-00010101000000-000000000000
+	github.com/Agent-Field/agentfield/sdk/go v0.0.0-20260713163335-795bdd57b4de
 	github.com/invopop/jsonschema v0.13.0
 	golang.org/x/sync v0.11.0
 )
@@ -19,8 +19,8 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-// No sdk/go/vX.Y.Z submodule tags exist, so a normal versioned require is
-// impossible. Dev uses the go.work workspace; CI/Docker place the agentfield
-// repo as a sibling checkout at a pinned SHA and rely on this replace
-// (design §1.2). Path is two levels up from SWE-AF/go: ../.. -> the shared parent of both checkouts.
-replace github.com/Agent-Field/agentfield/sdk/go => ../../agentfield/sdk/go
+// The SDK has no sdk/go/vX.Y.Z submodule tags, so it is pinned by
+// pseudo-version above — the same commit go/Dockerfile pins via
+// AGENTFIELD_SDK_REF. Bump both together. Dev can still layer a local
+// checkout on top with the go.work workspace; nothing here depends on a
+// sibling checkout anymore, which is what makes `af install …//go` work.

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,3 +1,5 @@
+github.com/Agent-Field/agentfield/sdk/go v0.0.0-20260713163335-795bdd57b4de h1:GYwOpQQheZ53FgmPta3PJ2CKQjATnPIMwAvNsBA7vF4=
+github.com/Agent-Field/agentfield/sdk/go v0.0.0-20260713163335-795bdd57b4de/go.mod h1:08VZk14uw4GJH6a34psHkuLu+DcRr197Zi0IGmLlfrM=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=


### PR DESCRIPTION
Ships the `go/agentfield-package.yaml` that the go README's "Deployment: no `af install` (yet)" section was waiting for — the installer's subdirectory selector landed in Agent-Field/agentfield#752, so the Go node is now installable directly:

```bash
af install https://github.com/Agent-Field/SWE-AF//go
af run swe-planner-go
```

**What changed**

- **`go/agentfield-package.yaml`** (new): node `swe-planner-go`, `language: go`, `entrypoint.build ./cmd/swe-planner` → `bin/swe-planner`, same `user_environment` contract as the Python root manifest. `NODE_ID`/`PORT` are deliberately *not* declared — manifest defaults are appended after the runner's injected env, so a `PORT` default would override the installer's port assignment (verified live).
- **`go/go.mod`**: the local `replace` for the SDK pointed outside the package, making any installed copy unbuildable (`af install` refuses out-of-tree replaces with a pointed error). The SDK is now required by **pseudo-version at the exact commit `go/Dockerfile` already pins** (`AGENTFIELD_SDK_REF` 795bdd57) — resolves anywhere, no sibling checkout needed. Dev workspaces can still layer a local checkout via `go.work`; bump the pseudo-version and `AGENTFIELD_SDK_REF` together.
- **`go/README.md`**: deployment section rewritten around the new install path.

**Verified on Windows** (installer from Agent-Field/agentfield#752): install → `go build` at install time → `af run` (registers 30 reasoners, honors the assigned port) → `af uninstall` (clean removal, including node-scoped secrets). Python `swe-planner` and Go `swe-planner-go` install side by side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
