### PR TITLE
Say where the coding engine is on by default, and where it is opt-in

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -194,16 +194,21 @@
 #   zhipuai-coding-plan/glm-4.7 # GLM-4.7 via Z.AI direct (set ZHIPU_API_KEY)
 #   openrouter/z-ai/glm-5       # GLM-5 via OpenRouter (set OPENROUTER_API_KEY)
 
-# --- High-performance coding engine (Go node, ON by default) ---
+# --- High-performance coding engine, beta (Go node) ---
 #
 # The Go node ships prebuilt coding engines — one per supported platform, at
 # go/bin/swe-pro-darwin-arm64 and go/bin/swe-pro-linux-amd64 — that take over
-# per-issue coding work. `af install` turns this on for you (the manifest
-# defaults it to 1): the engine registers as its own node on the control plane
-# and builds route their coding through it. Set it to 0 to use the classic
-# coding loop instead. If the binary is missing, the node logs a warning and
-# keeps using the classic loop.
-# SWE_PRO_ENGINE=0
+# per-issue coding work: the engine registers as its own node on the control
+# plane and builds route their coding through it.
+#
+# Whether it runs depends on how the node was started:
+#   * `af install` / AgentField Desktop — ON for you already (the manifest
+#     defaults SWE_PRO_ENGINE to 1). Set it to 0 for the classic coding loop.
+#   * this file's audience (a clone, a fork, the compose stacks, a bare
+#     binary) — OFF. Uncomment the line below to opt in.
+# If the binary is missing, the node logs a warning and keeps using the
+# classic loop.
+# SWE_PRO_ENGINE=1
 
 # Engine sidecar identity and reachability. In containers, set the public URL
 # so the control plane can reach the engine's callback (mirrors

--- a/README.md
+++ b/README.md
@@ -947,14 +947,26 @@ the same node ids, running both against one control plane needs an explicit
 `NODE_ID` on one of them — `docker-compose.go.yml` does that. See
 [`go/README.md`](go/README.md) for build, run, and Docker instructions.
 
-### Coding engine (opt-in preview)
+### Coding engine (beta)
 
-The Go node ships a prebuilt high-performance coding engine next to the
-classic coding loop. It is **inert by default** — nothing changes unless you
-set `SWE_PRO_ENGINE=1`. With the flag set, builds route per-issue coding
-through the engine; unset it and the node returns to the classic
-coder → reviewer/QA loop. If the binary isn't present, the node logs a
-warning and keeps using the classic loop, so the flag is safe to leave on.
+The Go node ships a prebuilt high-performance coding engine next to the classic
+coding loop. Whether it runs depends on how you got the node:
+
+| How you run SWE-AF | Engine | To change it |
+| --- | --- | --- |
+| `af install` / AgentField Desktop | **On by default** — `go/agentfield-package.yaml` declares `SWE_PRO_ENGINE` with `default: "1"`, and the installer injects it | `SWE_PRO_ENGINE=0` for the classic loop |
+| Clone, fork, `docker-compose.go.yml`, or a bare binary | **Off** — nothing changes unless you ask for it | `SWE_PRO_ENGINE=1` to opt in |
+
+The gate is purely the environment variable; the manifest is simply what sets
+it for you on an `af install`. With the engine on, builds route per-issue
+coding through it — everything else, including branch/push/PR, stays with the
+standard pipeline. Turn it off and the node returns to the classic
+coder → reviewer/QA loop. Reasoner names and input/output shapes are identical
+either way, so switching costs nothing but a restart.
+
+If the binary isn't present or isn't runnable, the node logs a warning and
+keeps using the classic loop, so the flag is safe to leave on.
+
 Tuning knobs (`SWE_PRO_VARIANT`, `SWE_PRO_MAX_COST`, `SWE_PRO_PUBLIC_URL`)
 and the full env surface are documented in
 [`go/docs/pro-engine.md`](go/docs/pro-engine.md).

--- a/go/README.md
+++ b/go/README.md
@@ -165,7 +165,7 @@ set; the load-bearing ones:
 | `AGENT_CALLBACK_URL`                                      | Public URL the control plane calls the node back on. **Required for any containerized/remote deploy that isn't this compose file** (compose sets it per service) — without it the CP gets `504 agent_unreachable` |
 | `NODE_ID`                                                 | Node ID (`swe-planner` / `swe-fast`)           |
 | `PORT`                                                    | Listen port (`8005` / `8006`)                        |
-| `SWE_PRO_ENGINE`                                          | Opt-in preview: route per-issue coding through the bundled high-performance coding engine. **Default unset (off)**; `1`/`true`/`yes`/`on` enables it |
+| `SWE_PRO_ENGINE`                                          | Route per-issue coding through the bundled high-performance coding engine (beta). **Set to `1` for you by `af install` / Desktop; unset (off) everywhere else** — clone, fork, compose, bare binary. `1`/`true`/`yes`/`on` enables, `0`/`false` disables |
 | `SWE_PRO_VARIANT`                                         | Engine reasoning-effort variant (e.g. `low` for fastest turnaround, `high` for depth). Unset keeps the engine's own default |
 | `SWE_PRO_MAX_COST`                                        | Per-run cost ceiling in USD forwarded to the engine on every dispatch. Unset: no SWE-AF-side ceiling |
 | `SWE_PRO_PUBLIC_URL`                                      | Callback base URL for the engine, mirroring `AGENT_CALLBACK_URL` on the nodes. **In Docker this must be set to a container-reachable URL**, otherwise the control plane can't call the engine back |
@@ -178,15 +178,23 @@ authoritative set. The per-request build config JSON (`runtime`, `models`,
 budget/iteration knobs) is byte-identical to the Python node's — see the root
 [README](../README.md) and `.env.example` for the schema and examples.
 
-## Coding engine
+## Coding engine (beta)
 
 The Go node bundles a prebuilt high-performance coding engine alongside the
-classic coding loop, and runs it **by default**: `agentfield-package.yaml`
-declares `SWE_PRO_ENGINE` with `default: "1"`, so an `af install` node
-supervises the engine as a sidecar and routes per-issue coding through it. Set
-`SWE_PRO_ENGINE=0` and builds use the classic coder → reviewer/QA loop
-instead. A missing binary is not fatal — the node logs a warning and keeps
-using the classic loop.
+classic coding loop. Whether it runs is decided entirely by `SWE_PRO_ENGINE`,
+and the two ways of running the node differ only in who sets that variable:
+
+- **`af install` / AgentField Desktop — on by default.**
+  `agentfield-package.yaml` declares `SWE_PRO_ENGINE` with `default: "1"` and
+  the installer's env resolver injects it, so the node supervises the engine as
+  a sidecar and routes per-issue coding through it without being asked. Set
+  `SWE_PRO_ENGINE=0` to get the classic coder → reviewer/QA loop.
+- **Anything else — off.** A clone, a fork, `docker-compose.go.yml` (which
+  passes `SWE_PRO_ENGINE` through but leaves it empty), or a bare `swe-planner`
+  binary starts on the classic loop. Set `SWE_PRO_ENGINE=1` to opt in.
+
+A missing or non-runnable binary is not fatal — the node logs a warning and
+keeps using the classic loop.
 
 Full env surface (including the `SWE_PRO_*` knobs above, model pools, and the
 sidecar's restart behaviour): [`docs/pro-engine.md`](docs/pro-engine.md).

--- a/go/agentfield-package.yaml
+++ b/go/agentfield-package.yaml
@@ -52,8 +52,9 @@ user_environment:
       description: Override the model id for every role (e.g. openrouter/deepseek/deepseek-v4-flash)
     - name: SWE_PRO_ENGINE
       description: >-
-        High-performance coding engine. On by default — set it to 0 (or false)
-        to use the classic coding loop instead.
+        High-performance coding engine (beta). On by default for nodes
+        installed this way — set it to 0 (or false) to use the classic coding
+        loop instead.
       # The resolver injects this last unless the process env or a stored
       # secret overrides it, so an `af install` gets the engine without asking
       # and `SWE_PRO_ENGINE=0 af run` still opts out.

--- a/go/docs/pro-engine.md
+++ b/go/docs/pro-engine.md
@@ -1,4 +1,4 @@
-# Pro engine
+# Pro engine (beta)
 
 The Go node runs a high-performance coding engine, shipped as prebuilt
 binaries — one per supported platform, vendored at `go/bin` as
@@ -6,15 +6,21 @@ binaries — one per supported platform, vendored at `go/bin` as
 installed on macOS and Linux alike and the node picks the matching build at
 startup.
 
-It is **on by default** for nodes installed with `af install`:
-`agentfield-package.yaml` declares `SWE_PRO_ENGINE` with `default: "1"`, and
-the installer's env resolver injects that into the node process. Turning it
-off is a one-variable change and every existing integration — reasoner calls,
-cron triggers, `execute_fn_target` overrides — behaves identically either way.
+It is **on by default for nodes installed with `af install` or AgentField
+Desktop**: `agentfield-package.yaml` declares `SWE_PRO_ENGINE` with
+`default: "1"`, and the installer's env resolver injects that into the node
+process. Turning it off is a one-variable change and every existing
+integration — reasoner calls, cron triggers, `execute_fn_target` overrides —
+behaves identically either way.
 
-The gate itself is still purely the env var, so a binary launched outside the
-`af` runner (a bare `swe-planner`, a container that sets nothing) starts on the
-classic loop.
+**Everywhere else it is off**, because the gate is purely the env var and
+nothing but the installer sets it: a bare `swe-planner`, a clone or fork you
+run yourself, and the compose stacks (`docker-compose.go.yml` passes
+`SWE_PRO_ENGINE` through but leaves it empty) all start on the classic loop
+until you set `SWE_PRO_ENGINE=1`.
+
+This is a beta: it is the coding path we are actively developing, and rough
+edges are expected. `SWE_PRO_ENGINE=0` is always one restart away.
 
 ## Opting out
 
@@ -68,7 +74,7 @@ what keeps a macOS install from exec'ing the Linux build.
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `SWE_PRO_ENGINE` | `1` via the manifest (unset = off for a bare binary) | Truthy (`1`/`true`/`yes`/`on`) enables; `0`/`false` opts out |
+| `SWE_PRO_ENGINE` | `1` via the manifest on `af install` / Desktop; unset (off) for a clone, fork, compose stack or bare binary | Truthy (`1`/`true`/`yes`/`on`) enables; `0`/`false` opts out |
 | `SWE_PRO_BIN` | `/usr/local/bin/swe-pro`, else a `swe-pro-<GOOS>-<GOARCH>` / `swe-pro` sibling | Engine binary path (authoritative when set) |
 | `SWE_PRO_NODE_ID` | `swe-pro` | Engine's control-plane node id |
 | `SWE_PRO_PORT` | `8801` | Engine's listen port |
@@ -105,7 +111,8 @@ past the longest single issue you expect, or bound engine runs with
 
 ## Rollout
 
-The pro engine is the default for `af install` nodes as of this release. The
+The pro engine is the default for `af install` / Desktop nodes as of this
+release, and opt-in everywhere else (clone, fork, compose, bare binary). The
 classic coding loop remains fully supported and is one variable away
 (`SWE_PRO_ENGINE=0`); existing reasoner names and input/output shapes are
 identical either way, so switching costs nothing but a restart.


### PR DESCRIPTION
## The actual rule

The engine is gated purely by `SWE_PRO_ENGINE`, and the only thing that sets that variable for you is the installer. `go/agentfield-package.yaml` declares it with `default: "1"`, and the installer's env resolver injects declared defaults, so:

| How you run the node | Engine |
| --- | --- |
| `af install` / AgentField Desktop | **on** |
| clone, fork, `docker-compose.go.yml`, bare binary | **off** |

`docker-compose.go.yml` passes `SWE_PRO_ENGINE` through but leaves it empty, so compose users are in the second row.

## What each doc was saying

- **`README.md`** — headed "Coding engine (opt-in preview)" and stated the engine is "**inert by default** — nothing changes unless you set `SWE_PRO_ENGINE=1`". True for a checkout; wrong for the install path the README itself recommends two sections earlier.
- **`go/README.md`** — contradicted itself: the prose said the node "runs it **by default**", the env table said "**Default unset (off)**".
- **`.env.example`** — headed "(Go node, ON by default)" for an audience that only ever sees it off, and offered `# SWE_PRO_ENGINE=0` as the line to uncomment, i.e. exactly backwards for that reader.
- **`go/docs/pro-engine.md`** — already correct; only needed the compose case named explicitly, since "a container that sets nothing" doesn't obviously cover a compose file that sets it empty.

All four now state the same two-part rule, and call the engine a **beta** rather than a "preview".

## Behaviour

None changed. The manifest keeps `default: "1"`; only its `description` string is edited, to name the beta and scope "on by default" to nodes installed that way. `TestEnabledOptOutContract` asserts on `Enabled()` semantics, not on the description, and is untouched.

## Validation

Ran the literal steps from `.github/workflows/ci.yml`'s Go job in a worktree off `origin/main`:

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test -race -count=1 ./...` — **28 packages ok, exit 0**

The Python job (`make check`) is unaffected: no Python source or test reads any of the touched files. `tests/test_deployment_docs.py` only asserts the literal string `.env.example` appears in a deployment doc, which it still does.

Verified against a live install beforehand — `af install https://github.com/Agent-Field/SWE-AF` with `SWE_PRO_ENGINE` unset everywhere brings the engine up, confirming the manifest default is what decides it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)