### PR TITLE
feat(benchmark): add the evaluator the README already points at

### DIFF
--- a/examples/agent-comparison/evaluator/README.md
+++ b/examples/agent-comparison/evaluator/README.md
@@ -1,0 +1,28 @@
+# Benchmark evaluator
+
+Deterministic scorer for the benchmark rubric published in the root README
+(Functional 30 / Structure 20 / Hygiene 20 / Git 15 / Quality 15). Run it
+against any agent's output directory and get the same numbers anyone else
+would:
+
+```bash
+python score.py <project_dir>              # Structure + Hygiene + Git (55 pts)
+python score.py <project_dir> --run-tests  # + Functional (30 pts, executes npm test)
+python score.py <project_dir> --json       # machine-readable report
+```
+
+Every check prints its evidence, so a disputed score is an argument about a
+file listing or a git log, not about taste.
+
+Honest boundaries, by design:
+
+- **Quality (15 pts) is never auto-scored.** It is a judgment call; the
+  script reports the inputs to that judgment (README, package metadata,
+  custom error types) and assigns no points.
+- **Unscorable ≠ zero.** The vendored artifacts in `../` had their `.git`
+  stripped when they were copied in, so the Git dimension (and clean-status
+  check) is reported as UNSCORABLE on them. Comparable scores must be
+  produced from each agent's original output directory, including its
+  `.git`.
+
+Tested in `tests/test_benchmark_scorer.py`.

--- a/examples/agent-comparison/evaluator/score.py
+++ b/examples/agent-comparison/evaluator/score.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Deterministic scorer for the README benchmark rubric.
+
+The benchmark table in the README scores five dimensions (Functional 30,
+Structure 20, Hygiene 20, Git 15, Quality 15). Four of them are mechanical
+properties of the generated project, so they should not require a human --
+or trust in one. This script recomputes them from a project directory and
+prints per-check evidence, so anyone can re-run the comparison on any
+agent's output and get the same numbers.
+
+What it will and will not do:
+
+- Structure / Hygiene / Git (55 pts) are scored deterministically. Git
+  checks need the project's real ``.git`` history; on the checked-in
+  artifacts (history stripped when they were copied into examples/) they
+  are reported as UNSCORABLE rather than silently zeroed.
+- Functional (30 pts) is scored by actually running ``npm install`` and
+  ``npm test``, opt-in via ``--run-tests`` because it executes the
+  project's code.
+- Quality (15 pts) is a judgment call. This script does not fake one: it
+  reports observations (README, package metadata, custom error types) and
+  assigns no points. A deterministic scorer that pretended to measure
+  "quality" would just be an opinion with extra steps.
+
+So a full run reports up to 85 recomputable points and clearly labels the
+remaining 15 as judgment. Scores are only comparable when produced from
+each agent's original output directory, including its ``.git``.
+
+Usage:
+    python score.py <project_dir> [--run-tests] [--json]
+
+Exit code is 0 unless the directory is missing or not a project.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+
+SOURCE_DIRS = ("src", "lib", "bin")
+TEST_DIRS = ("test", "tests", "__tests__")
+JUNK_NAMES = (".DS_Store",)
+JUNK_DIRS = ("node_modules", "coverage")
+JUNK_GLOBS = ("*.log",)
+# Files the todo-app prompt tends to leave behind: persisted runtime data.
+JUNK_DATA = ("todos.json", "todo.json", "data.json")
+
+TRIVIAL_SUBJECT = re.compile(r"^(wip|fix|update|tmp|temp|changes|stuff|misc)\.?$", re.I)
+
+
+@dataclass
+class Check:
+    dimension: str
+    name: str
+    points: int
+    # True = earned, False = not earned, None = unscorable in this context.
+    passed: bool | None
+    evidence: str
+
+
+@dataclass
+class Report:
+    project: str
+    checks: list[Check] = field(default_factory=list)
+    observations: list[str] = field(default_factory=list)
+
+    def add(self, dimension: str, name: str, points: int, passed: bool | None, evidence: str) -> None:
+        self.checks.append(Check(dimension, name, points, passed, evidence))
+
+    def earned(self) -> int:
+        return sum(c.points for c in self.checks if c.passed is True)
+
+    def scoreable(self) -> int:
+        return sum(c.points for c in self.checks if c.passed is not None)
+
+
+def _list_files(root: Path) -> list[Path]:
+    out: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in (".git", "node_modules")]
+        for f in filenames:
+            out.append(Path(dirpath, f).relative_to(root))
+    return out
+
+
+def _git(root: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(root), *args], capture_output=True, text=True, timeout=60
+    )
+
+
+# ---------------------------------------------------------------- structure
+
+def score_structure(root: Path, report: Report) -> None:
+    files = _list_files(root)
+    js_at_root = [f for f in files if f.parent == Path(".") and f.suffix in (".js", ".mjs", ".cjs", ".ts")]
+    src_dirs = sorted({f.parts[0] for f in files if f.parts[0] in SOURCE_DIRS})
+    test_dirs = sorted({f.parts[0] for f in files if f.parts[0] in TEST_DIRS})
+
+    # Source lives in a dedicated directory, not flat at the project root.
+    # A lone root cli.js entry point alongside a src/ dir is conventional and
+    # does not count against it; three root modules and no src/ does.
+    modular = bool(src_dirs) and len(js_at_root) <= 1
+    report.add(
+        "structure", "source in dedicated dir", 7, modular,
+        f"source dirs: {src_dirs or 'none'}; root-level modules: {[str(f) for f in js_at_root] or 'none'}",
+    )
+
+    report.add(
+        "structure", "tests in dedicated dir", 7, bool(test_dirs),
+        f"test dirs: {test_dirs or 'none'}",
+    )
+
+    modules = [f for f in files if f.suffix in (".js", ".mjs", ".cjs", ".ts")
+               and not any(part in TEST_DIRS for part in f.parts)]
+    report.add(
+        "structure", "more than one source module", 6, len(modules) >= 2,
+        f"{len(modules)} source modules",
+    )
+
+
+# ------------------------------------------------------------------ hygiene
+
+def score_hygiene(root: Path, report: Report) -> None:
+    gitignore = root / ".gitignore"
+    report.add("hygiene", ".gitignore exists", 5, gitignore.is_file(),
+               "present" if gitignore.is_file() else "absent")
+
+    covers = gitignore.is_file() and "node_modules" in gitignore.read_text(errors="replace")
+    report.add(
+        "hygiene", ".gitignore covers node_modules", 5,
+        covers if gitignore.is_file() else False,
+        "listed" if covers else "not listed (or no .gitignore)",
+    )
+
+    junk: list[str] = []
+    for d in JUNK_DIRS:
+        if (root / d).is_dir():
+            junk.append(d + "/")
+    files = _list_files(root)
+    for f in files:
+        if f.name in JUNK_NAMES or f.name in JUNK_DATA or any(f.match(g) for g in JUNK_GLOBS):
+            junk.append(str(f))
+    report.add(
+        "hygiene", "no junk artifacts in tree", 5, not junk,
+        f"junk found: {junk}" if junk else "clean",
+    )
+
+    if (root / ".git").exists():
+        status = _git(root, "status", "--porcelain")
+        dirty = status.stdout.strip()
+        report.add(
+            "hygiene", "clean git status", 5, not dirty,
+            f"{len(dirty.splitlines())} dirty paths" if dirty else "clean",
+        )
+    else:
+        report.add("hygiene", "clean git status", 5, None, "UNSCORABLE: no .git in this copy")
+
+
+# ---------------------------------------------------------------------- git
+
+def score_git(root: Path, report: Report) -> None:
+    if not (root / ".git").exists():
+        for name, pts in (("history has >= 3 commits", 5),
+                          ("commit subjects are descriptive", 5),
+                          ("no duplicated subjects", 5)):
+            report.add("git", name, pts, None,
+                       "UNSCORABLE: no .git in this copy — score from the agent's original output")
+        return
+
+    log = _git(root, "log", "--format=%s")
+    if log.returncode != 0:
+        for name, pts in (("history has >= 3 commits", 5),
+                          ("commit subjects are descriptive", 5),
+                          ("no duplicated subjects", 5)):
+            report.add("git", name, pts, None, f"UNSCORABLE: git log failed: {log.stderr.strip()}")
+        return
+
+    subjects = [s for s in log.stdout.splitlines() if s.strip()]
+    report.add("git", "history has >= 3 commits", 5, len(subjects) >= 3, f"{len(subjects)} commits")
+
+    weak = [s for s in subjects if len(s) < 10 or TRIVIAL_SUBJECT.match(s.strip())]
+    report.add(
+        "git", "commit subjects are descriptive", 5, bool(subjects) and not weak,
+        f"weak subjects: {weak}" if weak else "all subjects >= 10 chars and non-trivial",
+    )
+
+    dupes = sorted({s for s in subjects if subjects.count(s) > 1})
+    report.add(
+        "git", "no duplicated subjects", 5, bool(subjects) and not dupes,
+        f"duplicated: {dupes}" if dupes else "all unique",
+    )
+
+
+# --------------------------------------------------------------- functional
+
+def score_functional(root: Path, report: Report, run_tests: bool) -> None:
+    if not run_tests:
+        report.add("functional", "npm test passes", 30, None,
+                   "NOT RUN: pass --run-tests to execute the project's own suite")
+        return
+    if not (root / "package.json").is_file():
+        report.add("functional", "npm test passes", 30, False, "no package.json")
+        return
+    env = {**os.environ, "CI": "1"}
+    install = subprocess.run(["npm", "install", "--no-audit", "--no-fund", "--silent"],
+                             cwd=root, capture_output=True, text=True, timeout=600, env=env)
+    if install.returncode != 0:
+        report.add("functional", "npm test passes", 30, False,
+                   f"npm install failed: {install.stderr.strip()[:200]}")
+        return
+    test = subprocess.run(["npm", "test", "--silent"],
+                          cwd=root, capture_output=True, text=True, timeout=600, env=env)
+    lines = [ln for ln in (test.stdout + test.stderr).splitlines() if ln.strip()]
+    tail = lines[-1] if lines else "(no output)"
+    report.add("functional", "npm test passes", 30, test.returncode == 0,
+               f"exit {test.returncode}: {tail[:200]}")
+
+
+# ------------------------------------------------------ quality observations
+
+def observe_quality(root: Path, report: Report) -> None:
+    """Quality (15) is judgment. Report inputs to that judgment; score nothing."""
+    report.observations.append(
+        f"README present: {(root / 'README.md').is_file()}"
+    )
+    pkg = root / "package.json"
+    if pkg.is_file():
+        try:
+            meta = json.loads(pkg.read_text())
+            have = [k for k in ("description", "license", "author") if meta.get(k)]
+            report.observations.append(f"package.json metadata present: {have or 'none'}")
+        except json.JSONDecodeError:
+            report.observations.append("package.json: not valid JSON")
+    error_types: set[str] = set()
+    for f in _list_files(root):
+        if f.suffix in (".js", ".mjs", ".cjs", ".ts"):
+            text = (root / f).read_text(errors="replace")
+            error_types.update(re.findall(r"class\s+(\w*Error)\s+extends", text))
+    report.observations.append(f"custom error types: {sorted(error_types) or 'none'}")
+
+
+# ------------------------------------------------------------------- output
+
+def render(report: Report) -> str:
+    lines = [f"project: {report.project}", ""]
+    by_dim: dict[str, list[Check]] = {}
+    for c in report.checks:
+        by_dim.setdefault(c.dimension, []).append(c)
+    for dim, checks in by_dim.items():
+        earned = sum(c.points for c in checks if c.passed is True)
+        scoreable = sum(c.points for c in checks if c.passed is not None)
+        total = sum(c.points for c in checks)
+        head = f"{dim} — {earned}/{scoreable} scoreable"
+        if scoreable < total:
+            head += f" ({total - scoreable} pts unscorable here)"
+        lines.append(head)
+        for c in checks:
+            mark = {True: "PASS", False: "fail", None: "  — "}[c.passed]
+            lines.append(f"  [{mark}] ({c.points:>2}) {c.name}: {c.evidence}")
+        lines.append("")
+    lines.append(f"deterministic total: {report.earned()}/{report.scoreable()} scoreable points")
+    lines.append("quality (15 pts): judgment — observations only:")
+    for o in report.observations:
+        lines.append(f"  - {o}")
+    return "\n".join(lines)
+
+
+def score(root: Path, run_tests: bool = False) -> Report:
+    report = Report(project=str(root))
+    score_structure(root, report)
+    score_hygiene(root, report)
+    score_git(root, report)
+    score_functional(root, report, run_tests)
+    observe_quality(root, report)
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("project_dir", type=Path)
+    parser.add_argument("--run-tests", action="store_true",
+                        help="execute npm install + npm test for the Functional dimension")
+    parser.add_argument("--json", action="store_true", help="emit the report as JSON")
+    args = parser.parse_args(argv)
+
+    root = args.project_dir
+    if not root.is_dir():
+        print(f"error: {root} is not a directory", file=sys.stderr)
+        return 2
+    report = score(root, run_tests=args.run_tests)
+    if args.json:
+        print(json.dumps(asdict(report), indent=2))
+    else:
+        print(render(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/agent-comparison/evaluator/score.py
+++ b/examples/agent-comparison/evaluator/score.py
@@ -83,16 +83,27 @@ class Report:
 def _list_files(root: Path) -> list[Path]:
     out: list[Path] = []
     for dirpath, dirnames, filenames in os.walk(root):
-        dirnames[:] = [d for d in dirnames if d not in (".git", "node_modules")]
+        # Prune everything JUNK_DIRS names, not a hand-picked subset: a
+        # checked-in coverage/ must not be counted as project modules by
+        # Structure while Hygiene docks it as junk — one directory, one verdict.
+        dirnames[:] = [d for d in dirnames if d != ".git" and d not in JUNK_DIRS]
         for f in filenames:
             out.append(Path(dirpath, f).relative_to(root))
     return out
 
 
 def _git(root: Path, *args: str) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        ["git", "-C", str(root), *args], capture_output=True, text=True, timeout=60
-    )
+    # core.fsmonitor is cleared so scoring a repo can never execute a
+    # repo-configured monitor daemon; a scorer must read the project, not
+    # run it (running is what --run-tests opts into).
+    cmd = ["git", "-c", "core.fsmonitor=", "-C", str(root), *args]
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
+        # No git binary / a hung git is "couldn't look", not a property of
+        # the project. Surface it as a failed CompletedProcess so every
+        # caller's returncode check routes to UNSCORABLE with evidence.
+        return subprocess.CompletedProcess(cmd, returncode=127, stdout="", stderr=str(e))
 
 
 # ---------------------------------------------------------------- structure
@@ -127,12 +138,29 @@ def score_structure(root: Path, report: Report) -> None:
 
 # ------------------------------------------------------------------ hygiene
 
+def _gitignore_covers(gitignore: Path, target: str) -> bool:
+    """True when a non-comment line actually ignores `target`. A substring
+    scan would award the points to a commented-out line."""
+    for raw in gitignore.read_text(errors="replace").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        # Normalize the common spellings: node_modules, /node_modules,
+        # node_modules/, **/node_modules — all ignore the directory.
+        normalized = line.strip("/")
+        if normalized.startswith("**/"):
+            normalized = normalized[3:]
+        if normalized == target:
+            return True
+    return False
+
+
 def score_hygiene(root: Path, report: Report) -> None:
     gitignore = root / ".gitignore"
     report.add("hygiene", ".gitignore exists", 5, gitignore.is_file(),
                "present" if gitignore.is_file() else "absent")
 
-    covers = gitignore.is_file() and "node_modules" in gitignore.read_text(errors="replace")
+    covers = gitignore.is_file() and _gitignore_covers(gitignore, "node_modules")
     report.add(
         "hygiene", ".gitignore covers node_modules", 5,
         covers if gitignore.is_file() else False,
@@ -154,11 +182,16 @@ def score_hygiene(root: Path, report: Report) -> None:
 
     if (root / ".git").exists():
         status = _git(root, "status", "--porcelain")
-        dirty = status.stdout.strip()
-        report.add(
-            "hygiene", "clean git status", 5, not dirty,
-            f"{len(dirty.splitlines())} dirty paths" if dirty else "clean",
-        )
+        if status.returncode != 0:
+            # git missing/failed: empty stdout must not read as "clean".
+            report.add("hygiene", "clean git status", 5, None,
+                       f"UNSCORABLE: git status failed: {status.stderr.strip()[:200]}")
+        else:
+            dirty = status.stdout.strip()
+            report.add(
+                "hygiene", "clean git status", 5, not dirty,
+                f"{len(dirty.splitlines())} dirty paths" if dirty else "clean",
+            )
     else:
         report.add("hygiene", "clean git status", 5, None, "UNSCORABLE: no .git in this copy")
 
@@ -209,14 +242,31 @@ def score_functional(root: Path, report: Report, run_tests: bool) -> None:
         report.add("functional", "npm test passes", 30, False, "no package.json")
         return
     env = {**os.environ, "CI": "1"}
-    install = subprocess.run(["npm", "install", "--no-audit", "--no-fund", "--silent"],
-                             cwd=root, capture_output=True, text=True, timeout=600, env=env)
+    try:
+        # --ignore-scripts: running the project's suite is the explicit
+        # opt-in here; package lifecycle scripts are not part of that deal.
+        install = subprocess.run(
+            ["npm", "install", "--no-audit", "--no-fund", "--silent", "--ignore-scripts"],
+            cwd=root, capture_output=True, text=True, timeout=600, env=env)
+    except FileNotFoundError:
+        # "unscorable is never zero" applies to the scorer's own toolchain
+        # too: a machine without npm couldn't look, the project didn't fail.
+        report.add("functional", "npm test passes", 30, None, "UNSCORABLE: npm is not installed")
+        return
+    except subprocess.TimeoutExpired:
+        report.add("functional", "npm test passes", 30, False, "npm install timed out after 600s")
+        return
     if install.returncode != 0:
         report.add("functional", "npm test passes", 30, False,
                    f"npm install failed: {install.stderr.strip()[:200]}")
         return
-    test = subprocess.run(["npm", "test", "--silent"],
-                          cwd=root, capture_output=True, text=True, timeout=600, env=env)
+    try:
+        test = subprocess.run(["npm", "test", "--silent"],
+                              cwd=root, capture_output=True, text=True, timeout=600, env=env)
+    except subprocess.TimeoutExpired:
+        # A suite that never finishes IS a property of the project.
+        report.add("functional", "npm test passes", 30, False, "npm test timed out after 600s")
+        return
     lines = [ln for ln in (test.stdout + test.stderr).splitlines() if ln.strip()]
     tail = lines[-1] if lines else "(no output)"
     report.add("functional", "npm test passes", 30, test.returncode == 0,

--- a/tests/test_benchmark_scorer.py
+++ b/tests/test_benchmark_scorer.py
@@ -166,6 +166,87 @@ def test_quality_is_observed_never_scored(well_formed: Path):
     assert any("package.json metadata" in o for o in report.observations)
 
 
+def test_coverage_dir_is_pruned_from_structure_not_double_counted(well_formed: Path):
+    """A checked-in coverage/ is junk (Hygiene docks it) — it must not ALSO
+    inflate Structure's module count as if it were project source."""
+    (well_formed / "coverage").mkdir()
+    (well_formed / "coverage" / "bundle.js").write_text("x\n")
+    (well_formed / "coverage" / "report.js").write_text("x\n")
+
+    report = scorer.score(well_formed)
+    modules = _check(report, "structure", "more than one source module")
+    # 4 real modules (cli + 3 in src/); the two coverage files are pruned.
+    assert "4 source modules" in modules.evidence
+    assert _check(report, "hygiene", "no junk artifacts in tree").passed is False
+
+
+def test_commented_out_gitignore_line_earns_nothing(well_formed: Path):
+    (well_formed / ".gitignore").write_text("# node_modules\n")
+    report = scorer.score(well_formed)
+    assert _check(report, "hygiene", ".gitignore covers node_modules").passed is False
+
+
+def test_gitignore_spelling_variants_all_cover(well_formed: Path):
+    for spelling in ("node_modules", "node_modules/", "/node_modules", "**/node_modules"):
+        (well_formed / ".gitignore").write_text(f"{spelling}\n")
+        report = scorer.score(well_formed)
+        check = _check(report, "hygiene", ".gitignore covers node_modules")
+        assert check.passed is True, f"spelling {spelling!r} should cover"
+
+
+def test_missing_npm_is_unscorable_not_a_crash(well_formed: Path, monkeypatch):
+    """FileNotFoundError from a machine without npm is 'couldn't look',
+    never a traceback and never a zero."""
+    real_run = scorer.subprocess.run
+
+    def no_npm(cmd, *a, **kw):
+        if cmd[0] == "npm":
+            raise FileNotFoundError("npm")
+        return real_run(cmd, *a, **kw)
+
+    monkeypatch.setattr(scorer.subprocess, "run", no_npm)
+    report = scorer.score(well_formed, run_tests=True)
+    fn = _check(report, "functional", "npm test passes")
+    assert fn.passed is None
+    assert "npm is not installed" in fn.evidence
+
+
+def test_hung_npm_test_is_a_failure_with_evidence(well_formed: Path, monkeypatch):
+    (well_formed / "package.json").write_text('{"name": "p"}\n')
+    real_run = scorer.subprocess.run
+
+    def hang_on_test(cmd, *a, **kw):
+        if cmd[0] == "npm" and "test" in cmd:
+            raise scorer.subprocess.TimeoutExpired(cmd, 600)
+        if cmd[0] == "npm":  # install: pretend success
+            return scorer.subprocess.CompletedProcess(cmd, 0, "", "")
+        return real_run(cmd, *a, **kw)
+
+    monkeypatch.setattr(scorer.subprocess, "run", hang_on_test)
+    report = scorer.score(well_formed, run_tests=True)
+    fn = _check(report, "functional", "npm test passes")
+    assert fn.passed is False
+    assert "timed out" in fn.evidence
+
+
+def test_missing_git_binary_is_unscorable_not_a_crash(well_formed: Path, monkeypatch):
+    real_run = scorer.subprocess.run
+
+    def no_git(cmd, *a, **kw):
+        if cmd[0] == "git":
+            raise FileNotFoundError("git")
+        return real_run(cmd, *a, **kw)
+
+    monkeypatch.setattr(scorer.subprocess, "run", no_git)
+    report = scorer.score(well_formed)
+    # .git exists but git can't run: every git-backed check is unscorable.
+    assert _check(report, "hygiene", "clean git status").passed is None
+    for name in ("history has >= 3 commits",
+                 "commit subjects are descriptive",
+                 "no duplicated subjects"):
+        assert _check(report, "git", name).passed is None
+
+
 def test_scores_the_checked_in_sonnet_artifact():
     """Smoke against a real vendored artifact: claude-code-sonnet is flat
     (cli.js / todo.js / todo.test.js at the root), which is exactly what the

--- a/tests/test_benchmark_scorer.py
+++ b/tests/test_benchmark_scorer.py
@@ -1,0 +1,178 @@
+"""Tests for the deterministic benchmark scorer.
+
+The scorer's whole claim is that the mechanical dimensions of the README
+benchmark (Structure, Hygiene, Git) can be recomputed by anyone from a
+project directory. These tests pin that claim: a well-formed project earns
+the full deterministic score, each defect docks exactly its own check, and
+states the scorer cannot see (no .git, tests not run) are reported as
+unscorable rather than silently zeroed — a scorer that can't tell "failed"
+from "couldn't look" would rank projects by how much of them it happened
+to see.
+
+The scorer is stdlib-only and lives with the benchmark assets it scores:
+``examples/agent-comparison/evaluator/score.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCORER = (
+    Path(__file__).resolve().parents[1]
+    / "examples" / "agent-comparison" / "evaluator" / "score.py"
+)
+_spec = importlib.util.spec_from_file_location("benchmark_scorer", _SCORER)
+scorer = importlib.util.module_from_spec(_spec)
+# dataclasses resolves string annotations through sys.modules[cls.__module__],
+# so the module must be registered before exec_module runs its @dataclass defs.
+sys.modules["benchmark_scorer"] = scorer
+_spec.loader.exec_module(scorer)
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        check=True,
+        capture_output=True,
+        env={
+            "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+        },
+    )
+
+
+def _check(report, dimension: str, name: str):
+    for c in report.checks:
+        if c.dimension == dimension and c.name == name:
+            return c
+    raise AssertionError(f"no check {dimension}/{name} in report")
+
+
+@pytest.fixture
+def well_formed(tmp_path: Path) -> Path:
+    """A project shaped the way the rubric's top scores describe."""
+    root = tmp_path / "proj"
+    (root / "src").mkdir(parents=True)
+    (root / "tests").mkdir()
+    (root / "src" / "store.js").write_text("module.exports = {};\n")
+    (root / "src" / "commands.js").write_text("module.exports = {};\n")
+    (root / "cli.js").write_text("#!/usr/bin/env node\n")
+    (root / "tests" / "store.test.js").write_text("test('x', () => {});\n")
+    (root / ".gitignore").write_text("node_modules/\ncoverage/\n")
+    (root / "package.json").write_text(
+        '{"name": "p", "description": "d", "license": "MIT"}\n'
+    )
+    _git(root, "init", "-q")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-qm", "feat: initial project scaffold")
+    (root / "src" / "utils.js").write_text("module.exports = {};\n")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-qm", "feat: add shared utils module")
+    (root / "tests" / "utils.test.js").write_text("test('y', () => {});\n")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-qm", "test: cover utils edge cases")
+    return root
+
+
+def test_well_formed_project_earns_all_deterministic_points(well_formed: Path):
+    report = scorer.score(well_formed)
+    # Structure 20 + Hygiene 20 + Git 15 — everything scoreable without executing code.
+    assert report.scoreable() == 55
+    assert report.earned() == 55
+
+
+def test_flat_layout_docks_structure_only(well_formed: Path):
+    # Flatten: move modules to the root, drop the test dir.
+    for f in list((well_formed / "src").iterdir()):
+        f.rename(well_formed / f.name)
+    (well_formed / "src").rmdir()
+    for f in list((well_formed / "tests").iterdir()):
+        f.rename(well_formed / f.name)
+    (well_formed / "tests").rmdir()
+    _git(well_formed, "add", "-A")
+    _git(well_formed, "commit", "-qm", "refactor: flatten layout for test")
+
+    report = scorer.score(well_formed)
+    assert _check(report, "structure", "source in dedicated dir").passed is False
+    assert _check(report, "structure", "tests in dedicated dir").passed is False
+    # Hygiene and git are untouched by layout.
+    assert _check(report, "hygiene", "no junk artifacts in tree").passed is True
+    assert _check(report, "git", "history has >= 3 commits").passed is True
+
+
+def test_junk_artifacts_and_dirty_tree_dock_hygiene(well_formed: Path):
+    (well_formed / "coverage").mkdir()
+    (well_formed / "coverage" / "lcov.info").write_text("x\n")
+    (well_formed / "todos.json").write_text("[]\n")  # persisted runtime data
+
+    report = scorer.score(well_formed)
+    junk = _check(report, "hygiene", "no junk artifacts in tree")
+    assert junk.passed is False
+    assert "coverage/" in junk.evidence and "todos.json" in junk.evidence
+    # Untracked junk also means the tree is not clean.
+    assert _check(report, "hygiene", "clean git status").passed is False
+
+
+def test_weak_and_duplicated_commit_subjects_dock_git(well_formed: Path):
+    (well_formed / "a.txt").write_text("1")
+    _git(well_formed, "add", "-A")
+    _git(well_formed, "commit", "-qm", "wip")
+    (well_formed / "b.txt").write_text("2")
+    _git(well_formed, "add", "-A")
+    _git(well_formed, "commit", "-qm", "feat: add shared utils module")  # duplicate
+
+    report = scorer.score(well_formed)
+    weak = _check(report, "git", "commit subjects are descriptive")
+    assert weak.passed is False
+    assert "wip" in weak.evidence
+    dupes = _check(report, "git", "no duplicated subjects")
+    assert dupes.passed is False
+    assert "feat: add shared utils module" in dupes.evidence
+
+
+def test_missing_git_history_is_unscorable_not_zero(tmp_path: Path):
+    """The checked-in benchmark artifacts have their .git stripped; the Git
+    dimension must be reported as unscorable there, never as a silent 0 —
+    otherwise vendored copies would rank below originals for free."""
+    root = tmp_path / "no-git"
+    (root / "src").mkdir(parents=True)
+    (root / "src" / "a.js").write_text("x\n")
+    report = scorer.score(root)
+    for name in ("history has >= 3 commits",
+                 "commit subjects are descriptive",
+                 "no duplicated subjects"):
+        assert _check(report, "git", name).passed is None
+    assert _check(report, "hygiene", "clean git status").passed is None
+    # Unscorable points are excluded from the denominator, not failed.
+    assert report.scoreable() == 35  # structure 20 + hygiene 15
+
+
+def test_functional_not_run_by_default(well_formed: Path):
+    report = scorer.score(well_formed)
+    fn = _check(report, "functional", "npm test passes")
+    assert fn.passed is None
+    assert "NOT RUN" in fn.evidence
+
+
+def test_quality_is_observed_never_scored(well_formed: Path):
+    report = scorer.score(well_formed)
+    assert all(c.dimension != "quality" for c in report.checks)
+    assert any("package.json metadata" in o for o in report.observations)
+
+
+def test_scores_the_checked_in_sonnet_artifact():
+    """Smoke against a real vendored artifact: claude-code-sonnet is flat
+    (cli.js / todo.js / todo.test.js at the root), which is exactly what the
+    README's Structure column docks it for — the scorer must see it too."""
+    artifact = _SCORER.parent.parent / "claude-code-sonnet"
+    if not artifact.is_dir():
+        pytest.skip("benchmark artifact not present")
+    report = scorer.score(artifact)
+    assert _check(report, "structure", "source in dedicated dir").passed is False
+    assert _check(report, "structure", "tests in dedicated dir").passed is False


### PR DESCRIPTION
The README says "Benchmark assets, logs, evaluator, and generated projects live in examples/agent-comparison/" — but no evaluator is there, so the score table (95/73/62/59) cannot currently be re-derived from anything in the repo. This adds a deterministic scorer for the published rubric so anyone can re-run the comparison on any agent's output and get the same numbers.

What it scores and how honestly it does it:

- Structure (20), Hygiene (20), Git (15): recomputed from the project directory, one evidence line per check. A disputed score becomes an argument about a file listing or a git log, not about taste.
- Functional (30): actually runs npm install + npm test, opt-in via --run-tests because it executes the project's code.
- Quality (15): never auto-scored. It is a judgment call, so the script reports the inputs to that judgment (README, package metadata, custom error types) and assigns no points. A deterministic scorer that pretended to measure "quality" would just be an opinion with extra steps.
- Unscorable is never zero: the vendored artifacts had .git stripped when they were copied in, so the Git dimension reports UNSCORABLE on them and drops out of the denominator instead of silently failing.

Stdlib-only, no new dependencies. tests/test_benchmark_scorer.py covers the full-marks fixture, each defect docking exactly its own check, the unscorable-vs-zero distinction, and a smoke run against the vendored claude-code-sonnet artifact (8 tests, pass under the CI env guard).

## Summary

- What changed
- Why it changed

## Validation

- [ ] `make check`
- [ ] Relevant manual test performed (if needed)

## Behavior Impact

- [ ] No behavior change
- [ ] Backward compatible behavior change
- [ ] Breaking change (explain below)

## Notes

Any rollout notes, migration notes, or follow-ups.
