### PR TITLE
fix(go): bump AgentField Go SDK past the codex --output-schema fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # Reproduce go/Dockerfile's sparse SDK clone; keep in sync with its AGENTFIELD_SDK_REF.
-      AGENTFIELD_SDK_REF: 054a7d18b4bfbd6b48f8582a337894c3c5975d36
+      AGENTFIELD_SDK_REF: 20955b2637b4708758c328a4f64fe460c7d4b772
       AGENTFIELD_REPO: https://github.com/Agent-Field/agentfield.git
       GOWORK: off
     steps:

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -22,7 +22,7 @@ FROM golang:1.23-bookworm AS builder
 
 # Pinned AgentField SDK ref. Default = agentfield origin/main HEAD at port time
 # (v0.1.107-rc.1). Changing this string invalidates the clone layer below.
-ARG AGENTFIELD_SDK_REF=054a7d18b4bfbd6b48f8582a337894c3c5975d36
+ARG AGENTFIELD_SDK_REF=20955b2637b4708758c328a4f64fe460c7d4b772
 ARG AGENTFIELD_REPO=https://github.com/Agent-Field/agentfield.git
 
 WORKDIR /src

--- a/go/go.mod
+++ b/go/go.mod
@@ -5,7 +5,7 @@ module github.com/Agent-Field/SWE-AF/go
 go 1.21
 
 require (
-	github.com/Agent-Field/agentfield/sdk/go v0.0.0-20260721154150-054a7d18b4bf
+	github.com/Agent-Field/agentfield/sdk/go v0.0.0-20260723130821-20955b2637b4
 	github.com/invopop/jsonschema v0.13.0
 	golang.org/x/sync v0.11.0
 )

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,5 +1,5 @@
-github.com/Agent-Field/agentfield/sdk/go v0.0.0-20260721154150-054a7d18b4bf h1:wTYUlaz81NirvBpFC7tdXeCpHCWcmaKQZFAqamNZTJw=
-github.com/Agent-Field/agentfield/sdk/go v0.0.0-20260721154150-054a7d18b4bf/go.mod h1:08VZk14uw4GJH6a34psHkuLu+DcRr197Zi0IGmLlfrM=
+github.com/Agent-Field/agentfield/sdk/go v0.0.0-20260723130821-20955b2637b4 h1:OwOEyxRfYD0n2LAmaJIJdfejWpIYgRAf9oq/YA4qfVk=
+github.com/Agent-Field/agentfield/sdk/go v0.0.0-20260723130821-20955b2637b4/go.mod h1:08VZk14uw4GJH6a34psHkuLu+DcRr197Zi0IGmLlfrM=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=

--- a/go/internal/roles/coding/coding.go
+++ b/go/internal/roles/coding/coding.go
@@ -514,6 +514,10 @@ func parseSynthesis(resp *ai.Response) (*schemas.QASynthesisResult, bool) {
 	if err := resp.JSON(&out); err != nil {
 		return nil, false
 	}
+	// The system prompt names the actions in uppercase (FIX/APPROVE/BLOCK) and
+	// the reflected request schema carries no enum, so models routinely answer
+	// in uppercase. Normalize before the enum check.
+	out.Action = schemas.QASynthesisAction(strings.ToLower(strings.TrimSpace(string(out.Action))))
 	switch out.Action {
 	case schemas.QASynthesisActionFix, schemas.QASynthesisActionApprove, schemas.QASynthesisActionBlock:
 		return &out, true

--- a/go/internal/roles/coding/coding_test.go
+++ b/go/internal/roles/coding/coding_test.go
@@ -593,3 +593,33 @@ func TestInputDefaults(t *testing.T) {
 		t.Fatalf("qa_synthesizer default model must be haiku, got %q", si.Model)
 	}
 }
+
+// Contract: models routinely answer the action in uppercase (the system prompt
+// names FIX/APPROVE/BLOCK and the reflected request schema carries no enum), so
+// parseSynthesis must case-normalize instead of dropping the synthesis and
+// triggering the deterministic fallback.
+func TestRunQASynthesizerNormalizesUppercaseAction(t *testing.T) {
+	nr := &noteRecorder{}
+	mai := &mockAI{resp: aiJSONResponse(`{"action":"APPROVE","summary":"env failures are pre-existing","stuck":false}`)}
+	mh := &mockHarness{fn: func(_ any) (*harness.Result, error) {
+		t.Fatal("run_qa_synthesizer must not call the harness")
+		return nil, nil
+	}}
+
+	out, err := RunQASynthesizer(context.Background(), newDeps(mh, mai, nr), map[string]any{
+		"qa_result":         map[string]any{"passed": false},
+		"review_result":     map[string]any{"approved": true},
+		"iteration_history": []any{},
+		"iteration_id":      "s2",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m := asMap(t, out)
+	if m["action"] != "approve" {
+		t.Fatalf("expected normalized action \"approve\", got %v", m["action"])
+	}
+	if m["summary"] != "env failures are pre-existing" {
+		t.Fatalf("model synthesis was discarded for the fallback: %v", m)
+	}
+}


### PR DESCRIPTION
Two fixes that together make SWE-AF actually able to run on the codex runtime on Windows. Found while debugging a swe-planner-go install whose every codex `build` died in seconds.

## 1. Bump the pinned AgentField Go SDK past the codex `--output-schema` fix

The pinned SDK (`054a7d18`, v0.1.113, Jul 21) predates Agent-Field/agentfield#818 — *"survive OpenAI's strict validator on codex --output-schema"*. Without it, any codex role invocation whose reflected output schema OpenAI's strict validator refuses dies immediately, surfacing only as the role's generic parse-failure fallback (observed live: `Product manager failed to produce a valid PRD` ~6s into every build). Bumps the pseudo-version to agentfield `main` (`20955b26`) and keeps the two `AGENTFIELD_SDK_REF` mirrors (go/Dockerfile ARG, CI go-job env) in sync, as the go.mod comment requires.

## 2. Case-normalize the QA-synthesizer action before the enum check

The synthesizer system prompt names its actions in uppercase (FIX/APPROVE/BLOCK), the SDK's schema reflection drops the enum from `response_format`, and `parseSynthesis` compared the answer case-sensitively against the lowercase constants. Models therefore routinely answer `"APPROVE"` — and **every** real synthesis was silently discarded for the deterministic fallback, which defaults to FIX whenever QA reports any failure. On machines with pre-existing environment-dependent test failures this is an inescapable infinite coding loop: observed live as 30 coder/QA/review iterations across 4 issues with zero acceptances, on two different synthesizer models. Reproduced by replaying the exact call (real prompts + `ai.WithSchema`) standalone; fixed with TrimSpace+ToLower before the enum switch, plus a regression test.

## Validation

- `gofmt` clean, `go build`, `go vet`, `go test -race -count=1 ./...` all green locally; CI green.
- Live end-to-end on Windows after reinstalling from this branch: a full `plan` → `execute` run (6-issue DAG on a real repo) completed 6/6 issues on the codex runtime, with the synthesizer returning real verdicts — the first successful SWE-AF-on-codex build on this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)