### PR TITLE
fix(qa-synthesizer): read the schema router.ai() actually returns

### DIFF
--- a/swe_af/reasoners/execution_agents.py
+++ b/swe_af/reasoners/execution_agents.py
@@ -1259,13 +1259,15 @@ async def run_qa_synthesizer(
             schema=QASynthesisResult,
             model=model,
         )
-        if result.parsed is not None:
+        # Unlike the harness-backed agents above, router.ai() returns the
+        # validated schema instance itself — there is no .parsed wrapper.
+        if isinstance(result, QASynthesisResult):
             router.note(
-                f"QA synthesizer complete: action={result.parsed.action.value}, "
-                f"stuck={result.parsed.stuck}",
+                f"QA synthesizer complete: action={result.action.value}, "
+                f"stuck={result.stuck}",
                 tags=["qa_synthesizer", "complete"],
             )
-            out = result.parsed.model_dump()
+            out = result.model_dump()
             out["iteration_id"] = iteration_id
             return out
     except FatalHarnessError:

--- a/swe_af/reasoners/execution_agents.py
+++ b/swe_af/reasoners/execution_agents.py
@@ -1270,6 +1270,10 @@ async def run_qa_synthesizer(
             out = result.model_dump()
             out["iteration_id"] = iteration_id
             return out
+        router.note(
+            f"QA synthesizer returned {type(result).__name__}, not QASynthesisResult",
+            tags=["qa_synthesizer", "error"],
+        )
     except FatalHarnessError:
         raise  # Non-retryable — propagate immediately
     except Exception as e:

--- a/tests/test_qa_synthesizer_direct_schema.py
+++ b/tests/test_qa_synthesizer_direct_schema.py
@@ -1,0 +1,56 @@
+"""Regression test for the QA synthesizer dropping the AI's decision (#113).
+
+``run_qa_synthesizer`` is the only reasoner that calls ``router.ai()`` — every
+other agent in ``execution_agents`` goes through ``router.harness()``, which
+returns a ``HarnessResult`` wrapper carrying a ``.parsed`` attribute.
+``router.ai(..., schema=X)`` instead returns the validated ``X`` instance
+directly, so reading ``.parsed`` off it raised ``AttributeError``.  The
+surrounding broad ``except Exception`` swallowed that, logged "QA synthesizer
+agent failed" and fell through to the crude tests_passed/review_approved
+heuristic — discarding the synthesizer's decision on *every* call.
+
+Contract: whatever ``router.ai()`` returns for the schema is the decision that
+comes back, even when the heuristic fallback would have decided otherwise.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from swe_af.execution.schemas import QASynthesisAction, QASynthesisResult
+from swe_af.reasoners import execution_agents
+
+
+class _StubRouter:
+    """Stands in for the module-level router, returning *decision* from ai()."""
+
+    def __init__(self, decision: QASynthesisResult) -> None:
+        self._decision = decision
+
+    async def ai(self, *args: Any, **kwargs: Any) -> QASynthesisResult:
+        return self._decision
+
+    def note(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+
+async def test_ai_decision_wins_over_heuristic_fallback(monkeypatch) -> None:
+    """A BLOCK from the synthesizer survives inputs the fallback would approve."""
+    decision = QASynthesisResult(
+        action=QASynthesisAction.BLOCK,
+        summary="Tests pass but the fix regresses the public API.",
+        stuck=True,
+    )
+    monkeypatch.setattr(execution_agents, "router", _StubRouter(decision))
+
+    out = await execution_agents.run_qa_synthesizer(
+        qa_result={"passed": True},
+        review_result={"approved": True, "blocking": False},
+        iteration_history=[],
+        iteration_id="iter-7",
+    )
+
+    assert out["action"] == QASynthesisAction.BLOCK
+    assert out["summary"] == decision.summary
+    assert out["stuck"] is True
+    assert out["iteration_id"] == "iter-7"

--- a/tests/test_qa_synthesizer_direct_schema.py
+++ b/tests/test_qa_synthesizer_direct_schema.py
@@ -1,4 +1,4 @@
-"""Regression test for the QA synthesizer dropping the AI's decision (#113).
+"""Regression tests for the QA synthesizer dropping the AI's decision (#113).
 
 ``run_qa_synthesizer`` is the only reasoner that calls ``router.ai()`` — every
 other agent in ``execution_agents`` goes through ``router.harness()``, which
@@ -8,30 +8,27 @@ directly, so reading ``.parsed`` off it raised ``AttributeError``.  The
 surrounding broad ``except Exception`` swallowed that, logged "QA synthesizer
 agent failed" and fell through to the crude tests_passed/review_approved
 heuristic — discarding the synthesizer's decision on *every* call.
-
-Contract: whatever ``router.ai()`` returns for the schema is the decision that
-comes back, even when the heuristic fallback would have decided otherwise.
 """
 
 from __future__ import annotations
 
-from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
 from swe_af.execution.schemas import QASynthesisAction, QASynthesisResult
 from swe_af.reasoners import execution_agents
 
+# Inputs the heuristic fallback resolves to APPROVE, so any other action in the
+# result can only have come from the synthesizer itself.
+FALLBACK_APPROVES = {
+    "qa_result": {"passed": True},
+    "review_result": {"approved": True, "blocking": False},
+}
 
-class _StubRouter:
-    """Stands in for the module-level router, returning *decision* from ai()."""
 
-    def __init__(self, decision: QASynthesisResult) -> None:
-        self._decision = decision
-
-    async def ai(self, *args: Any, **kwargs: Any) -> QASynthesisResult:
-        return self._decision
-
-    def note(self, *args: Any, **kwargs: Any) -> None:
-        pass
+def _error_notes(router: MagicMock) -> list:
+    return [
+        c for c in router.note.call_args_list if "error" in c.kwargs.get("tags", [])
+    ]
 
 
 async def test_ai_decision_wins_over_heuristic_fallback(monkeypatch) -> None:
@@ -41,16 +38,34 @@ async def test_ai_decision_wins_over_heuristic_fallback(monkeypatch) -> None:
         summary="Tests pass but the fix regresses the public API.",
         stuck=True,
     )
-    monkeypatch.setattr(execution_agents, "router", _StubRouter(decision))
+    router = MagicMock(ai=AsyncMock(return_value=decision))
+    monkeypatch.setattr(execution_agents, "router", router)
 
     out = await execution_agents.run_qa_synthesizer(
-        qa_result={"passed": True},
-        review_result={"approved": True, "blocking": False},
-        iteration_history=[],
-        iteration_id="iter-7",
+        iteration_history=[], iteration_id="iter-7", **FALLBACK_APPROVES
     )
 
+    assert router.ai.await_args.kwargs["schema"] is QASynthesisResult
     assert out["action"] == QASynthesisAction.BLOCK
     assert out["summary"] == decision.summary
     assert out["stuck"] is True
     assert out["iteration_id"] == "iter-7"
+    assert _error_notes(router) == []
+
+
+async def test_non_schema_response_falls_back_and_says_so(monkeypatch) -> None:
+    """An unparseable response reaches the heuristic, but not silently.
+
+    ``ai()`` hands back a ``ToolCallResponse`` when the model's content is not
+    parseable JSON.  Issue #113 was diagnosed from the note this path emits, so
+    the fallback must stay loud.
+    """
+    router = MagicMock(ai=AsyncMock(return_value=object()))
+    monkeypatch.setattr(execution_agents, "router", router)
+
+    out = await execution_agents.run_qa_synthesizer(
+        iteration_history=[], iteration_id="iter-8", **FALLBACK_APPROVES
+    )
+
+    assert out["action"] == QASynthesisAction.APPROVE
+    assert _error_notes(router), "operators lose their only signal for this path"


### PR DESCRIPTION
## Summary

- `run_qa_synthesizer` read `result.parsed` off the return of `router.ai(..., schema=QASynthesisResult)`. The SDK returns the validated schema instance directly, so that raised `AttributeError`, the broad `except Exception` swallowed it, and the function fell through to the `tests_passed`/`review_approved` heuristic on *every* call. The synthesizer's decision was never used. Fixes #113.
- This is the only affected call site. `run_qa_synthesizer` is the one reasoner in the module that calls `router.ai()`; the eighteen other LLM-calling agents use `router.harness()`, whose `HarnessResult` really does carry `.parsed`. They are correct and untouched.

I used `isinstance(result, QASynthesisResult)` rather than a `getattr(result, "parsed", result)` compatibility shim, because `AgentAI.ai(..., schema=X)` returns `schema(**json_data)` in both `0.1.113` (this repo's floor pin) and current `0.1.132`, so there is no wrapper to fall back to on any supported version. The type gate also routes the one remaining non-schema return, a `ToolCallResponse` when the model content is not parseable JSON, to the heuristic fallback deliberately and with its own note, rather than through a swallowed `AttributeError`. Happy to switch to the shim if you would rather keep the older shape working.

## Validation

- [x] `make check` - 1210 passed, 1 skipped (1208 passed before this change)
- [x] Relevant manual test performed (if needed)

Two tests in `tests/test_qa_synthesizer_direct_schema.py`, both run against the unpatched file first to confirm they fail for the right reason. The first feeds inputs the heuristic resolves to `approve` while the synthesizer returns `block`, so only the real decision can produce `block`. The second fails if the non-schema path ever stops logging.

## Behavior Impact

- [ ] No behavior change
- [x] Backward compatible behavior change
- [ ] Breaking change (explain below)

## Notes

Worth a look before merge, since this un-deadens two paths rather than just silencing an error:

- `action` is now the synthesizer's judgement instead of the heuristic's. `block` was previously reachable only when the reviewer set `blocking`; it can now come from the synthesizer alone, and `coding_loop.py:765` turns that into `FAILED_UNRECOVERABLE`.
- `stuck` from the synthesizer was always `False`, so `coding_loop.py:687` only ever saw the `_detect_stuck_loop` backstop at `:809`. The synthesizer's own `stuck` signal becomes load-bearing here for the first time.

Both are the behaviour of the code as written, but they are newly live, and by default they are driven by a `haiku`-class model. If you would prefer to land the fix without switching those on in the same change, say so and I will split it.

Written with AI assistance (Claude). I reviewed, tested, and verified the SDK behaviour myself.