### PR TITLE
feat(runtime): add Grok as a first-class coding runtime

### DIFF
--- a/agentfield-package.yaml
+++ b/agentfield-package.yaml
@@ -40,6 +40,9 @@ user_environment:
   optional:
     - name: SWE_DEFAULT_MODEL
       description: Override the model id for every role (e.g. openrouter/deepseek/deepseek-v4-flash)
+    - name: SWE_DEFAULT_RUNTIME
+      description: Coding-agent runtime (claude_code|open_code|codex|grok)
+      default: claude_code
     - name: AGENTFIELD_SERVER
       description: Control-plane URL
       default: http://localhost:8080

--- a/swe_af/execution/schemas.py
+++ b/swe_af/execution/schemas.py
@@ -617,6 +617,9 @@ _RUNTIME_BASE_MODELS: dict[str, dict[str, str]] = {
     "codex": {
         **{field: _CODEX_API_KEY_MODEL for field in ALL_MODEL_FIELDS},
     },
+    "grok": {
+        **{field: "grok-4.5" for field in ALL_MODEL_FIELDS},
+    },
 }
 
 
@@ -647,7 +650,7 @@ def _codex_default_model() -> str:
     return _CODEX_CHATGPT_MODEL if _codex_uses_chatgpt_auth() else _CODEX_API_KEY_MODEL
 
 
-def _runtime_to_provider(runtime: str) -> Literal["claude", "opencode", "codex"]:
+def _runtime_to_provider(runtime: str) -> Literal["claude", "opencode", "codex", "grok"]:
     return runtime_to_harness_provider(runtime)  # type: ignore[return-value]
 
 
@@ -672,7 +675,7 @@ def _openrouter_only_env() -> bool:
     return bool(os.getenv("OPENROUTER_API_KEY", "").strip())
 
 
-def _default_runtime() -> Literal["claude_code", "open_code", "codex"]:
+def _default_runtime() -> Literal["claude_code", "open_code", "codex", "grok"]:
     """Default runtime, honoring the ``SWE_DEFAULT_RUNTIME`` env var.
 
     Lets the deployer pick the runtime without every caller having to pass
@@ -898,7 +901,7 @@ class BuildConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    runtime: Literal["claude_code", "open_code", "codex"] = Field(default_factory=_default_runtime)
+    runtime: Literal["claude_code", "open_code", "codex", "grok"] = Field(default_factory=_default_runtime)
     models: dict[str, str] | None = None
 
     max_review_iterations: int = 2
@@ -1017,7 +1020,7 @@ class BuildConfig(BaseModel):
         _validate_flat_models(self.models)
 
     @property
-    def ai_provider(self) -> Literal["claude", "opencode", "codex"]:
+    def ai_provider(self) -> Literal["claude", "opencode", "codex", "grok"]:
         return _runtime_to_provider(self.runtime)
 
     @property
@@ -1207,7 +1210,7 @@ class ExecutionConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    runtime: Literal["claude_code", "open_code", "codex"] = Field(default_factory=_default_runtime)
+    runtime: Literal["claude_code", "open_code", "codex", "grok"] = Field(default_factory=_default_runtime)
     models: dict[str, str] | None = None
     _resolved_models: dict[str, str] = PrivateAttr(default_factory=dict)
 
@@ -1259,7 +1262,7 @@ class ExecutionConfig(BaseModel):
         return self._resolved_models[field_name]
 
     @property
-    def ai_provider(self) -> Literal["claude", "opencode", "codex"]:
+    def ai_provider(self) -> Literal["claude", "opencode", "codex", "grok"]:
         return _runtime_to_provider(self.runtime)
 
     @property

--- a/swe_af/fast/__init__.py
+++ b/swe_af/fast/__init__.py
@@ -18,8 +18,10 @@ from __future__ import annotations
 
 from agentfield import AgentRouter
 from swe_af.runtime.codex_harness_patch import apply_codex_harness_patch
+from swe_af.runtime.grok_harness_patch import apply_grok_harness_patch
 
 apply_codex_harness_patch()
+apply_grok_harness_patch()
 
 fast_router = AgentRouter(tags=["swe-fast"])
 

--- a/swe_af/fast/schemas.py
+++ b/swe_af/fast/schemas.py
@@ -113,7 +113,7 @@ class FastBuildConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    runtime: Literal["claude_code", "open_code", "codex"] = Field(default_factory=_default_fast_runtime)
+    runtime: Literal["claude_code", "open_code", "codex", "grok"] = Field(default_factory=_default_fast_runtime)
     models: dict[str, str] | None = None
     max_tasks: int = 10
     task_timeout_seconds: int = 300

--- a/swe_af/issue/__init__.py
+++ b/swe_af/issue/__init__.py
@@ -19,8 +19,10 @@ from __future__ import annotations
 
 from agentfield import AgentRouter
 from swe_af.runtime.codex_harness_patch import apply_codex_harness_patch
+from swe_af.runtime.grok_harness_patch import apply_grok_harness_patch
 
 apply_codex_harness_patch()
+apply_grok_harness_patch()
 
 issue_router = AgentRouter(tags=["swe-issue"])
 

--- a/swe_af/issue/schemas.py
+++ b/swe_af/issue/schemas.py
@@ -106,7 +106,7 @@ class IssueBuildConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    runtime: Literal["claude_code", "open_code", "codex"] = Field(
+    runtime: Literal["claude_code", "open_code", "codex", "grok"] = Field(
         default_factory=_default_runtime
     )
     models: dict[str, str] | None = None

--- a/swe_af/reasoners/__init__.py
+++ b/swe_af/reasoners/__init__.py
@@ -1,7 +1,9 @@
 from agentfield import AgentRouter
 from swe_af.runtime.codex_harness_patch import apply_codex_harness_patch
+from swe_af.runtime.grok_harness_patch import apply_grok_harness_patch
 
 apply_codex_harness_patch()
+apply_grok_harness_patch()
 
 router = AgentRouter(tags=["swe-planner"])
 

--- a/swe_af/runtime/__init__.py
+++ b/swe_af/runtime/__init__.py
@@ -1,6 +1,7 @@
 """Runtime mapping helpers."""
 
 from swe_af.runtime.codex_harness_patch import apply_codex_harness_patch
+from swe_af.runtime.grok_harness_patch import apply_grok_harness_patch
 from .providers import (
     RUNTIME_VALUES,
     normalize_runtime_provider,
@@ -14,4 +15,5 @@ __all__ = [
     "runtime_to_harness_adapter",
     "runtime_to_harness_provider",
     "apply_codex_harness_patch",
+    "apply_grok_harness_patch",
 ]

--- a/swe_af/runtime/grok_harness_patch.py
+++ b/swe_af/runtime/grok_harness_patch.py
@@ -1,0 +1,114 @@
+"""Grok structured-output patch (Codex-patch architecture, no silent fallback).
+
+AgentField's default schema path asks the model to Write ``.agentfield_output.json``.
+Grok headless runs (and SWE-AF roles without a Write tool / with read-only
+permission) cannot create that file, so structured parsing fails.
+
+This module mirrors ``codex_harness_patch``:
+
+1. When ``provider=grok``, replace the Write-tool prompt suffix with a
+   "return final JSON as the answer" contract (schema file is written for
+   reference only).
+2. After a Grok CLI run, persist non-empty final message text to
+   ``.agentfield_output.json`` when a schema file is present — same role as
+   Codex ``--output-last-message``. Transport only: empty results are left
+   alone and the harness fails loudly.
+
+Non-goals:
+
+- No business-level deterministic approve/fix synthesis.
+- No automatic re-run with weaker settings when parse fails.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+_PATCHED = False
+
+_ORIGINAL_BUILD_PROMPT_SUFFIX: Any = None
+_ORIGINAL_GROK_EXECUTE: Any = None
+
+
+def _grok_build_prompt_suffix(schema: Any, cwd: str) -> str:
+    """Codex-style suffix: final JSON answer, no Write-tool requirement."""
+    from agentfield.harness import _schema
+
+    json_schema = _schema.schema_to_json_schema(schema)
+    schema_json = json.dumps(json_schema, indent=2)
+    _schema.write_schema_file(schema_json, cwd)
+    schema_path = _schema.get_schema_path(cwd)
+    return (
+        "\n\n---\n"
+        "CRITICAL GROK STRUCTURED OUTPUT REQUIREMENTS:\n"
+        f"Return a single final JSON object conforming to the schema at: {schema_path}\n"
+        "Do not use markdown fences, comments, or surrounding prose.\n"
+        "Do not try to create .agentfield_output.json yourself with a Write tool; "
+        "emit the JSON object as your final response text. AgentField will capture "
+        "that final response for schema validation.\n"
+        f"Required JSON Schema:\n{schema_json}\n"
+    )
+
+
+def apply_grok_harness_patch() -> None:
+    """Install Grok structured-output hooks. Idempotent."""
+    global _PATCHED, _ORIGINAL_BUILD_PROMPT_SUFFIX, _ORIGINAL_GROK_EXECUTE
+    if _PATCHED:
+        return
+
+    # Ensure Codex patch is installed first so ``active_provider`` is set on
+    # Agent.harness and codex dispatch remains intact for codex calls.
+    from swe_af.runtime.codex_harness_patch import (
+        active_provider,
+        apply_codex_harness_patch,
+    )
+
+    apply_codex_harness_patch()
+
+    try:
+        from agentfield.harness import _runner, _schema
+        from agentfield.harness.providers.grok import GrokProvider
+    except Exception:
+        return
+
+    _ORIGINAL_BUILD_PROMPT_SUFFIX = _schema.build_prompt_suffix
+
+    def build_prompt_suffix_dispatching(schema: Any, cwd: str) -> str:
+        if active_provider.get() == "grok":
+            return _grok_build_prompt_suffix(schema, cwd)
+        return _ORIGINAL_BUILD_PROMPT_SUFFIX(schema, cwd)
+
+    _ORIGINAL_GROK_EXECUTE = GrokProvider.execute
+
+    async def execute_with_final_message_persist(
+        self: Any, prompt: str, options: dict[str, object]
+    ) -> Any:
+        raw = await _ORIGINAL_GROK_EXECUTE(self, prompt, options)
+
+        cwd = options.get("cwd") or options.get("project_dir")
+        if not isinstance(cwd, str) or not cwd.strip():
+            return raw
+
+        schema_path = _schema.get_schema_path(cwd)
+        if not Path(schema_path).exists():
+            return raw
+
+        text = raw.result if isinstance(getattr(raw, "result", None), str) else None
+        if not text or not text.strip():
+            return raw
+
+        output_path = _schema.get_output_path(cwd)
+        try:
+            Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+            Path(output_path).write_text(text, encoding="utf-8")
+        except OSError:
+            return raw
+
+        return raw
+
+    _schema.build_prompt_suffix = build_prompt_suffix_dispatching
+    _runner.build_prompt_suffix = build_prompt_suffix_dispatching
+    GrokProvider.execute = execute_with_final_message_persist  # type: ignore[method-assign]
+    _PATCHED = True

--- a/swe_af/runtime/providers.py
+++ b/swe_af/runtime/providers.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-RUNTIME_VALUES = ("claude_code", "open_code", "codex")
+RUNTIME_VALUES = ("claude_code", "open_code", "codex", "grok")
 
 
 def normalize_runtime_provider(runtime: str) -> str:
@@ -14,6 +14,8 @@ def normalize_runtime_provider(runtime: str) -> str:
         return "open_code"
     if value == "codex":
         return "codex"
+    if value in {"grok", "xai", "grok-cli", "grok_build"}:
+        return "grok"
     raise ValueError(f"Unsupported runtime provider: {runtime}")
 
 
@@ -24,6 +26,8 @@ def runtime_to_harness_provider(runtime: str) -> str:
         return "claude"
     if normalized == "open_code":
         return "opencode"
+    if normalized == "grok":
+        return "grok"
     return "codex"
 
 
@@ -34,4 +38,6 @@ def runtime_to_harness_adapter(runtime: str) -> str:
         return "claude-code"
     if normalized == "open_code":
         return "opencode"
+    if normalized == "grok":
+        return "grok"
     return "codex"

--- a/tests/test_grok_harness_patch.py
+++ b/tests/test_grok_harness_patch.py
@@ -1,0 +1,124 @@
+"""Tests for Grok structured-output patch (Codex-style, no silent fallback)."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+from pydantic import BaseModel
+
+from swe_af.runtime.codex_harness_patch import active_provider
+from swe_af.runtime.grok_harness_patch import apply_grok_harness_patch
+
+
+class _TinySchema(BaseModel):
+    action: str
+    summary: str = ""
+
+
+def test_grok_prompt_suffix_rejects_write_tool_instruction(tmp_path: Path) -> None:
+    from agentfield.harness import _schema
+
+    apply_grok_harness_patch()
+    token = active_provider.set("grok")
+    try:
+        suffix = _schema.build_prompt_suffix(_TinySchema, str(tmp_path))
+    finally:
+        active_provider.reset(token)
+
+    assert "CRITICAL GROK STRUCTURED OUTPUT REQUIREMENTS" in suffix
+    assert "Do not try to create .agentfield_output.json yourself" in suffix
+    assert "Write tool" in suffix
+    # Must not require Write-to-file as the only path (AF default language).
+    assert "You MUST use your Write tool to create this file" not in suffix
+    assert (tmp_path / ".agentfield_schema.json").exists()
+
+
+def test_non_grok_provider_keeps_original_or_codex_suffix(tmp_path: Path) -> None:
+    from agentfield.harness import _schema
+
+    apply_grok_harness_patch()
+    token = active_provider.set("claude-code")
+    try:
+        suffix = _schema.build_prompt_suffix(_TinySchema, str(tmp_path))
+    finally:
+        active_provider.reset(token)
+
+    assert "CRITICAL GROK STRUCTURED OUTPUT REQUIREMENTS" not in suffix
+
+
+def test_grok_execute_persists_final_message_when_schema_present(tmp_path: Path) -> None:
+    from agentfield.harness import _schema
+    from agentfield.harness._result import FailureType, Metrics, RawResult
+    from agentfield.harness.providers.grok import GrokProvider
+    from swe_af.runtime import grok_harness_patch as patch_mod
+
+    apply_grok_harness_patch()
+    # Seed schema file (as build_prompt_suffix would).
+    _schema.write_schema_file(
+        '{"type":"object","properties":{"action":{"type":"string"}}}',
+        str(tmp_path),
+    )
+
+    final_json = '{"action":"approve","summary":"ok"}'
+    original = AsyncMock(
+        return_value=RawResult(
+            result=final_json,
+            messages=[],
+            metrics=Metrics(),
+            is_error=False,
+            failure_type=FailureType.NONE,
+            returncode=0,
+        )
+    )
+    # Replace the stored original so our wrap calls this mock.
+    patch_mod._ORIGINAL_GROK_EXECUTE = original
+
+    provider = GrokProvider()
+    raw = asyncio.run(
+        provider.execute(
+            "task",
+            {"cwd": str(tmp_path), "model": "grok-4.5"},
+        )
+    )
+
+    assert raw.result == final_json
+    out = tmp_path / ".agentfield_output.json"
+    assert out.exists()
+    assert out.read_text(encoding="utf-8") == final_json
+    original.assert_awaited_once()
+
+
+def test_grok_execute_does_not_invent_output_when_result_empty(tmp_path: Path) -> None:
+    from agentfield.harness import _schema
+    from agentfield.harness._result import FailureType, Metrics, RawResult
+    from agentfield.harness.providers.grok import GrokProvider
+    from swe_af.runtime import grok_harness_patch as patch_mod
+
+    apply_grok_harness_patch()
+    _schema.write_schema_file(
+        '{"type":"object","properties":{"action":{"type":"string"}}}',
+        str(tmp_path),
+    )
+
+    original = AsyncMock(
+        return_value=RawResult(
+            result=None,
+            messages=[],
+            metrics=Metrics(),
+            is_error=True,
+            error_message="no output",
+            failure_type=FailureType.CRASH,
+            returncode=1,
+        )
+    )
+    patch_mod._ORIGINAL_GROK_EXECUTE = original
+
+    provider = GrokProvider()
+    raw = asyncio.run(
+        provider.execute("task", {"cwd": str(tmp_path), "model": "grok-4.5"})
+    )
+
+    assert raw.is_error is True
+    assert not (tmp_path / ".agentfield_output.json").exists()


### PR DESCRIPTION
## Summary

This PR makes **Grok** a first-class SWE-AF coding runtime, parallel to `claude_code`, `open_code`, and `codex`.

Operators can select Grok via:

- environment: `SWE_DEFAULT_RUNTIME=grok` (optional package env)
- request config: `{"runtime": "grok", "models": {"default": "grok-4.5"}}`

Harness-backed roles then resolve to AgentField’s `provider="grok"` adapter and use the default model id `grok-4.5` unless overridden.

## Dependency

**Requires AgentField with the Grok CLI harness provider.**

Tracking PR: https://github.com/Agent-Field/agentfield/pull/861

Until that lands in a released SDK, local development can install AgentField from the corresponding branch / commit. This SWE-AF PR is intentionally split so SDK and product runtime concerns review independently.

## Motivation

SWE-AF already abstracts coding-agent selection through `ExecutionConfig.runtime` / `BuildConfig.runtime` and `runtime_to_harness_adapter()`. Adding Grok is mostly a matter of:

1. accepting `grok` in the runtime vocabulary and model tables, and  
2. bridging AgentField’s default **Write-file schema strategy** to Grok’s headless CLI behavior.

Without (1), config validation rejects Grok. Without (2), schema-bearing harness calls fail under tool-less / read-only roles even when the model produces a correct final answer.

## Architecture

### Runtime mapping

```text
SWE_DEFAULT_RUNTIME=grok
        │
        ▼
normalize_runtime_provider → "grok"
        │
        ├─ runtime_to_harness_adapter → "grok"
        └─ _RUNTIME_BASE_MODELS["grok"] → all roles default to "grok-4.5"
```

Aliases accepted by `normalize_runtime_provider`: `grok`, `xai`, `grok-cli`, `grok_build`.

### Structured output adapter (Codex-patch architecture)

AgentField’s default schema path instructs the coding agent to **Write** `.agentfield_output.json`. That is correct for tool-rich sessions, but it is a poor fit when:

- the role intentionally has `tools=[]` (no Write), or  
- `permission_mode` is read-only and file creation is undesirable / impossible.

Codex already has a project-local adapter (`codex_harness_patch`) that:

1. rewrites the schema prompt for `provider=codex`, and  
2. relies on CLI-native persistence of the final message.

This PR adds the Grok counterpart: `swe_af/runtime/grok_harness_patch.py`.

#### Design rules

| Rule | Rationale |
| --- | --- |
| Provider-scoped prompt rewrite only when `active_provider == "grok"` | Claude / OpenCode / Codex keep their existing suffixes |
| Schema file is still written for reference | Model can open/read the schema contract |
| Final answer must be a single JSON object in response text | Avoids Write-tool dependency |
| Non-empty final text is persisted to `.agentfield_output.json` | Transport equivalent of Codex `--output-last-message` so the runner’s file parse path works |
| Empty / missing final text is **not** invented | Harness validation fails loudly; no silent success |

#### Explicit non-goals

- No deterministic business-level approve/fix/block when synthesis fails  
- No automatic second attempt with weaker schema / permission settings  
- No Grok `--json-schema` constrained decoding in this PR (follow-up candidate)

### Startup wiring

`apply_grok_harness_patch()` is invoked next to `apply_codex_harness_patch()` from:

- `swe_af.reasoners` (swe-planner)
- `swe_af.fast`
- `swe_af.issue`

The Grok patch **composes** with the Codex patch: it depends on `active_provider` from the Codex patch’s `Agent.harness` wrapper and only intercepts Grok calls.

## Configuration surface

### Package env (`agentfield-package.yaml`)

```yaml
- name: SWE_DEFAULT_RUNTIME
  description: Coding-agent runtime (claude_code|open_code|codex|grok)
  default: claude_code
```

### Python config

```python
ExecutionConfig(runtime="grok", models={"default": "grok-4.5"})
# or BuildConfig(...)
```

### Model defaults

`_RUNTIME_BASE_MODELS["grok"]` sets every role model field to `grok-4.5`. Per-role and env overrides (`SWE_DEFAULT_MODEL`, tier envs, `models.<role>`) still win via existing resolution order.

## Files

| Path | Change |
| --- | --- |
| `swe_af/runtime/providers.py` | Recognize and map `grok` |
| `swe_af/runtime/grok_harness_patch.py` | Structured-output adapter |
| `swe_af/runtime/__init__.py` | Export / apply surface |
| `swe_af/reasoners/__init__.py` | Install patch on planner boot |
| `swe_af/fast/__init__.py` | Install patch on swe-fast boot |
| `swe_af/issue/__init__.py` | Install patch on issue surface boot |
| `swe_af/execution/schemas.py` | Runtime literal + base models + `ai_provider` |
| `swe_af/fast/schemas.py` | Runtime literal |
| `swe_af/issue/schemas.py` | Runtime literal |
| `agentfield-package.yaml` | Document `SWE_DEFAULT_RUNTIME` including grok |
| `tests/test_grok_harness_patch.py` | Unit coverage for prompt rewrite + persist rules |

## Behavioral impact

| Scenario | Before | After |
| --- | --- | --- |
| `runtime="grok"` in config | Validation error / unsupported | Accepted; harness provider `grok` |
| Schema role without Write under Grok | Often no structured result | Final JSON response captured when present |
| Schema role produces empty output | N/A / failure | Still fails loudly (no invented payload) |
| Other runtimes | Unchanged | Unchanged |

## Test plan

- [x] Unit: Grok prompt suffix is used only when `active_provider == "grok"`
- [x] Unit: non-Grok providers keep prior suffix behavior
- [x] Unit: non-empty final message is persisted when schema file exists
- [x] Unit: empty final message does **not** create an invented output file
- [x] Regression: existing Codex harness patch tests still pass alongside Grok patch tests (`16 passed` in combined run with Grok-capable AgentField on `PYTHONPATH`)
- [ ] CI green on this branch
- [ ] Integration (optional, local): with AgentField #861 + Grok CLI installed, run a short `resume_build` / single issue with `runtime=grok` and confirm harness roles complete structured validation

## Compatibility / rollout

1. Land / release AgentField Grok provider (linked PR).  
2. Merge this PR.  
3. Deployers set `SWE_DEFAULT_RUNTIME=grok` and ensure the Grok Build CLI is on `PATH` (or configured via harness bin options once exposed).  

No migration is required for existing Claude / OpenRouter / Codex deployments; the change is additive.

## Follow-ups

1. Optional native Grok `--json-schema` constrained decoding (stronger guarantees than prompt-only JSON).  
2. Idle-watchdog guidance for long non-streaming Grok sessions (`AGENTFIELD_HARNESS_IDLE_SECONDS`).  
3. Pin minimum AgentField version once the Grok provider ships in a numbered release.