### PR TITLE
Default every model to DeepSeek V4 Flash 0731 (classic loop + pro engine)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@
 # needed to get started; GH_TOKEN below is optional.
 # With ONLY an OpenRouter key set (no ANTHROPIC_API_KEY, no SWE_DEFAULT_RUNTIME),
 # SWE-AF auto-selects the open_code runtime and defaults every role to
-# openrouter/deepseek/deepseek-v4-flash. Override with SWE_DEFAULT_MODEL.
+# openrouter/deepseek/deepseek-v4-flash-0731. Override with SWE_DEFAULT_MODEL.
 # OPENROUTER_API_KEY=sk-or-v1-...
 
 # Option B: Anthropic API key — used by claude-agent-sdk for all coding agents
@@ -127,19 +127,19 @@
 # a config through. Unset = auto: open_code when an OpenRouter key is the
 # only provider credential, else claude_code. An invalid value is logged as
 # a warning and ignored. Leave this UNSET on an OpenRouter-only deployment —
-# auto-select already picks open_code and the deepseek-v4-flash default.
+# auto-select already picks open_code and the deepseek-v4-flash-0731 default.
 # SWE_DEFAULT_RUNTIME=claude_code  # or: open_code, codex
 
 # Default model when callers don't pass `models` in the request config.
 # Applies to all 16 agent roles for whichever runtime is active. Caller
 # config (`models.default` or per-role keys) overrides this. Set this on
 # the deployment to pin a model without code changes — e.g. swap from
-# deepseek-v4-flash to a newer release. Empty / unset → use the runtime's
-# baked-in defaults (openrouter/deepseek/deepseek-v4-flash on open_code).
+# deepseek-v4-flash-0731 to a newer release. Empty / unset → use the runtime's
+# baked-in defaults (openrouter/deepseek/deepseek-v4-flash-0731 on open_code).
 # This is the variable to use for role model selection; AI_MODEL below is
 # part of the same cascade but is also the direct-LLM fallback, so prefer
 # this one.
-# SWE_DEFAULT_MODEL=openrouter/deepseek/deepseek-v4-flash
+# SWE_DEFAULT_MODEL=openrouter/deepseek/deepseek-v4-flash-0731
 
 # Per-tier models. Each of the 17 agent roles belongs to one of three tiers:
 #   high = planning-heavy reasoning (pm, architect, tech_lead, replan)
@@ -156,7 +156,7 @@
 # and codex (model_reasoning_effort).
 # SWE_MODEL_HIGH=openrouter/z-ai/glm-5.2
 # SWE_MODEL_MED=openrouter/deepseek/deepseek-v4-pro
-# SWE_MODEL_LOW=openrouter/deepseek/deepseek-v4-flash
+# SWE_MODEL_LOW=openrouter/deepseek/deepseek-v4-flash-0731
 
 # Runtime/model selection is configured via API request config (V2):
 # {
@@ -185,7 +185,7 @@
 # {"runtime": "codex", "models": {"default": "gpt-5.3-codex"}}
 
 # Available open runtime model IDs (format: provider/model-name):
-#   openrouter/deepseek/deepseek-v4-flash  # the open_code default
+#   openrouter/deepseek/deepseek-v4-flash-0731  # the open_code default
 #   deepseek/deepseek-chat      # DeepSeek via OpenRouter
 #   minimax/minimax-m2.5        # MiniMax M2.5 via OpenRouter
 #   qwen/qwen-2.5-72b-instruct  # Qwen via OpenRouter
@@ -225,7 +225,7 @@
 # Engine model pools and reasoning effort. Unset keeps the engine's own
 # defaults (all OpenRouter ids, so an OpenRouter key is all it needs).
 # SWE_PRO_MODELS_HIGH=openrouter/deepseek/deepseek-v4-pro
-# SWE_PRO_MODELS_LOW=openrouter/deepseek/deepseek-v4-flash
+# SWE_PRO_MODELS_LOW=openrouter/deepseek/deepseek-v4-flash-0731
 # SWE_PRO_VARIANT=low
 # Per-run USD ceiling. Unset = no per-run cap; set this on shared or
 # unattended deployments so a wide issue DAG cannot run away.

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ New to AgentField? Install the control plane first with `curl -fsSL https://agen
 
 One click deploys SWE-AF + AgentField control plane + PostgreSQL. Exactly **one** environment variable is required in Railway — an LLM provider key:
 
-- `OPENROUTER_API_KEY` — **recommended, simplest**. One key, 200+ open and proprietary models. With only this set (no `ANTHROPIC_API_KEY`, no `SWE_DEFAULT_RUNTIME`), SWE-AF auto-selects the `open_code` runtime and defaults every role to `openrouter/deepseek/deepseek-v4-flash` — no further configuration needed.
+- `OPENROUTER_API_KEY` — **recommended, simplest**. One key, 200+ open and proprietary models. With only this set (no `ANTHROPIC_API_KEY`, no `SWE_DEFAULT_RUNTIME`), SWE-AF auto-selects the `open_code` runtime and defaults every role to `openrouter/deepseek/deepseek-v4-flash-0731` — no further configuration needed.
 - *Alternative:* `ANTHROPIC_API_KEY`, or `CLAUDE_CODE_OAUTH_TOKEN` from `claude setup-token` in [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) (uses Pro/Max subscription credits), to run the `claude_code` runtime instead.
 
 Optional:

--- a/agentfield-package.yaml
+++ b/agentfield-package.yaml
@@ -31,7 +31,7 @@ user_environment:
   require_one_of:
     # SWE-AF runs on either Claude (Anthropic) or open models via OpenRouter.
     # Provide one. With only an OpenRouter key it auto-selects the open_code
-    # runtime and defaults to openrouter/deepseek/deepseek-v4-flash.
+    # runtime and defaults to openrouter/deepseek/deepseek-v4-flash-0731.
     - id: llm_provider
       description: an LLM provider key
       options:
@@ -55,7 +55,7 @@ user_environment:
     - name: SWE_DEFAULT_RUNTIME
       description: Coding runtime for every role (claude_code | open_code | codex)
     - name: SWE_DEFAULT_MODEL
-      description: Override the model id for every role (e.g. openrouter/deepseek/deepseek-v4-flash)
+      description: Override the model id for every role (e.g. openrouter/deepseek/deepseek-v4-flash-0731)
     - name: AGENTFIELD_SERVER
       description: Control-plane URL
       default: http://localhost:8080

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -441,7 +441,7 @@ Runtime defaults:
 | Runtime | Base default | Special default |
 |---|---|---|
 | `claude_code` | `sonnet` | `qa_synthesizer=haiku` |
-| `open_code` | `openrouter/deepseek/deepseek-v4-flash` | none |
+| `open_code` | `openrouter/deepseek/deepseek-v4-flash-0731` | none |
 | `codex` | `gpt-5.3-codex` | none |
 
 The `open_code` default applies both when the runtime is auto-selected (only

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -27,7 +27,7 @@ it commented out unless you mean to use it.
 
 | Variable | Purpose |
 |---|---|
-| `OPENROUTER_API_KEY` | **Recommended** — OpenRouter key (200+ models). The only secret needed to get started: on its own it auto-selects the `open_code` runtime and defaults every role to `openrouter/deepseek/deepseek-v4-flash` |
+| `OPENROUTER_API_KEY` | **Recommended** — OpenRouter key (200+ models). The only secret needed to get started: on its own it auto-selects the `open_code` runtime and defaults every role to `openrouter/deepseek/deepseek-v4-flash-0731` |
 | `ANTHROPIC_API_KEY` | Anthropic API key for Claude models (`claude_code` runtime) |
 | `CLAUDE_CODE_OAUTH_TOKEN` | Claude Code subscription token (uses Pro/Max credits) |
 | `OPENAI_API_KEY` | OpenAI API key |

--- a/go/agentfield-package.yaml
+++ b/go/agentfield-package.yaml
@@ -49,7 +49,7 @@ user_environment:
     - name: SWE_DEFAULT_RUNTIME
       description: Coding runtime for every role (claude_code | open_code | codex)
     - name: SWE_DEFAULT_MODEL
-      description: Override the model id for every role (e.g. openrouter/deepseek/deepseek-v4-flash)
+      description: Override the model id for every role (e.g. openrouter/deepseek/deepseek-v4-flash-0731)
     - name: SWE_PRO_ENGINE
       description: >-
         High-performance coding engine (beta). On by default for nodes

--- a/go/docs/pro-engine.md
+++ b/go/docs/pro-engine.md
@@ -91,7 +91,7 @@ The engine inherits `OPENROUTER_API_KEY` and the control-plane coordinates
 `SWE_DEFAULT_RUNTIME` unset, so with an OpenRouter key as the only provider
 credential the node auto-selects the `open_code` runtime and defaults every
 role — including the advisory and verification roles that run outside the
-engine — to `openrouter/deepseek/deepseek-v4-flash`. Setting
+engine — to `openrouter/deepseek/deepseek-v4-flash-0731`. Setting
 `SWE_DEFAULT_RUNTIME` explicitly is supported but unnecessary here.
 
 ## Control-plane inactivity sweep

--- a/go/internal/config/config_test.go
+++ b/go/internal/config/config_test.go
@@ -121,7 +121,7 @@ func TestResolveRuntimeModels_OpenCodeDefaults(t *testing.T) {
 	clearProviderEnv(t) // no provider env -> the shared open_code base applies
 	got := mustResolve(t, "open_code", nil)
 	for _, field := range AllModelFields {
-		if got[field] != "openrouter/deepseek/deepseek-v4-flash" {
+		if got[field] != "openrouter/deepseek/deepseek-v4-flash-0731" {
 			t.Errorf("field %s = %q, want deepseek base", field, got[field])
 		}
 	}
@@ -132,7 +132,7 @@ func TestResolveRuntimeModels_OpenRouterAutoDefaults(t *testing.T) {
 	t.Setenv("OPENROUTER_API_KEY", "sk-or")
 	got := mustResolve(t, "open_code", nil)
 	for _, field := range AllModelFields {
-		if got[field] != "openrouter/deepseek/deepseek-v4-flash" {
+		if got[field] != "openrouter/deepseek/deepseek-v4-flash-0731" {
 			t.Errorf("field %s = %q, want deepseek auto", field, got[field])
 		}
 	}
@@ -148,7 +148,7 @@ func TestResolveRuntimeModels_ExplicitOpenCodeSameDefault(t *testing.T) {
 	t.Setenv("SWE_DEFAULT_RUNTIME", "open_code")
 	got := mustResolve(t, "open_code", nil)
 	for _, field := range AllModelFields {
-		if got[field] != "openrouter/deepseek/deepseek-v4-flash" {
+		if got[field] != "openrouter/deepseek/deepseek-v4-flash-0731" {
 			t.Errorf("field %s = %q, want deepseek (explicit)", field, got[field])
 		}
 	}
@@ -223,7 +223,7 @@ func TestResolveRuntimeModels_EmptyEnvTreatedAsUnset(t *testing.T) {
 	t.Setenv("HARNESS_MODEL", "   ")
 	got := mustResolve(t, "open_code", nil)
 	for _, field := range AllModelFields {
-		if got[field] != "openrouter/deepseek/deepseek-v4-flash" {
+		if got[field] != "openrouter/deepseek/deepseek-v4-flash-0731" {
 			t.Errorf("empty env -> base: field %s = %q", field, got[field])
 		}
 	}
@@ -361,7 +361,7 @@ func TestBuildConfig_OpenCodeProvider(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resolved["coder_model"] != "openrouter/deepseek/deepseek-v4-flash" {
+	if resolved["coder_model"] != "openrouter/deepseek/deepseek-v4-flash-0731" {
 		t.Errorf("coder_model = %q", resolved["coder_model"])
 	}
 }
@@ -377,7 +377,7 @@ func TestBuildConfig_AutoOpenRouterEndToEnd(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resolved["coder_model"] != "openrouter/deepseek/deepseek-v4-flash" {
+	if resolved["coder_model"] != "openrouter/deepseek/deepseek-v4-flash-0731" {
 		t.Errorf("coder_model = %q", resolved["coder_model"])
 	}
 }
@@ -576,7 +576,7 @@ func TestBuildConfig_ToExecutionConfigDictRoundtrip(t *testing.T) {
 	if execCfg.CoderModel() != "deepseek/deepseek-chat" {
 		t.Errorf("exec coder_model = %q", execCfg.CoderModel())
 	}
-	if execCfg.QAModel() != "openrouter/deepseek/deepseek-v4-flash" {
+	if execCfg.QAModel() != "openrouter/deepseek/deepseek-v4-flash-0731" {
 		t.Errorf("exec qa_model = %q", execCfg.QAModel())
 	}
 	if execCfg.MaxRetriesPerIssue != 2 {
@@ -648,7 +648,7 @@ func TestExecutionConfig_CIFixerRole(t *testing.T) {
 	if mustLoadExec(t, map[string]any{"runtime": "claude_code"}).CIFixerModel() != "sonnet" {
 		t.Error("ci_fixer default claude")
 	}
-	if mustLoadExec(t, map[string]any{"runtime": "open_code"}).CIFixerModel() != "openrouter/deepseek/deepseek-v4-flash" {
+	if mustLoadExec(t, map[string]any{"runtime": "open_code"}).CIFixerModel() != "openrouter/deepseek/deepseek-v4-flash-0731" {
 		t.Error("ci_fixer default opencode")
 	}
 	cfg := mustLoadExec(t, map[string]any{"runtime": "claude_code", "models": map[string]any{"ci_fixer": "opus"}})
@@ -767,7 +767,7 @@ func TestFastResolveModels(t *testing.T) {
 		cfg, _ := LoadFastBuildConfig(map[string]any{"runtime": "open_code"})
 		got, _ := FastResolveModels(cfg)
 		for _, role := range fastRoles {
-			if got[role] != "openrouter/deepseek/deepseek-v4-flash" {
+			if got[role] != "openrouter/deepseek/deepseek-v4-flash-0731" {
 				t.Errorf("%s = %q, want the shared open_code default", role, got[role])
 			}
 		}

--- a/go/internal/config/modeltiers_test.go
+++ b/go/internal/config/modeltiers_test.go
@@ -22,7 +22,7 @@ var highTierFields = map[string]bool{
 }
 
 // openCodeBaseModel ports _OPEN_CODE_BASE.
-const openCodeBaseModel = "openrouter/deepseek/deepseek-v4-flash"
+const openCodeBaseModel = "openrouter/deepseek/deepseek-v4-flash-0731"
 
 // TestModelTiers_NoTierEnvsUnchanged ports TestNoTierEnvsUnchanged: no tier
 // envs set → resolution unchanged for all runtimes.
@@ -83,7 +83,7 @@ func TestModelTiers_TierEnvApplication(t *testing.T) {
 		tierModels := map[string]string{
 			"high": "openrouter/z-ai/glm-5.2",
 			"med":  "openrouter/deepseek/deepseek-v4-pro",
-			"low":  "openrouter/deepseek/deepseek-v4-flash",
+			"low":  "openrouter/deepseek/deepseek-v4-flash-0731",
 		}
 		for tier, model := range tierModels {
 			t.Setenv(tierModelEnvVars[tier], model)

--- a/go/internal/config/resolve.go
+++ b/go/internal/config/resolve.go
@@ -135,13 +135,14 @@ const (
 	// OpenRouter path (see openRouterOnlyEnv) and an explicit
 	// SWE_DEFAULT_RUNTIME=open_code resolve here, so opting in explicitly
 	// never silently swaps the model.
-	openRouterAutoDefaultModel = "openrouter/deepseek/deepseek-v4-flash"
+	openRouterAutoDefaultModel = "openrouter/deepseek/deepseek-v4-flash-0731"
 )
 
 // runtimeBaseModels ports _RUNTIME_BASE_MODELS[runtime] as a fresh copy for the
 // given runtime, or nil if the runtime is unknown. claude_code is all "sonnet"
-// except qa_synthesizer_model="haiku"; open_code is all minimax; codex is all
-// the API-key model (adjusted for auth mode by ResolveRuntimeModels).
+// except qa_synthesizer_model="haiku"; open_code is all
+// openRouterAutoDefaultModel (v4-flash-0731); codex is all the API-key model
+// (adjusted for auth mode by ResolveRuntimeModels).
 func runtimeBaseModels(runtime string) map[string]string {
 	base := make(map[string]string, len(AllModelFields))
 	switch runtime {

--- a/go/internal/orch/plan_test.go
+++ b/go/internal/orch/plan_test.go
@@ -450,7 +450,7 @@ func TestPlanOpenRouterOnlyDefaults(t *testing.T) {
 	if got := mapStr(pm[0].input, "ai_provider", ""); got != "open_code" {
 		t.Errorf("ai_provider = %q, want open_code", got)
 	}
-	if got := mapStr(pm[0].input, "model", ""); got != "openrouter/deepseek/deepseek-v4-flash" {
+	if got := mapStr(pm[0].input, "model", ""); got != "openrouter/deepseek/deepseek-v4-flash-0731" {
 		t.Errorf("model = %q, want the OpenRouter auto default", got)
 	}
 }

--- a/go/internal/roles/coding/coding.go
+++ b/go/internal/roles/coding/coding.go
@@ -503,9 +503,9 @@ func RunQASynthesizer(ctx context.Context, deps *Deps, input map[string]any) (an
 //     alias.
 //   - A leading "openrouter/" is stripped. Model ids are LiteLLM-style
 //     throughout this repo's config — config.openRouterAutoDefaultModel is
-//     "openrouter/deepseek/deepseek-v4-flash", which is exactly right for the
+//     "openrouter/deepseek/deepseek-v4-flash-0731", which is exactly right for the
 //     open_code harness runtime — but OpenRouter's own API names that model
-//     "deepseek/deepseek-v4-flash" and rejects the routing prefix with a 400.
+//     "deepseek/deepseek-v4-flash-0731" and rejects the routing prefix with a 400.
 //     The harness path keeps the prefix; only this direct boundary drops it.
 //
 // Other ids carrying a "/" are already in OpenRouter's namespace and pass

--- a/go/internal/roles/coding/coding_test.go
+++ b/go/internal/roles/coding/coding_test.go
@@ -181,7 +181,7 @@ func TestRunCoderDirectCallRuntimeDefaults(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("RunCoder: %v", err)
 	}
-	if mh.gotOpts.Provider != "opencode" || mh.gotOpts.Model != "openrouter/deepseek/deepseek-v4-flash" {
+	if mh.gotOpts.Provider != "opencode" || mh.gotOpts.Model != "openrouter/deepseek/deepseek-v4-flash-0731" {
 		t.Fatalf("defaults = provider %q, model %q", mh.gotOpts.Provider, mh.gotOpts.Model)
 	}
 }

--- a/go/internal/roles/coding/synthmodel_test.go
+++ b/go/internal/roles/coding/synthmodel_test.go
@@ -30,7 +30,7 @@ func TestMapSynthModelOpenRouter(t *testing.T) {
 		// config.openRouterAutoDefaultModel hands every role on an
 		// OpenRouter-only install, so the direct client must drop the prefix.
 		"openrouter/deepseek/deepseek-v4-flash-0731": "deepseek/deepseek-v4-flash-0731",
-		"openrouter/z-ai/glm-5":                 "z-ai/glm-5",
+		"openrouter/z-ai/glm-5":                      "z-ai/glm-5",
 	}
 	for in, want := range cases {
 		if got := mapSynthModel(in); got != want {

--- a/go/internal/roles/coding/synthmodel_test.go
+++ b/go/internal/roles/coding/synthmodel_test.go
@@ -29,7 +29,7 @@ func TestMapSynthModelOpenRouter(t *testing.T) {
 		// OpenRouter's own API rejects with a 400. This is the id
 		// config.openRouterAutoDefaultModel hands every role on an
 		// OpenRouter-only install, so the direct client must drop the prefix.
-		"openrouter/deepseek/deepseek-v4-flash": "deepseek/deepseek-v4-flash",
+		"openrouter/deepseek/deepseek-v4-flash-0731": "deepseek/deepseek-v4-flash-0731",
 		"openrouter/z-ai/glm-5":                 "z-ai/glm-5",
 	}
 	for in, want := range cases {
@@ -58,7 +58,7 @@ func TestMapSynthModelNonOpenRouter(t *testing.T) {
 	// anything else — a LiteLLM-style proxy behind AI_BASE_URL, say — the
 	// prefix is the routing instruction, so removing it would send the request
 	// to the wrong provider.
-	const prefixed = "openrouter/deepseek/deepseek-v4-flash"
+	const prefixed = "openrouter/deepseek/deepseek-v4-flash-0731"
 	if got := mapSynthModel(prefixed); got != prefixed {
 		t.Errorf("mapSynthModel(%q) = %q, want passthrough — the prefix is only stripped for OpenRouter", prefixed, got)
 	}

--- a/go/internal/roles/planning/planning_test.go
+++ b/go/internal/roles/planning/planning_test.go
@@ -180,7 +180,7 @@ func TestProductManagerDirectCallRuntimeDefaults(t *testing.T) {
 		clearRuntimeEnv(t)
 		t.Setenv("OPENROUTER_API_KEY", "test-key")
 		opts := run(t, map[string]any{})
-		if opts.Provider != "opencode" || opts.Model != "openrouter/deepseek/deepseek-v4-flash" {
+		if opts.Provider != "opencode" || opts.Model != "openrouter/deepseek/deepseek-v4-flash-0731" {
 			t.Fatalf("defaults = provider %q, model %q", opts.Provider, opts.Model)
 		}
 	})

--- a/swe_af/execution/schemas.py
+++ b/swe_af/execution/schemas.py
@@ -609,7 +609,7 @@ _CODEX_CHATGPT_MODEL = "gpt-5.5"         # ChatGPT-account auth (-codex blocked)
 # Default model for the open_code runtime — both the auto-selected OpenRouter
 # path (see _openrouter_only_env) and an explicit SWE_DEFAULT_RUNTIME=open_code
 # resolve here, so opting in explicitly never silently swaps the model.
-_OPENROUTER_AUTO_DEFAULT_MODEL = "openrouter/deepseek/deepseek-v4-flash"
+_OPENROUTER_AUTO_DEFAULT_MODEL = "openrouter/deepseek/deepseek-v4-flash-0731"
 
 _RUNTIME_BASE_MODELS: dict[str, dict[str, str]] = {
     "claude_code": {

--- a/swe_af/fast/schemas.py
+++ b/swe_af/fast/schemas.py
@@ -17,7 +17,7 @@ _CLAUDE_CODE_DEFAULT = "haiku"
 # OpenRouter-only install behaves the same on both nodes. Keep in sync with
 # ``swe_af.execution.schemas._OPENROUTER_AUTO_DEFAULT_MODEL`` (not imported at
 # module scope to avoid a circular import).
-_OPEN_CODE_DEFAULT = "openrouter/deepseek/deepseek-v4-flash"
+_OPEN_CODE_DEFAULT = "openrouter/deepseek/deepseek-v4-flash-0731"
 
 _RUNTIME_DEFAULTS: dict[str, str] = {
     "claude_code": _CLAUDE_CODE_DEFAULT,

--- a/tests/fast/test_app_planner_executor_verifier_wiring.py
+++ b/tests/fast/test_app_planner_executor_verifier_wiring.py
@@ -755,7 +755,7 @@ class TestPlannerAiParamThreading:
         config = FastBuildConfig(runtime="open_code")
         resolved = fast_resolve_models(config)
 
-        expected = "openrouter/deepseek/deepseek-v4-flash"
+        expected = "openrouter/deepseek/deepseek-v4-flash-0731"
         for role in ("pm_model", "coder_model", "verifier_model", "git_model"):
             assert resolved[role] == expected, (
                 f"open_code runtime: {role} should be {expected!r}, got {resolved[role]!r}"

--- a/tests/fast/test_fast_app_executor_verifier_crossfeature.py
+++ b/tests/fast/test_fast_app_executor_verifier_crossfeature.py
@@ -153,7 +153,7 @@ class TestConfigToCallArgThreading:
             "fast_execute_tasks must accept 'coder_model' param — "
             "schemas→executor cross-feature contract broken"
         )
-        assert resolved["coder_model"] == "openrouter/deepseek/deepseek-v4-flash", (
+        assert resolved["coder_model"] == "openrouter/deepseek/deepseek-v4-flash-0731", (
             f"open_code runtime default must be the shared default, got {resolved['coder_model']!r}"
         )
 

--- a/tests/fast/test_fast_router_schema_pipeline_integration.py
+++ b/tests/fast/test_fast_router_schema_pipeline_integration.py
@@ -569,7 +569,7 @@ class TestBuildConfigModelThreading:
         cfg = FastBuildConfig(runtime="open_code")
         resolved = fast_resolve_models(cfg)
 
-        open_code_model = "openrouter/deepseek/deepseek-v4-flash"
+        open_code_model = "openrouter/deepseek/deepseek-v4-flash-0731"
         for role, model in resolved.items():
             assert model == open_code_model, (
                 f"open_code runtime: role {role!r} should be {open_code_model!r}, got {model!r}"

--- a/tests/fast/test_integration.py
+++ b/tests/fast/test_integration.py
@@ -144,7 +144,7 @@ from swe_af.fast.schemas import fast_resolve_models, FastBuildConfig
 cfg = FastBuildConfig(runtime='open_code')
 resolved = fast_resolve_models(cfg)
 for role, model in resolved.items():
-    assert model == 'openrouter/deepseek/deepseek-v4-flash', f'{role}={model!r}'
+    assert model == 'openrouter/deepseek/deepseek-v4-flash-0731', f'{role}={model!r}'
 print('OK')
 """
     result = _run(code)

--- a/tests/fast/test_schemas.py
+++ b/tests/fast/test_schemas.py
@@ -115,7 +115,7 @@ class TestFastResolveModelsCludeCode:
 # fast_resolve_models — open_code runtime (AC-5)
 # ---------------------------------------------------------------------------
 
-_OPEN_CODE_MODEL = "openrouter/deepseek/deepseek-v4-flash"
+_OPEN_CODE_MODEL = "openrouter/deepseek/deepseek-v4-flash-0731"
 
 
 class TestFastResolveModelsOpenCode:

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -87,7 +87,7 @@ class TestResolveRuntimeModels(unittest.TestCase):
         with _provider_env():
             resolved = resolve_runtime_models(runtime="open_code", models=None)
         for field in ALL_MODEL_FIELDS:
-            self.assertEqual(resolved[field], "openrouter/deepseek/deepseek-v4-flash")
+            self.assertEqual(resolved[field], "openrouter/deepseek/deepseek-v4-flash-0731")
 
     def test_models_default_applies_to_all(self) -> None:
         resolved = resolve_runtime_models(
@@ -125,7 +125,7 @@ class TestBuildConfig(unittest.TestCase):
             cfg = BuildConfig(runtime="open_code")
             self.assertEqual(cfg.ai_provider, "opencode")
             resolved = cfg.resolved_models()
-        self.assertEqual(resolved["coder_model"], "openrouter/deepseek/deepseek-v4-flash")
+        self.assertEqual(resolved["coder_model"], "openrouter/deepseek/deepseek-v4-flash-0731")
 
 
 class TestOpenRouterAutoSelection(unittest.TestCase):
@@ -158,7 +158,7 @@ class TestOpenRouterAutoSelection(unittest.TestCase):
         with _provider_env(OPENROUTER_API_KEY="sk-or"):
             resolved = resolve_runtime_models(runtime="open_code", models=None)
         for field in ALL_MODEL_FIELDS:
-            self.assertEqual(resolved[field], "openrouter/deepseek/deepseek-v4-flash")
+            self.assertEqual(resolved[field], "openrouter/deepseek/deepseek-v4-flash-0731")
 
     def test_explicit_open_code_same_default(self) -> None:
         # A deployer who explicitly sets open_code resolves to the SAME model
@@ -167,7 +167,7 @@ class TestOpenRouterAutoSelection(unittest.TestCase):
         with _provider_env(OPENROUTER_API_KEY="sk-or", SWE_DEFAULT_RUNTIME="open_code"):
             resolved = resolve_runtime_models(runtime="open_code", models=None)
         for field in ALL_MODEL_FIELDS:
-            self.assertEqual(resolved[field], "openrouter/deepseek/deepseek-v4-flash")
+            self.assertEqual(resolved[field], "openrouter/deepseek/deepseek-v4-flash-0731")
 
     def test_swe_default_model_overrides_auto_deepseek(self) -> None:
         with _provider_env(OPENROUTER_API_KEY="sk-or", SWE_DEFAULT_MODEL="openrouter/qwen/qwen-3"):
@@ -180,7 +180,7 @@ class TestOpenRouterAutoSelection(unittest.TestCase):
             cfg = BuildConfig()
             self.assertEqual(cfg.runtime, "open_code")
             resolved = cfg.resolved_models()
-        self.assertEqual(resolved["coder_model"], "openrouter/deepseek/deepseek-v4-flash")
+        self.assertEqual(resolved["coder_model"], "openrouter/deepseek/deepseek-v4-flash-0731")
 
     def test_to_execution_config_dict_roundtrips(self) -> None:
         cfg = BuildConfig(runtime="open_code", models={"coder": "deepseek/deepseek-chat"})
@@ -189,7 +189,7 @@ class TestOpenRouterAutoSelection(unittest.TestCase):
         self.assertEqual(d["models"]["coder"], "deepseek/deepseek-chat")
         exec_cfg = ExecutionConfig(**d)
         self.assertEqual(exec_cfg.coder_model, "deepseek/deepseek-chat")
-        self.assertEqual(exec_cfg.qa_model, "openrouter/deepseek/deepseek-v4-flash")
+        self.assertEqual(exec_cfg.qa_model, "openrouter/deepseek/deepseek-v4-flash-0731")
 
     def test_legacy_top_level_keys_rejected(self) -> None:
         with self.assertRaises(ValueError) as ctx:
@@ -370,7 +370,7 @@ class TestDefaultModelFromEnv(unittest.TestCase):
             resolved = resolve_runtime_models(runtime="open_code", models=None)
             for field in ALL_MODEL_FIELDS:
                 self.assertEqual(
-                    resolved[field], "openrouter/deepseek/deepseek-v4-flash"
+                    resolved[field], "openrouter/deepseek/deepseek-v4-flash-0731"
                 )
 
     def test_unset_env_uses_runtime_base(self) -> None:
@@ -380,7 +380,7 @@ class TestDefaultModelFromEnv(unittest.TestCase):
             resolved = resolve_runtime_models(runtime="open_code", models=None)
             for field in ALL_MODEL_FIELDS:
                 self.assertEqual(
-                    resolved[field], "openrouter/deepseek/deepseek-v4-flash"
+                    resolved[field], "openrouter/deepseek/deepseek-v4-flash-0731"
                 )
 
     def test_ai_model_env_used_when_swe_default_unset(self) -> None:
@@ -458,8 +458,8 @@ class TestExecutionConfig(unittest.TestCase):
     def test_open_code_resolution(self) -> None:
         cfg = ExecutionConfig(runtime="open_code")
         self.assertEqual(cfg.ai_provider, "opencode")
-        self.assertEqual(cfg.coder_model, "openrouter/deepseek/deepseek-v4-flash")
-        self.assertEqual(cfg.qa_synthesizer_model, "openrouter/deepseek/deepseek-v4-flash")
+        self.assertEqual(cfg.coder_model, "openrouter/deepseek/deepseek-v4-flash-0731")
+        self.assertEqual(cfg.qa_synthesizer_model, "openrouter/deepseek/deepseek-v4-flash-0731")
 
     def test_models_override(self) -> None:
         cfg = ExecutionConfig(runtime="claude_code", models={"default": "sonnet", "qa": "opus"})
@@ -495,7 +495,7 @@ class TestExecutionConfig(unittest.TestCase):
         self.assertEqual(cfg.ci_fixer_model, "sonnet")
 
         cfg = ExecutionConfig(runtime="open_code")
-        self.assertEqual(cfg.ci_fixer_model, "openrouter/deepseek/deepseek-v4-flash")
+        self.assertEqual(cfg.ci_fixer_model, "openrouter/deepseek/deepseek-v4-flash-0731")
 
         cfg = ExecutionConfig(
             runtime="claude_code", models={"ci_fixer": "opus"}

--- a/tests/test_model_tiers.py
+++ b/tests/test_model_tiers.py
@@ -26,7 +26,7 @@ from swe_af.execution.schemas import (
 _HIGH_FIELDS = {"pm_model", "architect_model", "tech_lead_model", "replan_model"}
 _LOW_FIELDS = {"qa_synthesizer_model", "git_model"}
 
-_OPEN_CODE_BASE = "openrouter/deepseek/deepseek-v4-flash"
+_OPEN_CODE_BASE = "openrouter/deepseek/deepseek-v4-flash-0731"
 
 # Env vars that steer provider/runtime/model selection. Cleared before every
 # test so assertions never depend on the developer's ambient shell.
@@ -92,7 +92,7 @@ class TestTierEnvApplication:
         tier_models = {
             "high": "openrouter/z-ai/glm-5.2",
             "med": "openrouter/deepseek/deepseek-v4-pro",
-            "low": "openrouter/deepseek/deepseek-v4-flash",
+            "low": "openrouter/deepseek/deepseek-v4-flash-0731",
         }
         for tier, model in tier_models.items():
             monkeypatch.setenv(TIER_MODEL_ENV_VARS[tier], model)

--- a/tests/test_planner_pipeline.py
+++ b/tests/test_planner_pipeline.py
@@ -385,7 +385,7 @@ async def test_plan_openrouter_only_defaults_to_open_code(mock_agent_ai, tmp_pat
     pm_call = mock_agent_ai.call_args_list[0]
     assert pm_call.args[0].endswith("run_product_manager")
     assert pm_call.kwargs["ai_provider"] == "open_code"
-    assert pm_call.kwargs["model"] == "openrouter/deepseek/deepseek-v4-flash"
+    assert pm_call.kwargs["model"] == "openrouter/deepseek/deepseek-v4-flash-0731"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Makes `openrouter/deepseek/deepseek-v4-flash-0731` (the DeepSeek V4 Flash released 2026-07-31) the default model everywhere. The old `openrouter/deepseek/deepseek-v4-flash` tag points at the **April 0423 snapshot** — so the "flash default" was months stale — and the pro engine's compiled-in HIGH pool still led with `deepseek-v4-pro`, which is why engine runs (`swe-pro.code_task`) used v4-pro regardless of the classic-loop constant.

Tag verified live on OpenRouter first: 6 providers, 1M context, $0.09/M in + $0.18/M out (v4-pro: $0.435/$0.87).

## Changes

**Commit 1 — defaults sweep (25 files)**
- `go/internal/config/resolve.go`: `openRouterAutoDefaultModel` → 0731 tag; fixed the stale `runtimeBaseModels` comment that still claimed "open_code is all minimax".
- Python node defaults (`swe_af/execution/schemas.py`, `swe_af/fast/schemas.py`).
- Manifests (root + `go/`), `.env.example`, README, architecture/deployment/pro-engine docs.
- Go + Python tests asserting the default updated to the new contract.

**Commit 2 — re-vendored engine binaries**
- `go/bin/swe-pro-{linux-amd64,darwin-arm64}` rebuilt from Agent-Field/swe-pro-go#27 (`c7f46db`): both compiled-in pools now lead with the 0731 tag (HIGH keeps v4-pro and the rest as fallbacks). The new build is clean (`vcs.modified=false`) — the previous vendored binary was a dirty build.
- Verified via `strings` (pool literals) and `go version -m` on both binaries, plus a `--help` run.

`cd go && go build ./... && go test ./...` pass. Python suite doesn't run in this environment (missing installed package); sources compile-checked and defaults are covered by the Go tests.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)