### PR TITLE
feat(go): make the Go node installable — manifest + resolvable SDK pin

### DIFF
--- a/go/agentfield-package.yaml
+++ b/go/agentfield-package.yaml
@@ -1,0 +1,51 @@
+config_version: v1
+name: swe-planner-go                    # MUST differ from root "swe-planner" (installer registry is keyed by name)
+version: 0.1.0
+description: SWE planning/execution agent node (Go port — plans and executes software-engineering tasks)
+author: Agent-Field
+language: go                            # explicit (also auto-detected from go/go.mod)
+
+entrypoint:
+  build: ./cmd/swe-planner
+  start: bin/swe-planner
+  healthcheck: /health
+
+agent_node:
+  node_id: swe-planner-go
+  default_port: 8005
+
+user_environment:
+  require_one_of:
+    # Same provider story as the Python node: Claude (Anthropic) or open
+    # models via OpenRouter. Provide one.
+    - id: llm_provider
+      description: an LLM provider key
+      options:
+        - name: ANTHROPIC_API_KEY
+          description: Anthropic API key (Claude)
+          type: secret
+          scope: global
+        - name: OPENROUTER_API_KEY
+          description: OpenRouter API key (DeepSeek/Qwen/Llama/… — 200+ models)
+          type: secret
+          scope: global
+  required:
+    # The core loop clones a repo, pushes a branch, and opens a pull request —
+    # all of which need GitHub write access (same as the Python node).
+    - name: GH_TOKEN
+      description: GitHub token (repo scope) for cloning repos and opening pull requests
+      type: secret
+      scope: global
+  optional:
+    - name: SWE_DEFAULT_MODEL
+      description: Override the model id for every role (e.g. openrouter/deepseek/deepseek-v4-flash)
+    - name: AGENTFIELD_SERVER
+      description: Control-plane URL
+      default: http://localhost:8080
+    - name: AGENTFIELD_API_KEY
+      description: Control-plane API key (if auth is enabled)
+      type: secret
+      scope: global
+    - name: NODE_ID
+      description: Identity this node registers under
+      default: swe-planner-go

--- a/go/go.mod
+++ b/go/go.mod
@@ -5,7 +5,7 @@ module github.com/Agent-Field/SWE-AF/go
 go 1.21
 
 require (
-	github.com/Agent-Field/agentfield/sdk/go v0.0.0-00010101000000-000000000000
+	github.com/Agent-Field/agentfield/sdk/go v0.0.0-20260714191100-2cc5fe2adcf4
 	github.com/invopop/jsonschema v0.13.0
 	golang.org/x/sync v0.11.0
 )
@@ -18,9 +18,3 @@ require (
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-// No sdk/go/vX.Y.Z submodule tags exist, so a normal versioned require is
-// impossible. Dev uses the go.work workspace; CI/Docker place the agentfield
-// repo as a sibling checkout at a pinned SHA and rely on this replace
-// (design §1.2). Path is two levels up from SWE-AF/go: ../.. -> the shared parent of both checkouts.
-replace github.com/Agent-Field/agentfield/sdk/go => ../../agentfield/sdk/go

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,3 +1,5 @@
+github.com/Agent-Field/agentfield/sdk/go v0.0.0-20260714191100-2cc5fe2adcf4 h1:B3uCMLZSa2rsRDRGuecBIXCgkYqBuScSK4CXKPDaCgk=
+github.com/Agent-Field/agentfield/sdk/go v0.0.0-20260714191100-2cc5fe2adcf4/go.mod h1:08VZk14uw4GJH6a34psHkuLu+DcRr197Zi0IGmLlfrM=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=


### PR DESCRIPTION
## What

Makes the Go node installable: `af install https://github.com/Agent-Field/SWE-AF//go` now works.

It failed twice over:
1. **No `go/agentfield-package.yaml`** — the manifest the installer's `//subdir` contract requires (pr-af's Go port has one; this repo's never did).
2. **`go/go.mod` pinned the SDK to the zero placeholder** (`v0.0.0-00010101…`) behind `replace => ../../agentfield/sdk/go` — resolvable only on a dev checkout with the monorepo sitting beside this repo.

## Changes

- **`go/agentfield-package.yaml`** (new): `config_version: v1`, name `swe-planner-go` (must differ from the root `swe-planner` — the registry is keyed by name), entrypoint `build: ./cmd/swe-planner` / `start: bin/swe-planner`, port 8005, and the same `user_environment` contract as the Python node (Anthropic **or** OpenRouter key, `GH_TOKEN` required, `SWE_DEFAULT_MODEL` etc. optional).
- **`go/go.mod` / `go.sum`**: drop the `replace`, pin the SDK to the same resolvable pseudo-version `pr-af//go` ships with. Dev flow unchanged — `go.work` overrides the `require` locally.

## Verification

`af install <local clone>//go` end-to-end: manifest parsed (provider choice + required/optional env recognized), `go build` succeeded standalone, `swe-planner-go` registered, uninstalled cleanly. `go build ./...` also passes from a bare clone with no sibling monorepo.

## Follow-up

Once merged, the AgentField Desktop catalog re-adds the `swe-planner-go` entry (it was removed because this install path was broken).

🤖 Generated with [Claude Code](https://claude.com/claude-code)