### PR TITLE
chore: track agentfield v0.1.111 (SDK re-pin + Python floor bump)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # Reproduce go/Dockerfile's sparse SDK clone; keep in sync with its AGENTFIELD_SDK_REF.
-      AGENTFIELD_SDK_REF: 795bdd57b4dec884cfe93e16783e8f4bfb2a2a7f
+      AGENTFIELD_SDK_REF: dfb5c8a37f93f510f3e390bd515afd9154194066
       AGENTFIELD_REPO: https://github.com/Agent-Field/agentfield.git
       GOWORK: off
     steps:

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -22,7 +22,7 @@ FROM golang:1.23-bookworm AS builder
 
 # Pinned AgentField SDK ref. Default = agentfield origin/main HEAD at port time
 # (v0.1.107-rc.1). Changing this string invalidates the clone layer below.
-ARG AGENTFIELD_SDK_REF=795bdd57b4dec884cfe93e16783e8f4bfb2a2a7f
+ARG AGENTFIELD_SDK_REF=dfb5c8a37f93f510f3e390bd515afd9154194066
 ARG AGENTFIELD_REPO=https://github.com/Agent-Field/agentfield.git
 
 WORKDIR /src

--- a/go/Makefile
+++ b/go/Makefile
@@ -39,7 +39,7 @@ run-fast:
 # AgentField SDK ref are overridable:
 #   make docker-build IMAGE=myrepo/swe-af-go:dev AGENTFIELD_SDK_REF=<sha>
 IMAGE ?= swe-af-go:latest
-AGENTFIELD_SDK_REF ?= 795bdd57b4dec884cfe93e16783e8f4bfb2a2a7f
+AGENTFIELD_SDK_REF ?= dfb5c8a37f93f510f3e390bd515afd9154194066
 
 # Build the multi-stage Go image from the repo root.
 docker-build:

--- a/go/go.mod
+++ b/go/go.mod
@@ -5,7 +5,7 @@ module github.com/Agent-Field/SWE-AF/go
 go 1.21
 
 require (
-	github.com/Agent-Field/agentfield/sdk/go v0.0.0-20260713163335-795bdd57b4de
+	github.com/Agent-Field/agentfield/sdk/go v0.0.0-20260720184209-dfb5c8a37f93
 	github.com/invopop/jsonschema v0.13.0
 	golang.org/x/sync v0.11.0
 )

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,5 +1,7 @@
 github.com/Agent-Field/agentfield/sdk/go v0.0.0-20260713163335-795bdd57b4de h1:GYwOpQQheZ53FgmPta3PJ2CKQjATnPIMwAvNsBA7vF4=
 github.com/Agent-Field/agentfield/sdk/go v0.0.0-20260713163335-795bdd57b4de/go.mod h1:08VZk14uw4GJH6a34psHkuLu+DcRr197Zi0IGmLlfrM=
+github.com/Agent-Field/agentfield/sdk/go v0.0.0-20260720184209-dfb5c8a37f93 h1:J0MecY4o7QpRWdl5CVcIw75EZP5FGn01taJKJ9MmhnM=
+github.com/Agent-Field/agentfield/sdk/go v0.0.0-20260720184209-dfb5c8a37f93/go.mod h1:08VZk14uw4GJH6a34psHkuLu+DcRr197Zi0IGmLlfrM=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.12"
 dependencies = [
     # >=0.1.96 ships ReasonerFailed, which build() raises so an empty build
     # reports `failed` (not `succeeded`) with its result preserved (#82 Gap 2).
-    "agentfield>=0.1.108",
+    "agentfield>=0.1.111",
     "pydantic>=2.0",
     # Compatibility pin: newer SDK builds have surfaced
     # "Unknown message type: rate_limit_event" during streaming.

--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -2,7 +2,7 @@
 #
 # Same runtime dependencies as requirements.txt.
 
-agentfield>=0.1.108
+agentfield>=0.1.111
 pydantic>=2.0
 claude-agent-sdk==0.1.20
 hax-sdk>=0.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 #
 # Install: python -m pip install -r requirements.txt
 
-agentfield>=0.1.108
+agentfield>=0.1.111
 pydantic>=2.0
 claude-agent-sdk==0.1.20
 hax-sdk>=0.2.4


### PR DESCRIPTION
## Summary

agentfield **v0.1.111** ships `model#variant` reasoning-effort support in all three SDK harnesses (Agent-Field/agentfield#801) — the piece the `SWE_MODEL_*` tier vars' optional `#variant` suffix (#100) rides on. This bump makes both SWE-AF nodes consume it:

- **Python floor** `agentfield>=0.1.108` → `>=0.1.111` in `pyproject.toml`, `requirements.txt`, `requirements-docker.txt` — the constraint-string change forces Docker layer rebuilds to actually pull the new release instead of serving the cached SDK.
- **Go SDK pin** → the v0.1.111 release commit (`dfb5c8a`) in `go/go.mod`/`go.sum`, plus the matching `AGENTFIELD_SDK_REF` in `.github/workflows/ci.yml`, `go/Dockerfile`, and `go/Makefile` (same file set as #95, the previous re-pin).

## Validation

- Fresh 3.12 venv from the committed tree: `pip install -e ".[dev]"` resolves **agentfield 0.1.111 from PyPI**, and the installed release contains the variant helper (`split_model_variant` importable and functional) — i.e. the released artifact really has #801.
- `make check` with 0.1.111 installed: **1052 passed, 1 skipped**.
- Go with the new pin (`GOWORK=off`, Go 1.23 toolchain): `gofmt`/`go build`/`go vet`/`go test -race ./...` — all packages ok.

With this merged, the full stack is live end-to-end: `SWE_MODEL_HIGH=openrouter/z-ai/glm-5.2#high` etc. resolve per role tier and the harness passes `--variant high` to opencode / `model_reasoning_effort` to codex on both the Python and Go nodes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)