### PR TITLE
fix(planning): make auto model defaults runtime-aware; surface empty harness completions distinctly

### DIFF
--- a/swe_af/app.py
+++ b/swe_af/app.py
@@ -1449,8 +1449,13 @@ async def plan(
     ``_default_runtime``). Any explicitly passed value always wins.
     """
     # Resolve provider/model defaults from the environment (see docstring).
+    # The model default is resolved *for the chosen runtime* so it can never
+    # hand a provider-prefixed id (e.g. an ``openrouter/…`` model) to a runtime
+    # whose CLI can't consume it — the cross-runtime leak that caused silent
+    # ~1s empty completions when a caller pinned ``codex`` under OpenRouter-only
+    # env. Explicit ``ai_provider`` still wins; only the auto default is gated.
     ai_provider = ai_provider or _default_runtime()
-    default_model = _default_planning_model()
+    default_model = _default_planning_model(ai_provider)
     pm_model = pm_model or default_model
     architect_model = architect_model or default_model
     tech_lead_model = tech_lead_model or default_model

--- a/swe_af/execution/fatal_error.py
+++ b/swe_af/execution/fatal_error.py
@@ -56,6 +56,36 @@ class FatalHarnessError(RuntimeError):
         self.original_message = message
 
 
+class EmptyHarnessCompletionError(RuntimeError):
+    """Raised when a harness call completes but produces no output at all.
+
+    Distinct from a *schema-invalid* completion (output present but unparseable
+    into the target schema). An empty completion — the harness returned with no
+    parsed object and no raw text, typically in ~1s — almost always means the
+    provider/model pairing is wrong: e.g. a model id prefixed for a *different*
+    runtime (an ``openrouter/…`` model handed to the codex CLI's OpenAI
+    backend, which doesn't know it) or missing/invalid auth for the selected
+    provider. Collapsing this into the generic "failed to produce a valid
+    <artifact>" message makes it indistinguishable from a genuine schema-quality
+    failure, so this error names the provider and model explicitly to point at
+    the real root cause.
+    """
+
+    def __init__(self, *, role: str, provider: str, model: str, detail: str = "") -> None:
+        message = (
+            f"{role} harness returned an empty completion "
+            f"(provider={provider}, model={model}) — check provider "
+            f"auth/model compatibility"
+        )
+        if detail:
+            message = f"{message}: {detail}"
+        super().__init__(message)
+        self.role = role
+        self.provider = provider
+        self.model = model
+        self.original_message = detail
+
+
 def is_fatal_error(error_message: str) -> bool:
     """Return True if *error_message* matches a known fatal API error pattern."""
     if not error_message:
@@ -86,3 +116,51 @@ def check_fatal_harness_error(result) -> None:
     msg = getattr(result, "error_message", "") or ""
     if is_fatal_error(msg):
         raise FatalHarnessError(msg)
+
+
+def _harness_output_text(result) -> str:
+    """Best-effort raw completion text from a HarnessResult-like object.
+
+    Reads ``result`` (the raw completion string) first, falling back to the
+    ``text`` convenience property. Returns ``""`` when neither is populated.
+    """
+    raw = getattr(result, "result", None)
+    if not raw:
+        raw = getattr(result, "text", None)
+    return raw or ""
+
+
+def check_empty_harness_completion(
+    result, *, role: str, provider: str, model: str
+) -> None:
+    """Raise ``EmptyHarnessCompletionError`` when a harness produced no output.
+
+    Call *after* ``check_fatal_harness_error`` and *before* the caller's
+    ``parsed is None`` schema-quality check. This fires only for the "empty
+    completion" shape — neither a parsed object nor any raw text — which is the
+    signature of a provider/model mismatch (a model id meant for a different
+    runtime, or bad auth) rather than a schema-quality problem. When raw text
+    *is* present but couldn't be parsed, this is a no-op and the caller's
+    generic schema-invalid error (which should also name provider+model) takes
+    over.
+
+    Parameters
+    ----------
+    result:
+        A ``HarnessResult`` (or any object exposing ``parsed`` / ``result`` /
+        ``text`` / ``error_message``).
+    role:
+        Human label for the failing reasoner (e.g. ``"PM"``, ``"Architect"``).
+    provider:
+        The harness provider the call used (e.g. ``"codex"``, ``"opencode"``).
+    model:
+        The model id the call was made with.
+    """
+    if getattr(result, "parsed", None):
+        return
+    if _harness_output_text(result).strip():
+        return
+    detail = (getattr(result, "error_message", "") or "").strip()
+    raise EmptyHarnessCompletionError(
+        role=role, provider=provider, model=model, detail=detail
+    )

--- a/swe_af/execution/fatal_error.py
+++ b/swe_af/execution/fatal_error.py
@@ -118,6 +118,39 @@ def check_fatal_harness_error(result) -> None:
         raise FatalHarnessError(msg)
 
 
+# The SDK classifies terminal harness failures on ``HarnessResult.failure_type``
+# (``FailureType`` in ``agentfield.harness._result``: none/crash/timeout/
+# api_error/no_output/schema). ``schema`` means the harness *did* produce output
+# that simply failed validation — the opposite of an empty completion.
+#
+# That enum is not re-exported from any public ``agentfield`` module, so rather
+# than importing a private symbol we compare on its token. ``FailureType``
+# subclasses ``str``, so the wire value is stable and this works whether the
+# attribute arrives as an enum member or as a plain string. SDKs predating
+# ``failure_type`` yield ``""`` and keep the previous behavior.
+_SCHEMA_FAILURE_TOKEN = "schema"
+
+
+def _failure_type_token(result) -> str:
+    """Normalized ``failure_type`` token, or ``""`` when absent/unreadable."""
+    raw = getattr(result, "failure_type", None)
+    if raw is None:
+        return ""
+    token = getattr(raw, "value", None)
+    if not isinstance(token, str):
+        token = getattr(raw, "name", None)
+    if not isinstance(token, str):
+        token = str(raw)
+    token = token.strip().lower()
+    # Tolerate a repr-ish "failuretype.schema" spelling from str(enum_member).
+    return token.rsplit(".", 1)[-1]
+
+
+def _is_schema_failure(result) -> bool:
+    """Whether the SDK already classified this as a schema-validation failure."""
+    return _failure_type_token(result) == _SCHEMA_FAILURE_TOKEN
+
+
 def _harness_output_text(result) -> str:
     """Best-effort raw completion text from a HarnessResult-like object.
 
@@ -139,16 +172,23 @@ def check_empty_harness_completion(
     ``parsed is None`` schema-quality check. This fires only for the "empty
     completion" shape — neither a parsed object nor any raw text — which is the
     signature of a provider/model mismatch (a model id meant for a different
-    runtime, or bad auth) rather than a schema-quality problem. When raw text
-    *is* present but couldn't be parsed, this is a no-op and the caller's
-    generic schema-invalid error (which should also name provider+model) takes
-    over.
+    runtime, or bad auth) rather than a schema-quality problem.
+
+    It is a no-op — deferring to the caller's generic schema-invalid error,
+    which should also name provider+model — when either:
+
+    - raw text *is* present but couldn't be parsed; or
+    - the SDK already classified the failure as ``failure_type=schema``. That
+      path returns ``result=None`` with no text even though the agent *did*
+      produce output (e.g. it wrote a malformed ``prd.json`` through the Write
+      tool and emitted no closing prose), so the empty-completion shape alone
+      cannot distinguish it from a real provider/model mismatch.
 
     Parameters
     ----------
     result:
         A ``HarnessResult`` (or any object exposing ``parsed`` / ``result`` /
-        ``text`` / ``error_message``).
+        ``text`` / ``failure_type`` / ``error_message``).
     role:
         Human label for the failing reasoner (e.g. ``"PM"``, ``"Architect"``).
     provider:
@@ -156,9 +196,17 @@ def check_empty_harness_completion(
     model:
         The model id the call was made with.
     """
-    if getattr(result, "parsed", None):
+    if getattr(result, "parsed", None) is not None:
         return
     if _harness_output_text(result).strip():
+        return
+    if _is_schema_failure(result):
+        # The SDK's terminal schema-failure path returns result=None with
+        # failure_type=SCHEMA — e.g. an agent that wrote a malformed prd.json
+        # via the Write tool and emitted no closing prose. There *was* output;
+        # it just didn't validate. Calling that an "empty completion — check
+        # provider auth" points at the wrong root cause, so defer to the
+        # caller's schema-invalid message.
         return
     detail = (getattr(result, "error_message", "") or "").strip()
     raise EmptyHarnessCompletionError(

--- a/swe_af/execution/schemas.py
+++ b/swe_af/execution/schemas.py
@@ -17,7 +17,11 @@ from pydantic import (
     model_validator,
 )
 from swe_af.hitl.ask_user import AskUserForm
-from swe_af.runtime.providers import RUNTIME_VALUES, runtime_to_harness_provider
+from swe_af.runtime.providers import (
+    RUNTIME_VALUES,
+    normalize_runtime_provider,
+    runtime_to_harness_provider,
+)
 
 # Global default for all agent max_turns. Change this one value to adjust everywhere.
 DEFAULT_AGENT_MAX_TURNS: int = 150
@@ -709,32 +713,44 @@ def _tier_models_from_env() -> dict[str, str]:
     return tiers
 
 
-def _default_planning_model() -> str:
+def _default_planning_model(runtime: str | None = None) -> str:
     """Model for the planning reasoners (the ``plan`` pipeline) when the caller
-    passes no model.
+    passes no model, resolved for the *given runtime*.
 
     The planning reasoners take an explicit ``model`` argument rather than a
-    runtime ``models={}`` config, so the ``resolve_runtime_models`` cascade
-    doesn't apply to them. This mirrors that cascade for the planning path so an
-    OpenRouter-only deployment is zero-config. The planning reasoners are
-    high-tier roles (see ``ROLE_TO_TIER``), so ``SWE_MODEL_HIGH`` beats the
-    generic default-model env — the same relative precedence tier env vars have
-    in ``resolve_runtime_models``. Precedence, first match wins:
+    runtime ``models={}`` config, so the SDK never runs the
+    ``resolve_runtime_models`` cascade for them. This delegates to that same
+    cascade for the high-tier ``pm`` role so the planning path picks a model
+    that is valid for ``runtime`` — critically, the auto default is
+    runtime-gated and never leaks a provider-prefixed id (e.g. an
+    ``openrouter/…`` model) into a runtime whose CLI cannot consume it. That
+    cross-runtime leak was the root cause of silent ~1s empty completions when a
+    caller pinned ``codex`` in an OpenRouter-only environment.
+
+    ``runtime`` is normalized (aliases like ``claude`` / ``opencode`` accepted).
+    When omitted, the runtime is resolved from the environment via
+    ``_default_runtime`` so callers that don't yet know the runtime keep the
+    historical env-only behavior.
+
+    Precedence is inherited from ``resolve_runtime_models`` (highest first):
 
         1. ``SWE_MODEL_HIGH`` (planning reasoners are high-tier)
         2. deployer env (``SWE_DEFAULT_MODEL`` → ``AI_MODEL`` → ``HARNESS_MODEL``)
-        3. the OpenRouter default when only an OpenRouter key is present
-        4. the Claude ``sonnet`` alias (historical default)
+        3. the runtime's own auto/base default:
+             - ``codex``       → a codex-native model (never ``openrouter/…``)
+             - ``open_code``   → the OpenRouter auto default (OpenRouter-only
+                                 env) or the ``open_code`` base default
+             - ``claude_code`` → the Claude ``sonnet`` alias (historical default)
+
+    Env / explicit values (layers 1–2) still win verbatim — the deployer owns
+    them — so only the auto default (layer 3) is made runtime-aware.
     """
-    high_model = _tier_models_from_env().get("high")
-    if high_model:
-        return high_model
-    env_model = _default_model_from_env()
-    if env_model:
-        return env_model
-    if _openrouter_only_env():
-        return _OPENROUTER_AUTO_DEFAULT_MODEL
-    return "sonnet"
+    resolved_runtime = normalize_runtime_provider(runtime) if runtime else _default_runtime()
+    return resolve_runtime_models(
+        runtime=resolved_runtime,
+        models=None,
+        field_names=["pm_model"],
+    )["pm_model"]
 
 
 def _legacy_hint_for_model_key(key: str) -> str:

--- a/swe_af/execution/schemas.py
+++ b/swe_af/execution/schemas.py
@@ -729,8 +729,23 @@ def _default_planning_model(runtime: str | None = None) -> str:
 
     ``runtime`` is normalized (aliases like ``claude`` / ``opencode`` accepted).
     When omitted, the runtime is resolved from the environment via
-    ``_default_runtime`` so callers that don't yet know the runtime keep the
-    historical env-only behavior.
+    ``_default_runtime`` — and the auto default then follows *that* runtime.
+    Omitting the argument therefore does **not** reproduce the old env-only
+    cascade in every configuration. The old cascade returned ``sonnet`` whenever
+    ``SWE_DEFAULT_RUNTIME`` was set to anything at all (setting it opts out of
+    ``_openrouter_only_env``), so these deployments change behavior:
+
+        SWE_DEFAULT_RUNTIME=open_code, no model env  → was ``sonnet``,
+            now the ``open_code`` base default
+        SWE_DEFAULT_RUNTIME=codex, no model env      → was ``sonnet``,
+            now the codex base default for the active auth mode
+
+    That is the intended fix, not a regression: a deployer who pinned a runtime
+    was silently getting a *Claude* planning model for it. Everything else is
+    unchanged — no ``SWE_DEFAULT_RUNTIME`` (auto-selection, both the
+    OpenRouter-only and the Claude branch), ``SWE_DEFAULT_RUNTIME=claude_code``,
+    and an invalid ``SWE_DEFAULT_RUNTIME`` all resolve exactly as before, as does
+    any configuration that sets a model env var (layers 1–2 below).
 
     Precedence is inherited from ``resolve_runtime_models`` (highest first):
 

--- a/swe_af/reasoners/pipeline.py
+++ b/swe_af/reasoners/pipeline.py
@@ -14,7 +14,10 @@ from pathlib import Path
 
 from pydantic import BaseModel
 
-from swe_af.execution.fatal_error import check_fatal_harness_error
+from swe_af.execution.fatal_error import (
+    check_empty_harness_completion,
+    check_fatal_harness_error,
+)
 from swe_af.execution.schemas import DEFAULT_AGENT_MAX_TURNS
 from swe_af.reasoners.schemas import (
     Architecture,
@@ -217,6 +220,12 @@ async def run_product_manager(
             cwd=repo_path,
         )
         check_fatal_harness_error(result)
+        # An empty completion here (no parsed output, no text) is a
+        # provider/model mismatch, not a schema-quality problem — surface it
+        # distinctly with provider+model instead of the generic PRD message.
+        check_empty_harness_completion(
+            result, role="PM", provider=provider, model=model
+        )
         return result.parsed
 
     initial_prior = list(prior_user_responses or [])
@@ -231,7 +240,13 @@ async def run_product_manager(
     )
 
     if parsed is None:
-        raise RuntimeError("Product manager failed to produce a valid PRD")
+        # Reached only when the harness produced non-empty but unparseable
+        # output (empty completions are raised distinctly above). Name the
+        # provider+model so the failure is diagnosable.
+        raise RuntimeError(
+            f"Product manager failed to produce a valid PRD "
+            f"(provider={provider}, model={model})"
+        )
 
     router.note("PM complete", tags=["pm", "complete"])
     return parsed.model_dump()
@@ -407,8 +422,14 @@ async def run_architect(
         cwd=repo_path,
     )
     check_fatal_harness_error(result)
+    check_empty_harness_completion(
+        result, role="Architect", provider=provider, model=model
+    )
     if result.parsed is None:
-        raise RuntimeError("Architect failed to produce a valid architecture")
+        raise RuntimeError(
+            f"Architect failed to produce a valid architecture "
+            f"(provider={provider}, model={model})"
+        )
 
     router.note("Architect complete", tags=["architect", "complete"])
     return result.parsed.model_dump()
@@ -462,8 +483,14 @@ async def run_tech_lead(
         cwd=repo_path,
     )
     check_fatal_harness_error(result)
+    check_empty_harness_completion(
+        result, role="Tech lead", provider=provider, model=model
+    )
     if result.parsed is None:
-        raise RuntimeError("Tech lead failed to produce a valid review")
+        raise RuntimeError(
+            f"Tech lead failed to produce a valid review "
+            f"(provider={provider}, model={model})"
+        )
 
     review = result.parsed.model_dump()
     review_json_path = os.path.join(base, "plan", "review.json")
@@ -539,8 +566,14 @@ async def run_sprint_planner(
         cwd=repo_path,
     )
     check_fatal_harness_error(result)
+    check_empty_harness_completion(
+        result, role="Sprint planner", provider=provider, model=model
+    )
     if result.parsed is None:
-        raise RuntimeError("Sprint planner failed to produce valid issues")
+        raise RuntimeError(
+            f"Sprint planner failed to produce valid issues "
+            f"(provider={provider}, model={model})"
+        )
 
     router.note("Sprint Planner complete", tags=["sprint_planner", "complete"])
     return {

--- a/tests/test_runtime_aware_model_default.py
+++ b/tests/test_runtime_aware_model_default.py
@@ -1,0 +1,276 @@
+"""Runtime-aware planning-model defaults + distinct empty-completion errors.
+
+Validation contract (see PR "fix(planning): make auto model defaults
+runtime-aware; surface empty harness completions distinctly"):
+
+- OpenRouter-only env + runtime ``codex`` → the auto default is NOT an
+  ``openrouter/``-prefixed id (it is a codex-native model). A caller pinning
+  ``codex`` in an OpenRouter-only environment must never hand the codex CLI a
+  model its OpenAI backend can't resolve (the silent ~1s empty-completion bug).
+- OpenRouter-only env + runtime ``open_code`` → the OpenRouter auto default is
+  preserved (unchanged behavior).
+- runtime ``claude_code`` → the ``sonnet`` historical default is preserved.
+- ``SWE_DEFAULT_MODEL`` (deployer env) wins in every runtime cell.
+- An empty harness completion raises a distinct error that names the provider
+  and the model, separate from the generic schema-invalid message.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from swe_af.execution.fatal_error import (
+    EmptyHarnessCompletionError,
+    check_empty_harness_completion,
+)
+from swe_af.execution.schemas import (
+    _CODEX_CHATGPT_MODEL,
+    _OPENROUTER_AUTO_DEFAULT_MODEL,
+    _default_planning_model,
+)
+
+# open_code's non-auto base default (an explicit open_code runtime, i.e. not
+# the OpenRouter-only auto-selection path). Mirrors _RUNTIME_BASE_MODELS.
+_OPEN_CODE_BASE = "openrouter/minimax/minimax-m2.5"
+
+# Every env var that steers runtime/model selection — cleared before each test
+# so results never depend on the developer's ambient shell.
+_STEERING_ENV_KEYS = (
+    "ANTHROPIC_API_KEY",
+    "OPENROUTER_API_KEY",
+    "OPENAI_API_KEY",
+    "SWE_DEFAULT_RUNTIME",
+    "SWE_DEFAULT_MODEL",
+    "AI_MODEL",
+    "HARNESS_MODEL",
+    "SWE_MODEL_LOW",
+    "SWE_MODEL_MED",
+    "SWE_MODEL_HIGH",
+    "SWE_CODEX_AUTH_MODE",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in _STEERING_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Matrix: (env) x (runtime) -> resolved planning-model default
+# ---------------------------------------------------------------------------
+
+# Env presets applied via monkeypatch.setenv. "swe_default_model" also sets an
+# OpenRouter key to prove the explicit env value wins over the auto default.
+_ENV_PRESETS: dict[str, dict[str, str]] = {
+    "openrouter_only": {"OPENROUTER_API_KEY": "sk-or-test"},
+    "anthropic": {"ANTHROPIC_API_KEY": "sk-ant-test"},
+    "swe_default_model": {
+        "OPENROUTER_API_KEY": "sk-or-test",
+        "SWE_DEFAULT_MODEL": "explicit/model-x",
+    },
+}
+
+# (env_preset, runtime) -> expected resolved default.
+# Under "swe_default_model" the deployer env wins verbatim for every runtime.
+# Under "openrouter_only"/"anthropic" the runtime's own auto/base default is
+# used — critically never an openrouter/ id for codex.
+_MATRIX: list[tuple[str, str, str]] = [
+    ("openrouter_only", "open_code", _OPENROUTER_AUTO_DEFAULT_MODEL),
+    ("openrouter_only", "codex", _CODEX_CHATGPT_MODEL),
+    ("openrouter_only", "claude_code", "sonnet"),
+    ("anthropic", "open_code", _OPEN_CODE_BASE),
+    ("anthropic", "codex", _CODEX_CHATGPT_MODEL),
+    ("anthropic", "claude_code", "sonnet"),
+    ("swe_default_model", "open_code", "explicit/model-x"),
+    ("swe_default_model", "codex", "explicit/model-x"),
+    ("swe_default_model", "claude_code", "explicit/model-x"),
+]
+
+
+@pytest.mark.parametrize(
+    ("env_preset", "runtime", "expected"),
+    _MATRIX,
+    ids=[f"{e}-{r}" for e, r, _ in _MATRIX],
+)
+def test_default_planning_model_matrix(
+    monkeypatch: pytest.MonkeyPatch,
+    env_preset: str,
+    runtime: str,
+    expected: str,
+) -> None:
+    """The resolved planning-model default is correct for each env x runtime."""
+    for key, value in _ENV_PRESETS[env_preset].items():
+        monkeypatch.setenv(key, value)
+
+    assert _default_planning_model(runtime) == expected
+
+
+@pytest.mark.parametrize("env_preset", ["openrouter_only", "anthropic"])
+def test_codex_default_is_never_openrouter_prefixed(
+    monkeypatch: pytest.MonkeyPatch, env_preset: str
+) -> None:
+    """Contract core: pinning codex never yields an openrouter/ model as the
+    auto default, regardless of which provider key happens to be present."""
+    for key, value in _ENV_PRESETS[env_preset].items():
+        monkeypatch.setenv(key, value)
+
+    resolved = _default_planning_model("codex")
+    assert not resolved.startswith("openrouter/"), (
+        f"codex runtime leaked a cross-runtime model id: {resolved!r}"
+    )
+
+
+def test_runtime_aliases_are_normalized(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Alias runtime spellings resolve the same as their canonical form."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    # "opencode" -> open_code, "claude"/"claude-code" -> claude_code
+    assert _default_planning_model("opencode") == _OPENROUTER_AUTO_DEFAULT_MODEL
+    assert _default_planning_model("claude") == "sonnet"
+    assert _default_planning_model("claude-code") == "sonnet"
+
+
+def test_omitted_runtime_falls_back_to_env_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No runtime arg → runtime is resolved from env (historical behavior)."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    # OpenRouter-only env auto-selects open_code, so the auto default applies.
+    assert _default_planning_model() == _OPENROUTER_AUTO_DEFAULT_MODEL
+
+
+# ---------------------------------------------------------------------------
+# Empty-completion detection: distinct from schema-invalid
+# ---------------------------------------------------------------------------
+
+
+def _fake_result(*, parsed=None, result="", error_message=None):
+    """A HarnessResult-like stand-in (parsed/result/error_message + is_error)."""
+    return SimpleNamespace(
+        parsed=parsed,
+        result=result,
+        error_message=error_message,
+        is_error=False,
+    )
+
+
+class TestCheckEmptyHarnessCompletion:
+    def test_empty_completion_raises_naming_provider_and_model(self) -> None:
+        result = _fake_result(parsed=None, result="")
+        with pytest.raises(EmptyHarnessCompletionError) as exc:
+            check_empty_harness_completion(
+                result,
+                role="PM",
+                provider="codex",
+                model="openrouter/deepseek/deepseek-v4-flash",
+            )
+        message = str(exc.value)
+        assert "PM" in message
+        assert "provider=codex" in message
+        assert "model=openrouter/deepseek/deepseek-v4-flash" in message
+        assert "empty completion" in message
+
+    def test_is_runtime_error_subclass(self) -> None:
+        err = EmptyHarnessCompletionError(role="PM", provider="codex", model="m")
+        assert isinstance(err, RuntimeError)
+        # Exposes structured fields for programmatic handling.
+        assert err.provider == "codex"
+        assert err.model == "m"
+        assert err.role == "PM"
+
+    def test_error_message_detail_is_appended(self) -> None:
+        result = _fake_result(parsed=None, result="", error_message="backend refused")
+        with pytest.raises(EmptyHarnessCompletionError, match="backend refused"):
+            check_empty_harness_completion(
+                result, role="Architect", provider="opencode", model="m"
+            )
+
+    def test_unparseable_but_nonempty_output_is_noop(self) -> None:
+        # Text present but not schema-parseable → NOT an empty completion; the
+        # caller's generic schema-invalid path handles it.
+        result = _fake_result(parsed=None, result="this is not valid json")
+        check_empty_harness_completion(
+            result, role="PM", provider="codex", model="m"
+        )  # must not raise
+
+    def test_valid_parsed_output_is_noop(self) -> None:
+        result = _fake_result(parsed=object(), result="")
+        check_empty_harness_completion(
+            result, role="PM", provider="codex", model="m"
+        )  # must not raise
+
+    def test_reads_text_property_when_result_absent(self) -> None:
+        # Object exposing only `.text` (HarnessResult's convenience property).
+        with_text = SimpleNamespace(parsed=None, text="present", is_error=False)
+        check_empty_harness_completion(
+            with_text, role="PM", provider="codex", model="m"
+        )  # non-empty text → no raise
+
+    def test_message_is_distinct_from_generic_schema_invalid(self) -> None:
+        """The empty-completion message must be distinguishable from the generic
+        'failed to produce a valid ...' schema-quality message."""
+        result = _fake_result(parsed=None, result="")
+        with pytest.raises(EmptyHarnessCompletionError) as exc:
+            check_empty_harness_completion(
+                result, role="PM", provider="codex", model="m"
+            )
+        message = str(exc.value)
+        generic = "Product manager failed to produce a valid PRD"
+        assert generic not in message
+        assert "empty completion" in message
+
+
+# ---------------------------------------------------------------------------
+# Reasoner wiring: run_product_manager surfaces the distinct error end-to-end
+# ---------------------------------------------------------------------------
+
+
+def test_run_product_manager_empty_completion_surfaces_provider_and_model(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An empty harness completion inside the PM reasoner raises the distinct
+    error naming the pinned provider+model — not the generic PRD message.
+
+    Reproduces the incident shape: ai_provider='codex' with an openrouter/
+    model id leaked in, harness completes in ~1s with a null message.
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    import swe_af.reasoners.pipeline as pipeline
+
+    # HAX disabled so run_with_ask_user calls the reasoner once (no pause loop).
+    monkeypatch.delenv("HAX_API_KEY", raising=False)
+
+    empty = SimpleNamespace(
+        parsed=None, result="", text="", error_message=None, is_error=False
+    )
+    mock_router = MagicMock()
+    mock_router.harness = AsyncMock(return_value=empty)
+    mock_router.note = MagicMock()
+    mock_router.agentfield_server = "http://localhost:9999"
+
+    real_pm = getattr(pipeline.run_product_manager, "_original_func", pipeline.run_product_manager)
+
+    with patch.object(pipeline, "router", mock_router):
+        with pytest.raises(EmptyHarnessCompletionError) as exc:
+            _run(
+                real_pm(
+                    goal="Build a thing",
+                    repo_path=str(tmp_path),
+                    artifacts_dir=".artifacts",
+                    model="openrouter/deepseek/deepseek-v4-flash",
+                    ai_provider="codex",
+                )
+            )
+
+    message = str(exc.value)
+    assert "provider=codex" in message
+    assert "model=openrouter/deepseek/deepseek-v4-flash" in message
+    assert "Product manager failed to produce a valid PRD" not in message

--- a/tests/test_runtime_aware_model_default.py
+++ b/tests/test_runtime_aware_model_default.py
@@ -29,12 +29,17 @@ from swe_af.execution.fatal_error import (
 from swe_af.execution.schemas import (
     _CODEX_CHATGPT_MODEL,
     _OPENROUTER_AUTO_DEFAULT_MODEL,
+    _RUNTIME_BASE_MODELS,
     _default_planning_model,
 )
 
-# open_code's non-auto base default (an explicit open_code runtime, i.e. not
-# the OpenRouter-only auto-selection path). Mirrors _RUNTIME_BASE_MODELS.
-_OPEN_CODE_BASE = "openrouter/minimax/minimax-m2.5"
+# open_code's base default for an *explicit* open_code runtime (i.e. not the
+# OpenRouter-only auto-selection path). Read straight off the runtime table
+# instead of being duplicated as a literal here: a hardcoded copy silently goes
+# stale every time the default model is rolled (it already did once), and the
+# behavior under test is "an explicit open_code runtime resolves open_code's own
+# base default" — not "…resolves <some specific model id>".
+_OPEN_CODE_BASE = _RUNTIME_BASE_MODELS["open_code"]["pm_model"]
 
 # Every env var that steers runtime/model selection — cleared before each test
 # so results never depend on the developer's ambient shell.
@@ -82,6 +87,10 @@ _ENV_PRESETS: dict[str, dict[str, str]] = {
 # Under "swe_default_model" the deployer env wins verbatim for every runtime.
 # Under "openrouter_only"/"anthropic" the runtime's own auto/base default is
 # used — critically never an openrouter/ id for codex.
+# Note the two open_code rows may resolve to the same id: since the open_code
+# base default and the OpenRouter auto default were unified, the auto-selection
+# path and an explicit open_code runtime land on the same model. They stay
+# separate rows because they exercise different branches of the cascade.
 _MATRIX: list[tuple[str, str, str]] = [
     ("openrouter_only", "open_code", _OPENROUTER_AUTO_DEFAULT_MODEL),
     ("openrouter_only", "codex", _CODEX_CHATGPT_MODEL),
@@ -126,6 +135,18 @@ def test_codex_default_is_never_openrouter_prefixed(
     assert not resolved.startswith("openrouter/"), (
         f"codex runtime leaked a cross-runtime model id: {resolved!r}"
     )
+
+
+@pytest.mark.parametrize("runtime", ["open_code", "codex"])
+def test_non_claude_runtime_default_is_not_the_claude_alias(
+    monkeypatch: pytest.MonkeyPatch, runtime: str
+) -> None:
+    """Contract core (other direction): pinning a non-Claude runtime never falls
+    back to the ``sonnet`` Claude alias, which is what the old env-only cascade
+    returned whenever ``SWE_DEFAULT_RUNTIME`` was set to anything at all."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+
+    assert _default_planning_model(runtime) != "sonnet"
 
 
 def test_runtime_aliases_are_normalized(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_runtime_aware_model_default.py
+++ b/tests/test_runtime_aware_model_default.py
@@ -13,6 +13,11 @@ runtime-aware; surface empty harness completions distinctly"):
 - ``SWE_DEFAULT_MODEL`` (deployer env) wins in every runtime cell.
 - An empty harness completion raises a distinct error that names the provider
   and the model, separate from the generic schema-invalid message.
+- A *schema* failure does NOT raise that error, even though it shares the
+  empty-completion shape (no parsed object, no text): the SDK marks it
+  ``failure_type=schema``, meaning output existed but failed validation, so
+  blaming provider auth would point at the wrong root cause.
+- A parsed object that is valid but falsy counts as a completion.
 """
 
 from __future__ import annotations
@@ -40,6 +45,18 @@ from swe_af.execution.schemas import (
 # behavior under test is "an explicit open_code runtime resolves open_code's own
 # base default" — not "…resolves <some specific model id>".
 _OPEN_CODE_BASE = _RUNTIME_BASE_MODELS["open_code"]["pm_model"]
+
+# The SDK's own SCHEMA failure classification, so the test exercises the real
+# object the harness hands back rather than a look-alike. The enum lives in a
+# private module (it is not re-exported from ``agentfield.harness``), so fall
+# back to the wire value if that ever moves — the production code compares on
+# the token for exactly the same reason.
+try:  # pragma: no cover - import shape depends on the installed SDK
+    from agentfield.harness._result import FailureType as _SdkFailureType
+
+    _SDK_SCHEMA_FAILURE = _SdkFailureType.SCHEMA
+except ImportError:  # pragma: no cover
+    _SDK_SCHEMA_FAILURE = "schema"
 
 # Every env var that steers runtime/model selection — cleared before each test
 # so results never depend on the developer's ambient shell.
@@ -172,12 +189,13 @@ def test_omitted_runtime_falls_back_to_env_resolution(
 # ---------------------------------------------------------------------------
 
 
-def _fake_result(*, parsed=None, result="", error_message=None):
+def _fake_result(*, parsed=None, result="", error_message=None, failure_type=None):
     """A HarnessResult-like stand-in (parsed/result/error_message + is_error)."""
     return SimpleNamespace(
         parsed=parsed,
         result=result,
         error_message=error_message,
+        failure_type=failure_type,
         is_error=False,
     )
 
@@ -226,6 +244,63 @@ class TestCheckEmptyHarnessCompletion:
         check_empty_harness_completion(
             result, role="PM", provider="codex", model="m"
         )  # must not raise
+
+    @pytest.mark.parametrize(
+        "falsy_parsed",
+        [[], {}, "", 0, False],
+        ids=["empty-list", "empty-dict", "empty-str", "zero", "false"],
+    )
+    def test_falsy_but_present_parsed_output_is_noop(self, falsy_parsed) -> None:
+        """A parsed object that is *valid but falsy* (an empty issue list, a
+        model that compares false) is still a completion — it must not be
+        reported as an empty one."""
+        result = _fake_result(parsed=falsy_parsed, result="")
+        check_empty_harness_completion(
+            result, role="Sprint planner", provider="opencode", model="m"
+        )  # must not raise
+
+    @pytest.mark.parametrize(
+        "failure_type",
+        [
+            _SDK_SCHEMA_FAILURE,  # the SDK's own enum member
+            "schema",  # a plain string, for SDKs/mocks that don't use the enum
+            "SCHEMA",
+            "FailureType.SCHEMA",  # str() of the enum member
+        ],
+        ids=["enum", "str", "upper", "enum-repr"],
+    )
+    def test_schema_failure_is_noop(self, failure_type) -> None:
+        """A terminal *schema* failure has the empty-completion shape (no parsed
+        object, no text) but is NOT a provider/auth problem — the agent produced
+        output that simply failed validation, e.g. a malformed prd.json written
+        via the Write tool with no closing prose. Mislabeling it "check provider
+        auth/model compatibility" points at the wrong root cause, so the
+        caller's schema-invalid message must take over instead."""
+        result = _fake_result(parsed=None, result=None, failure_type=failure_type)
+        check_empty_harness_completion(
+            result, role="PM", provider="opencode", model="m"
+        )  # must not raise
+
+    @pytest.mark.parametrize(
+        "failure_type", ["none", "crash", "timeout", "api_error", "no_output"]
+    )
+    def test_non_schema_failure_types_still_raise(self, failure_type: str) -> None:
+        """Only ``schema`` is exempt; every other terminal classification with
+        no parsed object and no text is still an empty completion."""
+        result = _fake_result(parsed=None, result=None, failure_type=failure_type)
+        with pytest.raises(EmptyHarnessCompletionError):
+            check_empty_harness_completion(
+                result, role="PM", provider="codex", model="m"
+            )
+
+    def test_result_without_failure_type_keeps_previous_behavior(self) -> None:
+        """Older SDK results (and hand-rolled stubs) expose no ``failure_type``
+        at all — those must still raise, unchanged."""
+        legacy = SimpleNamespace(parsed=None, result="", is_error=False)
+        with pytest.raises(EmptyHarnessCompletionError):
+            check_empty_harness_completion(
+                legacy, role="PM", provider="codex", model="m"
+            )
 
     def test_reads_text_property_when_result_absent(self) -> None:
         # Object exposing only `.text` (HarnessResult's convenience property).


### PR DESCRIPTION
## Incident

A caller invoked `swe-planner.plan` with `ai_provider="codex"` explicitly and no
model overrides, in an environment where only `OPENROUTER_API_KEY` was set (no
Anthropic/OpenAI keys, no `SWE_DEFAULT_*` vars). Two independent failures
collapsed into one opaque error:

1. **Cross-runtime model-id leakage.** The planning-model default cascade
   (`_default_planning_model()`) resolved from env keys *alone*, ignoring the
   caller's pinned runtime. With only an OpenRouter key present it returned the
   OpenRouter auto-default model id — so the **codex** CLI was spawned with an
   `openrouter/…`-prefixed model its OpenAI backend cannot resolve. Every
   attempt completed in ~1s with a null/empty message.

2. **Opaque empty completions.** The pipeline surfaced only the generic
   "Product manager failed to produce a valid PRD" — indistinguishable from a
   genuine schema-quality failure (a weak model emitting unparseable output).
   One message, two very different root causes.

## What changed

**Runtime-aware auto default** (`fix(planning)`) — `_default_planning_model()`
now takes the resolved runtime and delegates to the already-runtime-aware
`resolve_runtime_models()` cascade for the high-tier `pm` role. `plan()` threads
the resolved `ai_provider` into it. The auto default is gated on runtime:

- `codex` → a codex-native model (never an `openrouter/…`-prefixed id)
- `open_code` → the OpenRouter auto default (OpenRouter-only env) or the
  `open_code` base default otherwise
- `claude_code` → the historical `sonnet` default

Explicitly passed models and deployer env (`SWE_DEFAULT_MODEL` / `AI_MODEL` /
`HARNESS_MODEL`, `SWE_MODEL_HIGH`) still win **verbatim** — only the *auto*
default became runtime-aware.

**Distinct empty-completion error** (`fix(runtime)`) — new
`EmptyHarnessCompletionError` + `check_empty_harness_completion()`, wired into
the PM, architect, tech-lead and sprint-planner reasoners between the
fatal-error check and the `parsed is None` check. An empty completion (no parsed
object *and* no text — the signature of a provider/model mismatch or bad auth)
now raises an error naming the provider and model, e.g.:

> PM harness returned an empty completion (provider=codex,
> model=openrouter/deepseek/deepseek-v4-flash) — check provider auth/model
> compatibility

The generic "failed to produce a valid …" message is kept only for genuinely
non-empty-but-unparseable output, and now also includes provider+model context.

The check is **gated on `failure_type`**. The SDK's terminal schema-validation
path returns `result=None` with `failure_type=SCHEMA`, which has exactly the
empty-completion shape (no parsed object, no text) but a completely different
cause — the agent *did* produce output, e.g. a malformed `prd.json` written via
the Write tool with no closing prose, which simply failed to validate. Telling
that operator to "check provider auth/model compatibility" points at the wrong
thing, so a `schema` classification is a no-op and the schema-invalid message
propagates. Every other classification (`none`/`crash`/`timeout`/`api_error`/
`no_output`) still raises, and results with no `failure_type` attribute at all
keep the previous behavior, so older SDKs are unaffected. The comparison is on
the token rather than an imported symbol because `FailureType` is not
re-exported from any public `agentfield` module.

## Compatibility

**This changes behavior for deployments that pin a non-Claude runtime and set no
model env var.** The old cascade consulted `_openrouter_only_env()`, which
returns `False` as soon as `SWE_DEFAULT_RUNTIME` is set to *anything* — so those
deployments fell through to `sonnet` regardless of which runtime they pinned:

| Config (no `SWE_DEFAULT_MODEL` / `AI_MODEL` / `HARNESS_MODEL` / `SWE_MODEL_HIGH`) | Before | After |
| --- | --- | --- |
| `SWE_DEFAULT_RUNTIME=open_code` | `sonnet` | `open_code` base default |
| `SWE_DEFAULT_RUNTIME=codex`, `OPENAI_API_KEY` set | `sonnet` | `gpt-5.3-codex` |
| `SWE_DEFAULT_RUNTIME=codex`, no `OPENAI_API_KEY` | `sonnet` | `gpt-5.5` |
| `SWE_DEFAULT_RUNTIME=opencode` (alias) | `sonnet` | `open_code` base default |

Everything else resolves exactly as before: no `SWE_DEFAULT_RUNTIME` (both the
OpenRouter-only auto-selection branch and the Claude branch),
`SWE_DEFAULT_RUNTIME=claude_code`, an invalid `SWE_DEFAULT_RUNTIME`, and any
configuration that sets a model env var.

⚠️ **Deployment note.** The concrete case worth calling out:
`SWE_DEFAULT_RUNTIME=open_code` with **only** an `ANTHROPIC_API_KEY` previously
got `sonnet` for planning, which worked because the opencode proxy could serve
it. Those deployments will now get
`openrouter/deepseek/deepseek-v4-flash-0731`, **which requires an
`OPENROUTER_API_KEY`**. This is intentional — it makes the planning models
consistent with the coding loop, which already resolved through
`resolve_runtime_models()` and was therefore already using the OpenRouter
default in the same environment. But it is a real change: such a deployment must
add an `OPENROUTER_API_KEY`, or pin planning explicitly via `SWE_MODEL_HIGH` /
`SWE_DEFAULT_MODEL`.

## Validation Contract

| Contract behavior | Test |
| --- | --- |
| OpenRouter-only env + runtime `codex` → auto default is NOT `openrouter/`-prefixed (codex-native) | `test_default_planning_model_matrix[openrouter_only-codex]`, `test_codex_default_is_never_openrouter_prefixed` |
| OpenRouter-only env + runtime `open_code` → OpenRouter auto default preserved | `test_default_planning_model_matrix[openrouter_only-open_code]` |
| runtime `claude_code` → `sonnet` default preserved | `test_default_planning_model_matrix[*-claude_code]` |
| Pinning a non-Claude runtime never falls back to the `sonnet` Claude alias | `test_non_claude_runtime_default_is_not_the_claude_alias` |
| An explicit `open_code` runtime resolves `open_code`'s own base default | `test_default_planning_model_matrix[anthropic-open_code]` |
| `SWE_DEFAULT_MODEL` / explicit arg wins in all cases | `test_default_planning_model_matrix[swe_default_model-*]`, existing `test_plan_explicit_args_override_env`, `test_plan_swe_default_model_overrides_openrouter_auto` |
| Empty harness completion → error containing provider+model, distinct from schema-invalid message | `TestCheckEmptyHarnessCompletion::*`, `test_run_product_manager_empty_completion_surfaces_provider_and_model` |
| `failure_type=schema` has the empty-completion shape but does NOT raise it | `TestCheckEmptyHarnessCompletion::test_schema_failure_is_noop` (SDK enum, plain string, upper-case, and `str(enum)` spellings) |
| Every other `failure_type` still raises | `TestCheckEmptyHarnessCompletion::test_non_schema_failure_types_still_raise` |
| A result with no `failure_type` attribute keeps the previous behavior | `TestCheckEmptyHarnessCompletion::test_result_without_failure_type_keeps_previous_behavior` |
| A valid-but-falsy parsed object counts as a completion | `TestCheckEmptyHarnessCompletion::test_falsy_but_present_parsed_output_is_noop` |

Also covered: runtime-alias normalization, the omitted-runtime env fallback, and
that non-empty-but-unparseable output is a no-op for the empty-completion check
(so the generic schema-invalid path still fires).

The `open_code` base-default expectation is read off `_RUNTIME_BASE_MODELS`
rather than duplicated as a literal — the literal had already gone stale against
main's default-model roll, so the assertion would have failed on merge while the
resolver was behaving correctly.

## Test results

Both runs on Python 3.12 with `AGENTFIELD_SERVER` set, matching CI:

- **Branch head**: `make check` (full pytest suite + `compileall`) — 1168 passed,
  1 skipped.
- **Merged with `main`**: `make check` — 1181 passed, 1 skipped. This is what CI
  evaluates for a PR, and it is the run that catches the stale-literal drift.
- `ruff check` on the changed files reports the same findings as before the
  change (no new ones); the repo has no ruff gate in CI.
- Go CI job untouched — the diff contains no `go/` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
