### PR TITLE
fix(prompts): make .agentfield_output.json write a MANDATORY step in coder task

### DIFF
--- a/go/internal/prompts/coding/coder.go
+++ b/go/internal/prompts/coding/coder.go
@@ -489,7 +489,14 @@ func CoderTaskPrompt(o CoderTaskPromptOpts) string {
 			"3. Write or update tests per the Testing Strategy/guidance.\n"+
 			"4. Run tests and report results (tests_passed, test_summary).\n"+
 			"5. Commit your changes.\n"+
-			"6. Report codebase_learnings and agent_retro in your output.")
+			"6. MANDATORY output contract: write a file named `.agentfield_output.json` "+
+			"in your current working directory (the worktree path). "+
+			"The file MUST exist on disk before you finish. "+
+			"Use the Write tool with valid JSON conforming to the CoderResult schema: "+
+			`{"summary": string, "files_changed": [string], "complete": bool, "test_results": {"passed": int, "failed": int, "summary": string}, "codebase_learnings": [string], "agent_retro": object}. `+
+			"The harness validates this file on every run; without it, the coder run "+
+			"fails with `The output file was NOT created.`. "+
+			"Then report codebase_learnings and agent_retro.")
 	}
 
 	return strings.Join(sections, "\n")

--- a/go/internal/prompts/coding/coder_output_artifact_test.go
+++ b/go/internal/prompts/coding/coder_output_artifact_test.go
@@ -1,0 +1,111 @@
+package coding
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestCoderTaskPromptRequiresOutputArtifactContract is a regression test for
+// the SWE-AF/OpenCode output-contract fix.
+//
+// Background
+//
+// At SWE-AF commit 4237bebe7b63, the CoderTaskPrompt ended with the
+// instruction "Report codebase_learnings and agent_retro in your output."
+// The coding runtime (opencode/Claude Code/Codex) interpreted "in your
+// output" as the chat response, never writing a file to disk. The harness
+// in agentfield/sdk-go/harness/schema.go:541 then reported
+//
+//   "The output file was NOT created."
+//
+// because .agentfield_output.json was not present at the harness's expected
+// path (OutputPath = <worktree>/.agentfield_output.json). The coder call
+// failed with this error every time, for every model, on every worktree.
+//
+// Fix
+//
+// Step 6 of the "Your Task" section in CoderTaskPrompt now contains an
+// explicit MANDATORY instruction to write .agentfield_output.json in the
+// current working directory, with valid JSON conforming to the
+// CoderResult schema. This test fails on the upstream behavior and passes
+// with the patch.
+//
+// This test does NOT need a regenerated golden fixture. It is content-based
+// and verifies the structural contract that the coding runtime depends on.
+func TestCoderTaskPromptRequiresOutputArtifactContract(t *testing.T) {
+	prompt := CoderTaskPrompt(CoderTaskPromptOpts{
+		Issue: map[string]any{
+			"name":                "fix-add-bug",
+			"title":               "Fix the add() function",
+			"description":         "Change return a - b to return a + b",
+			"acceptance_criteria": []any{"add(2, 3) == 5"},
+		},
+		WorktreePath: "/workspaces/coder-test-branch",
+		Iteration:    1,
+	})
+
+	// Required: the exact filename the harness looks for.
+	const requiredFilename = ".agentfield_output.json"
+	if !strings.Contains(prompt, requiredFilename) {
+		t.Errorf("CoderTaskPrompt must mention %q so the coding runtime knows to write the output artifact. Got prompt:\n%s",
+			requiredFilename, prompt)
+	}
+
+	// Required: the instruction must be MANDATORY (the coding runtime
+	// must not treat it as optional). Without the MANDATORY framing, the
+	// runtime may deprioritize the artifact write in favor of code edits.
+	requiredFraming := []string{"MANDATORY", "current working directory"}
+	for _, kw := range requiredFraming {
+		if !strings.Contains(prompt, kw) {
+			t.Errorf("CoderTaskPrompt must include the keyword %q to frame the artifact write as a hard contract. Got prompt:\n%s",
+				kw, prompt)
+		}
+	}
+
+	// Required: the schema field names the harness validates against
+	// (per the CoderResult struct in internal/schemas/execution.go:375).
+	requiredSchemaFields := []string{
+		"summary",
+		"files_changed",
+		"complete",
+		"test_results",
+		"codebase_learnings",
+		"agent_retro",
+	}
+	for _, f := range requiredSchemaFields {
+		if !strings.Contains(prompt, f) {
+			t.Errorf("CoderTaskPrompt must list the CoderResult schema field %q so the runtime writes a valid result. Got prompt:\n%s",
+				f, prompt)
+		}
+	}
+
+	// Required: the prompt must mention the harness's specific failure
+	// message so the runtime can recognize and avoid it. The phrase
+	// "output file" + "NOT created" together signal the failure mode.
+	if !strings.Contains(prompt, "output file") || !strings.Contains(prompt, "NOT created") {
+		t.Errorf("CoderTaskPrompt must reference the harness failure mode (output file ... NOT created) so the runtime can avoid it. Got prompt:\n%s",
+			prompt)
+	}
+}
+
+// TestCoderTaskPromptOutputArtifactNotSilentlyRemovable protects against
+// regressions where someone reverts the MANDATORY framing. The fix is
+// minimal and surgical; this test ensures the contract is loud, not
+// implied.
+func TestCoderTaskPromptOutputArtifactNotSilentlyRemovable(t *testing.T) {
+	prompt := CoderTaskPrompt(CoderTaskPromptOpts{
+		Issue:        map[string]any{"name": "x"},
+		WorktreePath: "/tmp",
+		Iteration:    1,
+	})
+
+	// The MANDATORY word must appear immediately before the artifact
+	// instruction. If a future edit removes MANDATORY or moves it
+	// elsewhere, the test fails.
+	const mandatoryPrefix = "6. MANDATORY"
+	if !strings.HasPrefix(prompt[strings.Index(prompt, "## Your Task"):], mandatoryPrefix) &&
+		!strings.Contains(prompt[strings.Index(prompt, "## Your Task"):], "6. MANDATORY") {
+		t.Errorf("CoderTaskPrompt must begin step 6 of 'Your Task' with %q. Got:\n%s",
+			mandatoryPrefix, prompt[strings.Index(prompt, "## Your Task"):])
+	}
+}


### PR DESCRIPTION
## Summary

At commit `4237bebe7b63`, `CoderTaskPrompt` ends with:

> 6. Report codebase_learnings and agent_retro in your output.

The coding runtime (opencode/Claude Code/Codex) interpreted "in your output" as the chat response and never wrote a file to disk. The harness in `agentfield/sdk-go/harness/schema.go:541` then failed every coder call with:

> The output file was NOT created.

because `.agentfield_output.json` was not present at the harness'''s expected path (`<worktree>/.agentfield_output.json`). The coder call failed for every model, on every worktree, regardless of the model choice.

## Fix

Step 6 of the "Your Task" section in `CoderTaskPrompt` now contains an explicit `MANDATORY` instruction to write `.agentfield_output.json` in the current working directory, with valid JSON conforming to the `CoderResult` schema.

The schema fields listed in the prompt are the exact `CoderResult` struct fields defined in `internal/schemas/execution.go:375`. The filename `.agentfield_output.json` is the harness'''s `outputFilename` constant in `agentfield/sdk-go/harness/schema.go:18`.

## Diff vs upstream pinned

```
 go/internal/prompts/coding/coder.go                 |   9 +-
 go/internal/prompts/coding/coder_output_artifact_test.go | 111 +++++++++++++++++++++
 2 files changed, 119 insertions(+), 1 deletion(-)
```

## Regression test

A new test file `coder_output_artifact_test.go` adds two tests:

- `TestCoderTaskPromptRequiresOutputArtifactContract` — verifies the prompt contains the exact filename `.agentfield_output.json`, the `MANDATORY` framing, all six `CoderResult` schema field names, and the harness failure mode phrase.
- `TestCoderTaskPromptOutputArtifactNotSilentlyRemovable` — guards the `MANDATORY` prefix against future edits that might remove the framing.

Both tests fail on the upstream behavior and pass with the fix. The tests are content-based and do not require regenerating golden fixtures.

## Verification

- Patch commit: `0ed1ec5f343fe9ad1a7811c826693eff856abf70`
- Image built: `swe-planner:linux-amd64-patched-0ed1ec5` (digest `sha256:1b1bdbf8eeb9830038570a50193b01a53481910554a74ad9d591e81dc3557fb2`)
- Direct `run_coder` end-to-end on DeepSeek via async: **62.9s, status=succeeded, full CoderResult validated, worktree state correct, 6/6 tests pass**.

## Rollback

The patch is one paragraph in a single file (`go/internal/prompts/coding/coder.go`). Reverting commit `0ed1ec5` restores the original behavior. No migrations, no API changes, no schema changes.

## Related

- Root cause report: `SWE-AF-OPENCODE-ROOT-CAUSE.md` (in our private vault)
- Upstream issue: will be filed separately if one is not already open
- Fork: `https://github.com/diogoamorimtavares-blip/SWE-AF/tree/fix/coder-output-artifact`
