### PR TITLE
Point the repo-root install at the Go node

### DIFF
--- a/agentfield-package.yaml
+++ b/agentfield-package.yaml
@@ -4,6 +4,18 @@ version: 0.1.0
 description: SWE planning/execution agent node (plans and executes software-engineering tasks)
 author: Agent-Field
 
+# The Go node in go/ is the maintained SWE node: same reasoners, same
+# interface, one static binary, and it ships the coding engine. Installing this
+# repo installs that instead, and replaces an existing swe-planner — so
+# `af install https://github.com/Agent-Field/SWE-AF` is the one thing a user
+# has to know, before and after the switch.
+#
+# This manifest stays here as the redirect, so the Python node is still what
+# `python -m swe_af` and the Docker images run. The redirect is a git-install
+# behaviour only: to install this node deliberately, clone the repo and install
+# the checkout as a local path.
+superseded_by: https://github.com/Agent-Field/SWE-AF//go
+
 entrypoint:
   start: python -m swe_af
   healthcheck: /health


### PR DESCRIPTION
## Why

The Go node in `go/` is the maintained SWE node — same reasoners, same
interface, one static binary, and it ships the coding engine. Until now
getting it meant knowing to append `//go`, and anyone who installed this repo
earlier stayed on the Python node with no way across.

## What

The root manifest declares itself superseded by the Go node:

```yaml
name: swe-planner
superseded_by: https://github.com/Agent-Field/SWE-AF//go
```

So this becomes the one thing a user has to know, before and after the switch:

```
af install https://github.com/Agent-Field/SWE-AF
```

It installs the Go node, and **replaces** an existing `swe-planner` — warning
first, and carrying that node's secrets across.

The Python node is unchanged and still what `python -m swe_af` and the Docker
images run; this manifest stays as the redirect. To install it deliberately,
clone the repo and install the checkout as a local path.

## Requires

`superseded_by` support in agentfield (Agent-Field/agentfield#872). An older
`af` ignores the key and installs the Python node exactly as before, so this
is safe to land in either order.

## Verified end to end

Against a real repo containing this manifest and the `go/` node with its
bundled engine binary:

- `af install <repo url>` warns, then installs `swe-planner-go` — the Go node,
  engine binary present at `0755` with a matching checksum
- the recorded source keeps the `//go` selector, so the next update stays on
  the Go node instead of reverting to Python
- with an existing `swe-planner` installed: warned, replaced, its node-scoped
  secret moved to the successor, old registry entry and directory removed,
  global secrets untouched
- started with **only** an `OPENROUTER_API_KEY`: the node registered its 31
  reasoners, the harness ran `opencode … -m openrouter/deepseek/deepseek-v4-flash`,
  and the bundled engine stayed off (it is opt-in via `SWE_PRO_ENGINE`)
- triggered `implement_issue` and it succeeded, delivering a branch with the
  requested function plus a passing pytest test

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)