### PR TITLE
fix(go): direct role calls default to the configured runtime, not claude/sonnet

### DIFF
--- a/go/internal/config/resolve.go
+++ b/go/internal/config/resolve.go
@@ -274,6 +274,21 @@ func DefaultPlanningModel() string {
 	return "sonnet"
 }
 
+// DefaultRoleModel resolves the configured call-time default for one role.
+// It uses the same runtime base, environment cascade, and tier precedence as
+// ResolveRuntimeModels, without introducing a separate direct-call policy.
+func DefaultRoleModel(role string) (string, error) {
+	field, ok := RoleToModelField[role]
+	if !ok {
+		return "", fmt.Errorf("unknown role %s", pyRepr(role))
+	}
+	resolved, err := ResolveRuntimeModels(DefaultRuntime(), nil, []string{field})
+	if err != nil {
+		return "", err
+	}
+	return resolved[field], nil
+}
+
 // ---------------------------------------------------------------------------
 // Flat-model validation + resolution
 // ---------------------------------------------------------------------------

--- a/go/internal/roles/coding/coding.go
+++ b/go/internal/roles/coding/coding.go
@@ -9,9 +9,8 @@
 // so the wiring task (T6.2) can register it under the exact Python reasoner name
 // via Handlers(). The handlers mirror the Python functions 1:1:
 //
-//   - inputs are bound from the untyped map with the SAME parameter names and
-//     defaults as the Python function signatures (model="sonnet"/"haiku",
-//     ai_provider="claude", iteration=1, qa_ran=false, …);
+//   - inputs are bound from the untyped map with the same parameter names as
+//     Python; absent runtime/model values resolve from config at call time;
 //   - run_coder/run_qa/run_code_reviewer call the structured-output harness via
 //     harnessx.Run; run_qa_synthesizer uses the direct-LLM path (Deps.AI), the
 //     Go equivalent of Python's router.ai (NOT the coding harness);
@@ -112,12 +111,13 @@ type coderInput struct {
 	TargetRepo        string         `json:"target_repo"`
 }
 
-// UnmarshalJSON seeds the Python parameter defaults (iteration=1, model="sonnet",
-// ai_provider="claude") so keys absent from the input map keep those defaults.
 func (c *coderInput) UnmarshalJSON(b []byte) error {
-	*c = coderInput{Iteration: 1, Model: "sonnet", AIProvider: "claude"}
+	*c = coderInput{Iteration: 1}
 	type alias coderInput
-	return jsonUnmarshal(b, (*alias)(c))
+	if err := jsonUnmarshal(b, (*alias)(c)); err != nil {
+		return err
+	}
+	return resolveRoleDefaults(&c.AIProvider, &c.Model, "coder")
 }
 
 // RunCoder ports run_coder (execution_agents.py:963). Implements an issue and
@@ -216,12 +216,14 @@ type qaInput struct {
 	TargetRepo        string         `json:"target_repo"`
 }
 
-// UnmarshalJSON seeds the Python parameter defaults (model="sonnet",
-// ai_provider="claude").
+// UnmarshalJSON applies configured runtime/model defaults at call time.
 func (q *qaInput) UnmarshalJSON(b []byte) error {
-	*q = qaInput{Model: "sonnet", AIProvider: "claude"}
+	*q = qaInput{}
 	type alias qaInput
-	return jsonUnmarshal(b, (*alias)(q))
+	if err := jsonUnmarshal(b, (*alias)(q)); err != nil {
+		return err
+	}
+	return resolveRoleDefaults(&q.AIProvider, &q.Model, "qa")
 }
 
 // RunQA ports run_qa (execution_agents.py:1060). Reviews/augments tests and runs
@@ -304,11 +306,14 @@ type codeReviewerInput struct {
 }
 
 // UnmarshalJSON seeds the Python parameter defaults (qa_ran=false is the Go zero
-// value; model="sonnet", ai_provider="claude").
+// value; runtime/model defaults are resolved at call time).
 func (c *codeReviewerInput) UnmarshalJSON(b []byte) error {
-	*c = codeReviewerInput{Model: "sonnet", AIProvider: "claude"}
+	*c = codeReviewerInput{}
 	type alias codeReviewerInput
-	return jsonUnmarshal(b, (*alias)(c))
+	if err := jsonUnmarshal(b, (*alias)(c)); err != nil {
+		return err
+	}
+	return resolveRoleDefaults(&c.AIProvider, &c.Model, "code_reviewer")
 }
 
 // RunCodeReviewer ports run_code_reviewer (execution_agents.py:1134). Reviews
@@ -393,12 +398,28 @@ type qaSynthInput struct {
 	TargetRepo        string           `json:"target_repo"`
 }
 
-// UnmarshalJSON seeds the Python parameter defaults (model="haiku",
-// ai_provider="claude").
+// UnmarshalJSON applies configured runtime/model defaults at call time.
 func (q *qaSynthInput) UnmarshalJSON(b []byte) error {
-	*q = qaSynthInput{Model: "haiku", AIProvider: "claude"}
+	*q = qaSynthInput{}
 	type alias qaSynthInput
-	return jsonUnmarshal(b, (*alias)(q))
+	if err := jsonUnmarshal(b, (*alias)(q)); err != nil {
+		return err
+	}
+	return resolveRoleDefaults(&q.AIProvider, &q.Model, "qa_synthesizer")
+}
+
+func resolveRoleDefaults(aiProvider, model *string, role string) error {
+	if *aiProvider == "" {
+		*aiProvider = config.DefaultRuntime()
+	}
+	if *model == "" {
+		resolved, err := config.DefaultRoleModel(role)
+		if err != nil {
+			return err
+		}
+		*model = resolved
+	}
+	return nil
 }
 
 // RunQASynthesizer ports run_qa_synthesizer (execution_agents.py:1216). Merges

--- a/go/internal/roles/coding/coding_test.go
+++ b/go/internal/roles/coding/coding_test.go
@@ -167,6 +167,43 @@ func TestRunCoderSuccessKeySetAndIterationID(t *testing.T) {
 	}
 }
 
+func TestRunCoderDirectCallRuntimeDefaults(t *testing.T) {
+	for _, key := range []string{"ANTHROPIC_API_KEY", "OPENROUTER_API_KEY", "SWE_DEFAULT_RUNTIME", "SWE_MODEL_MED", "SWE_DEFAULT_MODEL", "AI_MODEL", "HARNESS_MODEL"} {
+		t.Setenv(key, "")
+	}
+	t.Setenv("OPENROUTER_API_KEY", "test-key")
+
+	mh := &mockHarness{fn: func(dest any) (*harness.Result, error) {
+		return &harness.Result{Parsed: dest}, nil
+	}}
+	if _, err := RunCoder(context.Background(), newDeps(mh, nil, &noteRecorder{}), map[string]any{
+		"issue": map[string]any{"name": "direct"}, "worktree_path": "/wt",
+	}); err != nil {
+		t.Fatalf("RunCoder: %v", err)
+	}
+	if mh.gotOpts.Provider != "opencode" || mh.gotOpts.Model != "openrouter/deepseek/deepseek-v4-flash" {
+		t.Fatalf("defaults = provider %q, model %q", mh.gotOpts.Provider, mh.gotOpts.Model)
+	}
+}
+
+func TestRunCoderExplicitRuntimeValuesUntouched(t *testing.T) {
+	t.Setenv("OPENROUTER_API_KEY", "test-key")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("SWE_DEFAULT_RUNTIME", "")
+	mh := &mockHarness{fn: func(dest any) (*harness.Result, error) {
+		return &harness.Result{Parsed: dest}, nil
+	}}
+	if _, err := RunCoder(context.Background(), newDeps(mh, nil, &noteRecorder{}), map[string]any{
+		"issue": map[string]any{"name": "explicit"}, "worktree_path": "/wt",
+		"ai_provider": "claude", "model": "sonnet",
+	}); err != nil {
+		t.Fatalf("RunCoder: %v", err)
+	}
+	if mh.gotOpts.Provider != "claude-code" || mh.gotOpts.Model != "sonnet" {
+		t.Fatalf("explicit = provider %q, model %q", mh.gotOpts.Provider, mh.gotOpts.Model)
+	}
+}
+
 // Contract: coder applies the web-search guardrail to its system prompt (via
 // tools.MaybeApplyCoderGuardrail) and runs with cwd = worktree.
 func TestRunCoderAppliesGuardrailAndCwd(t *testing.T) {
@@ -576,13 +613,16 @@ func TestHandlersRegistrationNames(t *testing.T) {
 	}
 }
 
-// Contract: input binding applies the Python default model per role.
+// Contract: input binding applies the configured call-time defaults per role.
 func TestInputDefaults(t *testing.T) {
+	for _, key := range []string{"ANTHROPIC_API_KEY", "OPENROUTER_API_KEY", "SWE_DEFAULT_RUNTIME", "SWE_MODEL_LOW", "SWE_MODEL_MED", "SWE_DEFAULT_MODEL", "AI_MODEL", "HARNESS_MODEL"} {
+		t.Setenv(key, "")
+	}
 	ci, err := bindInput[coderInput](map[string]any{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ci.Model != "sonnet" || ci.AIProvider != "claude" || ci.Iteration != 1 {
+	if ci.Model != "sonnet" || ci.AIProvider != "claude_code" || ci.Iteration != 1 {
 		t.Fatalf("coder defaults wrong: %+v", ci)
 	}
 	si, err := bindInput[qaSynthInput](map[string]any{})

--- a/go/internal/roles/gitops/finalize.go
+++ b/go/internal/roles/gitops/finalize.go
@@ -40,7 +40,11 @@ func RunRepoFinalize(ctx context.Context, deps *Deps, input map[string]any) (any
 	if err != nil {
 		return nil, err
 	}
-	opts := roleOptions(provider, orDefault(in.Model, "sonnet"), gitprompts.RepoFinalizeSystemPrompt, in.RepoPath,
+	model, err := resolveModel(in.Model, "git")
+	if err != nil {
+		return nil, err
+	}
+	opts := roleOptions(provider, model, gitprompts.RepoFinalizeSystemPrompt, in.RepoPath,
 		[]string{"Bash", "Read", "Write", "Glob", "Grep"}, in.PermissionMode)
 
 	val, ok, err := runRole[schemas.RepoFinalizeResult](ctx, deps, taskPrompt, opts, "repo_finalize", "Repo finalize agent failed")
@@ -104,7 +108,11 @@ func RunGitHubPR(ctx context.Context, deps *Deps, input map[string]any) (any, er
 	if err != nil {
 		return nil, err
 	}
-	opts := roleOptions(provider, orDefault(in.Model, "sonnet"), gitprompts.GitHubPRSystemPrompt, in.RepoPath,
+	model, err := resolveModel(in.Model, "git")
+	if err != nil {
+		return nil, err
+	}
+	opts := roleOptions(provider, model, gitprompts.GitHubPRSystemPrompt, in.RepoPath,
 		[]string{"Bash", "Write"}, in.PermissionMode)
 
 	val, ok, err := runRole[schemas.GitHubPRResult](ctx, deps, taskPrompt, opts, "github_pr", "GitHub PR agent failed")

--- a/go/internal/roles/gitops/gitops.go
+++ b/go/internal/roles/gitops/gitops.go
@@ -14,11 +14,9 @@
 // propagates *fatal.FatalHarnessError, and on a harness parse failure returns
 // the role's deterministic fallback (never an error).
 //
-// Model resolution is input-driven exactly as in Python: the reasoner reads the
-// model from its input (default "sonnet"). The caller (dag_executor) resolves
-// the per-role model — git_model for run_git_init, merger_model for run_merger,
-// integration_tester_model for run_integration_tester — and passes it in; the
-// reasoner does not re-resolve it here.
+// Explicit runtime/model inputs remain input-driven. Direct calls that omit
+// either value resolve the configured defaults at call time; orchestrators
+// already pass resolved values and therefore retain their existing behavior.
 package gitops
 
 import (
@@ -84,10 +82,7 @@ func Handlers() map[string]Handler {
 // Shared helpers (Python-parity string/number formatting + role plumbing)
 // ---------------------------------------------------------------------------
 
-// orDefault returns def when s is empty, else s. Reproduces a Python keyword
-// default: run_git_init(model="sonnet", ...) uses "sonnet" when the caller
-// omits model. Bind maps an absent key to "" (the Go zero), so "" == "use
-// default". Callers in practice always pass a resolved non-empty model.
+// orDefault returns def when s is empty, else s.
 func orDefault(s, def string) string {
 	if s == "" {
 		return def
@@ -95,14 +90,21 @@ func orDefault(s, def string) string {
 	return s
 }
 
-// resolveProvider maps the input ai_provider (default "claude") to the harness
+// resolveProvider maps the input ai_provider to the harness
 // adapter string, mirroring Python's
 // provider = runtime_to_harness_adapter(ai_provider). The adapter — not the
 // provider — is what the harness Options.Provider field expects (design §4.7).
 // An unsupported value returns the normalize error, matching Python raising
 // before the harness call.
 func resolveProvider(aiProvider string) (string, error) {
-	return runtimex.RuntimeToHarnessAdapter(orDefault(aiProvider, "claude"))
+	return runtimex.RuntimeToHarnessAdapter(orDefault(aiProvider, config.DefaultRuntime()))
+}
+
+func resolveModel(model, role string) (string, error) {
+	if model != "" {
+		return model, nil
+	}
+	return config.DefaultRoleModel(role)
 }
 
 // roleOptions builds the harness.Options for a role from its resolved

--- a/go/internal/roles/gitops/merge.go
+++ b/go/internal/roles/gitops/merge.go
@@ -57,7 +57,11 @@ func RunMerger(ctx context.Context, deps *Deps, input map[string]any) (any, erro
 	if err != nil {
 		return nil, err
 	}
-	opts := roleOptions(provider, orDefault(in.Model, "sonnet"), gitprompts.MergerSystemPrompt, in.RepoPath,
+	model, err := resolveModel(in.Model, "merger")
+	if err != nil {
+		return nil, err
+	}
+	opts := roleOptions(provider, model, gitprompts.MergerSystemPrompt, in.RepoPath,
 		[]string{"Bash", "Read", "Write", "Glob", "Grep"}, in.PermissionMode)
 
 	val, ok, err := runRole[schemas.MergeResult](ctx, deps, taskPrompt, opts, "merger", "Merger agent failed")
@@ -128,7 +132,11 @@ func RunIntegrationTester(ctx context.Context, deps *Deps, input map[string]any)
 	if err != nil {
 		return nil, err
 	}
-	opts := roleOptions(provider, orDefault(in.Model, "sonnet"), gitprompts.IntegrationTesterSystemPrompt, in.RepoPath,
+	model, err := resolveModel(in.Model, "integration_tester")
+	if err != nil {
+		return nil, err
+	}
+	opts := roleOptions(provider, model, gitprompts.IntegrationTesterSystemPrompt, in.RepoPath,
 		[]string{"Bash", "Read", "Write", "Glob", "Grep"}, in.PermissionMode)
 
 	val, ok, err := runRole[schemas.IntegrationTestResult](ctx, deps, taskPrompt, opts, "integration_tester", "Integration tester agent failed")

--- a/go/internal/roles/gitops/workspace.go
+++ b/go/internal/roles/gitops/workspace.go
@@ -61,7 +61,11 @@ func RunGitInit(ctx context.Context, deps *Deps, input map[string]any) (any, err
 	if err != nil {
 		return nil, err
 	}
-	opts := roleOptions(provider, orDefault(in.Model, "sonnet"), systemPrompt, in.RepoPath,
+	model, err := resolveModel(in.Model, "git")
+	if err != nil {
+		return nil, err
+	}
+	opts := roleOptions(provider, model, systemPrompt, in.RepoPath,
 		[]string{"Bash", "Write"}, in.PermissionMode)
 
 	val, ok, err := runRole[schemas.GitInitResult](ctx, deps, taskPrompt, opts, "git_init", "Git init agent failed")
@@ -139,7 +143,11 @@ func RunWorkspaceSetup(ctx context.Context, deps *Deps, input map[string]any) (a
 	if err != nil {
 		return nil, err
 	}
-	opts := roleOptions(provider, orDefault(in.Model, "sonnet"), gitprompts.SetupSystemPrompt, in.RepoPath,
+	model, err := resolveModel(in.Model, "git")
+	if err != nil {
+		return nil, err
+	}
+	opts := roleOptions(provider, model, gitprompts.SetupSystemPrompt, in.RepoPath,
 		[]string{"Bash", "Write"}, in.PermissionMode)
 
 	val, ok, err := runRole[workspaceSetupResult](ctx, deps, taskPrompt, opts, "workspace_setup", "Workspace setup agent failed")
@@ -200,7 +208,11 @@ func RunWorkspaceCleanup(ctx context.Context, deps *Deps, input map[string]any) 
 	if err != nil {
 		return nil, err
 	}
-	opts := roleOptions(provider, orDefault(in.Model, "sonnet"), gitprompts.CleanupSystemPrompt, in.RepoPath,
+	model, err := resolveModel(in.Model, "git")
+	if err != nil {
+		return nil, err
+	}
+	opts := roleOptions(provider, model, gitprompts.CleanupSystemPrompt, in.RepoPath,
 		[]string{"Bash", "Write"}, in.PermissionMode)
 
 	val, ok, err := runRole[workspaceCleanupResult](ctx, deps, taskPrompt, opts, "workspace_cleanup", "Workspace cleanup agent failed")

--- a/go/internal/roles/planning/planning.go
+++ b/go/internal/roles/planning/planning.go
@@ -85,10 +85,10 @@ func RunProductManager(ctx context.Context, deps *Deps, input map[string]any) (a
 	repoPath := getString(input, "repo_path", "")
 	artifactsDir := getString(input, "artifacts_dir", ".artifacts")
 	additionalContext := getString(input, "additional_context", "")
-	model := getString(input, "model", "sonnet")
+	model := orResolvedDefault(getString(input, "model", ""), config.DefaultPlanningModel())
 	maxTurns := getInt(input, "max_turns", config.DefaultAgentMaxTurns)
 	permissionMode := getString(input, "permission_mode", "")
-	aiProvider := getString(input, "ai_provider", "claude")
+	aiProvider := orResolvedDefault(getString(input, "ai_provider", ""), config.DefaultRuntime())
 	initialPrior := getPriorResponses(input)
 
 	_, paths, err := ensurePaths(repoPath, artifactsDir)
@@ -183,10 +183,10 @@ func RunEnvironmentScout(ctx context.Context, deps *Deps, input map[string]any) 
 	prd := getMap(input, "prd")
 	repoPath := getString(input, "repo_path", "")
 	artifactsDir := getString(input, "artifacts_dir", ".artifacts")
-	model := getString(input, "model", "sonnet")
+	model := orResolvedDefault(getString(input, "model", ""), config.DefaultPlanningModel())
 	maxTurns := getInt(input, "max_turns", config.DefaultAgentMaxTurns)
 	permissionMode := getString(input, "permission_mode", "")
-	aiProvider := getString(input, "ai_provider", "claude")
+	aiProvider := orResolvedDefault(getString(input, "ai_provider", ""), config.DefaultRuntime())
 	initialPrior := getPriorResponses(input)
 
 	// Ensure the artifact dirs exist; the scout writes no artifacts of its own.
@@ -302,10 +302,10 @@ func RunArchitect(ctx context.Context, deps *Deps, input map[string]any) (any, e
 	repoPath := getString(input, "repo_path", "")
 	artifactsDir := getString(input, "artifacts_dir", ".artifacts")
 	feedback := getString(input, "feedback", "")
-	model := getString(input, "model", "sonnet")
+	model := orResolvedDefault(getString(input, "model", ""), config.DefaultPlanningModel())
 	maxTurns := getInt(input, "max_turns", config.DefaultAgentMaxTurns)
 	permissionMode := getString(input, "permission_mode", "")
-	aiProvider := getString(input, "ai_provider", "claude")
+	aiProvider := orResolvedDefault(getString(input, "ai_provider", ""), config.DefaultRuntime())
 
 	_, paths, err := ensurePaths(repoPath, artifactsDir)
 	if err != nil {
@@ -374,10 +374,10 @@ func RunTechLead(ctx context.Context, deps *Deps, input map[string]any) (any, er
 	repoPath := getString(input, "repo_path", "")
 	artifactsDir := getString(input, "artifacts_dir", ".artifacts")
 	revisionNumber := getInt(input, "revision_number", 0)
-	model := getString(input, "model", "sonnet")
+	model := orResolvedDefault(getString(input, "model", ""), config.DefaultPlanningModel())
 	maxTurns := getInt(input, "max_turns", config.DefaultAgentMaxTurns)
 	permissionMode := getString(input, "permission_mode", "")
-	aiProvider := getString(input, "ai_provider", "claude")
+	aiProvider := orResolvedDefault(getString(input, "ai_provider", ""), config.DefaultRuntime())
 
 	base, paths, err := ensurePaths(repoPath, artifactsDir)
 	if err != nil {
@@ -460,10 +460,10 @@ func RunSprintPlanner(ctx context.Context, deps *Deps, input map[string]any) (an
 
 	repoPath := getString(input, "repo_path", "")
 	artifactsDir := getString(input, "artifacts_dir", ".artifacts")
-	model := getString(input, "model", "sonnet")
+	model := orResolvedDefault(getString(input, "model", ""), config.DefaultPlanningModel())
 	maxTurns := getInt(input, "max_turns", config.DefaultAgentMaxTurns)
 	permissionMode := getString(input, "permission_mode", "")
-	aiProvider := getString(input, "ai_provider", "claude")
+	aiProvider := orResolvedDefault(getString(input, "ai_provider", ""), config.DefaultRuntime())
 
 	_, paths, err := ensurePaths(repoPath, artifactsDir)
 	if err != nil {
@@ -637,6 +637,13 @@ func getString(input map[string]any, key, def string) string {
 		}
 	}
 	return def
+}
+
+func orResolvedDefault(value, def string) string {
+	if value == "" {
+		return def
+	}
+	return value
 }
 
 // getInt returns input[key] as an int when present, else def. Tolerates the

--- a/go/internal/roles/planning/planning_test.go
+++ b/go/internal/roles/planning/planning_test.go
@@ -156,6 +156,51 @@ func TestProductManagerHarnessOptions(t *testing.T) {
 	}
 }
 
+func TestProductManagerDirectCallRuntimeDefaults(t *testing.T) {
+	clearRuntimeEnv := func(t *testing.T) {
+		t.Helper()
+		for _, key := range []string{"ANTHROPIC_API_KEY", "OPENROUTER_API_KEY", "SWE_DEFAULT_RUNTIME", "SWE_MODEL_HIGH", "SWE_DEFAULT_MODEL", "AI_MODEL", "HARNESS_MODEL"} {
+			t.Setenv(key, "")
+		}
+	}
+	run := func(t *testing.T, input map[string]any) harness.Options {
+		t.Helper()
+		h := &fakeHarness{fn: func(_ int, _ string, dest any, _ harness.Options) (*harness.Result, error) {
+			return &harness.Result{Parsed: dest}, nil
+		}}
+		deps, _ := newDeps(h)
+		input["repo_path"] = t.TempDir()
+		if _, err := RunProductManager(context.Background(), deps, input); err != nil {
+			t.Fatalf("RunProductManager: %v", err)
+		}
+		return h.lastOpts
+	}
+
+	t.Run("OpenRouter only", func(t *testing.T) {
+		clearRuntimeEnv(t)
+		t.Setenv("OPENROUTER_API_KEY", "test-key")
+		opts := run(t, map[string]any{})
+		if opts.Provider != "opencode" || opts.Model != "openrouter/deepseek/deepseek-v4-flash" {
+			t.Fatalf("defaults = provider %q, model %q", opts.Provider, opts.Model)
+		}
+	})
+	t.Run("configured codex", func(t *testing.T) {
+		clearRuntimeEnv(t)
+		t.Setenv("SWE_DEFAULT_RUNTIME", "codex")
+		if got := run(t, map[string]any{}).Provider; got != "codex" {
+			t.Fatalf("provider = %q, want codex", got)
+		}
+	})
+	t.Run("explicit values win", func(t *testing.T) {
+		clearRuntimeEnv(t)
+		t.Setenv("OPENROUTER_API_KEY", "test-key")
+		opts := run(t, map[string]any{"ai_provider": "claude", "model": "sonnet"})
+		if opts.Provider != "claude-code" || opts.Model != "sonnet" {
+			t.Fatalf("explicit = provider %q, model %q", opts.Provider, opts.Model)
+		}
+	})
+}
+
 // Contract: parse failure raises (not a fallback).
 func TestProductManagerParseFailureRaises(t *testing.T) {
 	h := &fakeHarness{fn: func(_ int, _ string, _ any, _ harness.Options) (*harness.Result, error) {


### PR DESCRIPTION
## Summary
Direct reasoner calls (e.g. `POST /api/v1/execute/swe-planner-go.run_product_manager`) hard-coded `ai_provider: "claude"` / `model: "sonnet"`, ignoring the deployment's configured runtime. On an OpenRouter-only setup — the common cloud deploy — every direct role call tried the claude harness and failed in ~500ms, even though `config.DefaultRuntime()` already auto-selects `open_code` there and the orchestrators already resolve correctly. Verified live on a Railway control plane.

## Changes Made
- Absent/empty `ai_provider` resolves through `config.DefaultRuntime()` at call time; absent/empty `model` through `config.DefaultPlanningModel()` (planning roles) or the new `config.DefaultRoleModel(role)` (coding/gitops), which reuses `ResolveRuntimeModels` + `RoleToTier` — no new precedence policy.
- Explicit input values are used verbatim, so orchestrator-threaded calls are byte-identical (covered by tests).
- Known divergence from the Python port's literal signature defaults (`model="sonnet"`, `ai_provider="claude"`), which have the same direct-call problem — happy to mirror this fix in `swe_af/` as a follow-up.

## Test Plan
- [x] `gofmt` clean, `go build`, `go vet`
- [x] `go test -race -count=1 ./...` — 27 packages, all green (CI's exact flags)
- [x] New tests: OpenRouter-only defaults, `SWE_DEFAULT_RUNTIME=codex` override, explicit-values-untouched, for planning and coding roles

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)