### PR TITLE
docs: update Railway deploy link to agentfield-engineering-team template

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ New to AgentField? Install the control plane first with `curl -fsSL https://agen
 
 ### Deploy with Railway (fastest)
 
-[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/swe-af)
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/agentfield-engineering-team)
 
 One click deploys SWE-AF + AgentField control plane + PostgreSQL. Exactly **one** environment variable is required in Railway — an LLM provider key:
 


### PR DESCRIPTION
## Summary
The README's \"Deploy on Railway\" badge pointed at https://railway.com/deploy/swe-af, which now returns 404. The template moved to https://railway.com/deploy/agentfield-engineering-team (verified live).

## Changes Made
- README.md: point the Railway deploy badge at the new template URL — the only occurrence of the old link in the repo.

## Test Plan
- [x] `curl` the old URL → 404; new URL → 200
- [x] Grepped the repo for `railway.com/deploy` — no other references to the old template

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)