### PR TITLE
fix(examples): log skipped malformed JSONL lines

### DIFF
--- a/examples/diagrams/analyze_pipeline.py
+++ b/examples/diagrams/analyze_pipeline.py
@@ -42,7 +42,11 @@ def parse_log(filepath):
                 try:
                     events.append(json.loads(line))
                 except json.JSONDecodeError:
-                    pass
+                    print(
+                        f"Warning: skipping malformed JSONL line in {filepath}: "
+                        f"{line[:200]!r}",
+                        file=sys.stderr,
+                    )
     return events
 
 

--- a/examples/diagrams/analyze_v2.py
+++ b/examples/diagrams/analyze_v2.py
@@ -46,7 +46,11 @@ def parse_log(filepath):
                 try:
                     events.append(json.loads(line))
                 except json.JSONDecodeError:
-                    pass
+                    print(
+                        f"Warning: skipping malformed JSONL line in {filepath}: "
+                        f"{line[:200]!r}",
+                        file=sys.stderr,
+                    )
     return events
 
 


### PR DESCRIPTION
`analyze_v2.py` and `analyze_pipeline.py` already narrowed JSONL parsing to `json.JSONDecodeError`, but the exception handler silently discarded bad lines. Print a warning to stderr so corrupted or partial log data is no longer invisible.

Signed-off-by: Andrew White <andrew.white@cdw.com>