### PR TITLE
fix(runtime): resolve codex .cmd shim path so Windows spawns don't fail

### DIFF
--- a/swe_af/runtime/codex_harness_patch.py
+++ b/swe_af/runtime/codex_harness_patch.py
@@ -88,8 +88,16 @@ async def _run_codex_cli_with_stdin(
     env: dict[str, str] | None,
     cwd: str | None,
 ) -> tuple[str, str, int]:
+    # Windows: CreateProcess does no PATHEXT resolution, and npm installs the
+    # codex CLI only as a .cmd shim — spawning the bare name raises
+    # FileNotFoundError ([WinError 2]) on every call even though the shell
+    # finds it. resolve_cli_command resolves the shim's real path via
+    # shutil.which (a no-op on POSIX and for names that already carry a path).
+    from agentfield.harness._cli import resolve_cli_command
+
     proc = await asyncio.create_subprocess_exec(
-        *cmd,
+        resolve_cli_command(cmd[0]),
+        *cmd[1:],
         stdin=asyncio.subprocess.PIPE,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,

--- a/tests/test_codex_harness_patch.py
+++ b/tests/test_codex_harness_patch.py
@@ -108,3 +108,46 @@ def test_non_codex_prompt_suffix_keeps_agentfield_write_tool_default(tmp_path) -
 
     assert "Write tool" in suffix
     assert "Codex CLI" not in suffix
+
+
+def test_run_codex_cli_spawns_via_resolved_command(monkeypatch) -> None:
+    """The spawn must route cmd[0] through the SDK's resolve_cli_command.
+
+    On Windows, npm installs the codex CLI only as a .cmd shim, and
+    CreateProcess does no PATHEXT resolution — spawning the bare name fails
+    with FileNotFoundError ([WinError 2]) on every codex harness call.
+    resolve_cli_command resolves the shim's real path (no-op on POSIX).
+    """
+    import asyncio
+
+    import agentfield.harness._cli as sdk_cli
+
+    from swe_af.runtime.codex_harness_patch import _run_codex_cli_with_stdin
+
+    spawned: dict = {}
+
+    class FakeProc:
+        returncode = 0
+
+        async def communicate(self, data: bytes) -> tuple[bytes, bytes]:
+            spawned["stdin"] = data
+            return b"", b""
+
+    async def fake_exec(program: str, *args: str, **kwargs: object) -> FakeProc:
+        spawned["program"] = program
+        spawned["args"] = args
+        return FakeProc()
+
+    monkeypatch.setattr(sdk_cli, "resolve_cli_command", lambda name: f"resolved::{name}")
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+    stdout, stderr, returncode = asyncio.run(
+        _run_codex_cli_with_stdin(
+            ["codex", "exec", "--json"], "prompt", env=None, cwd=None
+        )
+    )
+
+    assert spawned["program"] == "resolved::codex"
+    assert spawned["args"][:2] == ("exec", "--json")
+    assert spawned["stdin"] == b"prompt"
+    assert (stdout, stderr, returncode) == ("", "", 0)


### PR DESCRIPTION
## Summary

On Windows, every codex harness call fails instantly with `[WinError 2] The system cannot find the file specified`. `_run_codex_cli_with_stdin` in `swe_af/runtime/codex_harness_patch.py` spawns the bare `"codex"` name via `asyncio.create_subprocess_exec`, but `CreateProcess` does no PATHEXT resolution and npm installs the codex CLI only as a `.cmd` shim — so the spawn never finds it, even though the shell does.

The AgentField SDK already ships the fix for exactly this (`agentfield.harness._cli.resolve_cli_command`, which resolves the shim's real path via `shutil.which` and is a no-op on POSIX), but this monkeypatch bypasses the SDK's spawn path and never picked it up. Mac/Linux never hit the bug, which is how it went unnoticed.

## Symptoms

- Any reasoner using the codex runtime on a Windows node fails in ~500ms with its fallback result (e.g. retry advisor returns "Retry advisor agent failed to produce a valid analysis").
- Node log shows `Schema validation retry N/2: The output file was NOT created.` followed by `Schema retry N provider error: [WinError 2] The system cannot find the file specified`.

## Changes Made

- Route `cmd[0]` through the SDK's `resolve_cli_command` before `create_subprocess_exec` (no-op on POSIX and for paths that already carry a separator).
- Regression test asserting the spawn receives the resolved command, with args and stdin passthrough unchanged.

## Test Plan

- [x] `make check` green (1130 passed, 1 skipped) on Python 3.12
- [x] Verified on a real Windows node: with this patch applied to the installed package, `run_retry_advisor` invoked with `ai_provider=codex` / `model=gpt-5.6-luna` returns real structured advice through the codex CLI (previously the instant WinError 2 fallback)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)