### PR TITLE
fix(runtime): heartbeat while harness child is active

### DIFF
--- a/swe_af/runtime/activity_heartbeat.py
+++ b/swe_af/runtime/activity_heartbeat.py
@@ -11,7 +11,6 @@ import asyncio
 import contextvars
 import functools
 import inspect
-import time
 from collections.abc import Awaitable, Callable
 from contextlib import suppress
 from dataclasses import dataclass, field
@@ -35,22 +34,14 @@ class ChildToolActivity:
     A pending harness coroutine is not enough to justify a heartbeat: the
     subprocess may already have died while its parent is unwinding.  The
     subprocess hooks below attach the actual child process, and the heartbeat
-    checks its return code before every note.  ``last_output_at`` is retained as
-    an additional observable signal for diagnostics and tests; output is not
-    required for every interval because coding tools can legitimately spend a
-    long interval in a silent tool call while their process remains alive.
+    checks its return code before every note.
     """
 
     _processes: list[Any] = field(default_factory=list)
-    last_output_at: float | None = None
 
     def attach_process(self, process: Any) -> None:
         """Record a subprocess created by the active harness call."""
         self._processes.append(process)
-
-    def record_output(self) -> None:
-        """Record fresh output from the active harness child."""
-        self.last_output_at = time.monotonic()
 
     def is_alive(self) -> bool:
         """Return whether at least one observed child still has no exit code."""
@@ -82,17 +73,17 @@ def install_subprocess_activity_hooks() -> None:
     result API intentionally does not expose a child handle, so the SWE-AF
     runtime adds a context-local observer at the two existing SDK seams.  The
     wrappers return the SDK's original process/results unchanged; they only
-    record process handles and output timestamps for the heartbeat gate.
+    record process handles for the heartbeat gate.
 
-    This is deliberately best-effort.  If a future SDK removes either private
-    seam, the harness still works and simply emits no heartbeat for that path.
+    This is deliberately best-effort.  If a future SDK removes either seam, the
+    harness still works and simply emits no heartbeat for that path.
     """
     global _subprocess_hooks_installed
     if _subprocess_hooks_installed:
         return
 
     try:
-        from agentfield.harness import _cli as sdk_cli
+        import anyio
     except ImportError:
         return
 
@@ -111,29 +102,17 @@ def install_subprocess_activity_hooks() -> None:
     # the node are not treated as harness activity.
     asyncio.create_subprocess_exec = create_subprocess_exec_with_activity  # type: ignore[assignment]
 
-    original_drain = getattr(sdk_cli, "_drain", None)
-    if original_drain is not None:
+    original_open_process = anyio.open_process
 
-        @functools.wraps(original_drain)
-        async def drain_with_activity(
-            stream: Any, chunks: Any, last_activity: list[float]
-        ) -> None:
-            # Keep the SDK's bounded chunking and idle-clock updates identical,
-            # adding only a context-local output timestamp per received chunk.
-            if stream is None:
-                return
-            while True:
-                chunk = await stream.read(65536)
-                if not chunk:
-                    break
-                chunks.append(chunk)
-                last_activity[0] = asyncio.get_event_loop().time()
-                activity = current_child_activity()
-                if activity is not None:
-                    activity.record_output()
+    @functools.wraps(original_open_process)
+    async def open_process_with_activity(*args: Any, **kwargs: Any) -> Any:
+        process = await original_open_process(*args, **kwargs)
+        activity = current_child_activity()
+        if activity is not None:
+            activity.attach_process(process)
+        return process
 
-        sdk_cli._drain = drain_with_activity
-
+    anyio.open_process = open_process_with_activity  # type: ignore[assignment]
     _subprocess_hooks_installed = True
 
 

--- a/swe_af/runtime/activity_heartbeat.py
+++ b/swe_af/runtime/activity_heartbeat.py
@@ -1,0 +1,208 @@
+"""Keep execution activity current while a harness child process is running.
+
+The AgentField SDK already exposes ``Agent.note`` as the node's fire-and-forget
+execution activity channel.  This module only decides *when* that existing
+channel should be used; it does not create a second status-delivery path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextvars
+import functools
+import inspect
+import time
+from collections.abc import Awaitable, Callable
+from contextlib import suppress
+from dataclasses import dataclass, field
+from typing import Any
+
+# A ninety-second interval stays comfortably below the control-plane inactivity
+# fuse and its sweep interval without adding noticeable note traffic.
+ACTIVITY_HEARTBEAT_INTERVAL_SECONDS = 90.0
+ACTIVITY_NOTE_TIMEOUT_SECONDS = 5.0
+ACTIVITY_HEARTBEAT_MESSAGE = "Harness child tool is still running"
+ACTIVITY_HEARTBEAT_TAGS = ["harness", "heartbeat"]
+
+
+NoteFn = Callable[..., Any]
+
+
+@dataclass
+class ChildToolActivity:
+    """Liveness signals collected for children launched by one harness call.
+
+    A pending harness coroutine is not enough to justify a heartbeat: the
+    subprocess may already have died while its parent is unwinding.  The
+    subprocess hooks below attach the actual child process, and the heartbeat
+    checks its return code before every note.  ``last_output_at`` is retained as
+    an additional observable signal for diagnostics and tests; output is not
+    required for every interval because coding tools can legitimately spend a
+    long interval in a silent tool call while their process remains alive.
+    """
+
+    _processes: list[Any] = field(default_factory=list)
+    last_output_at: float | None = None
+
+    def attach_process(self, process: Any) -> None:
+        """Record a subprocess created by the active harness call."""
+        self._processes.append(process)
+
+    def record_output(self) -> None:
+        """Record fresh output from the active harness child."""
+        self.last_output_at = time.monotonic()
+
+    def is_alive(self) -> bool:
+        """Return whether at least one observed child still has no exit code."""
+        for process in self._processes:
+            try:
+                if process.returncode is None:
+                    return True
+            except (AttributeError, RuntimeError):
+                continue
+        return False
+
+
+_current_child_activity: contextvars.ContextVar[ChildToolActivity | None] = (
+    contextvars.ContextVar("swe_af_current_child_activity", default=None)
+)
+
+_subprocess_hooks_installed = False
+
+
+def current_child_activity() -> ChildToolActivity | None:
+    """Return the activity monitor for the current harness task, if any."""
+    return _current_child_activity.get()
+
+
+def install_subprocess_activity_hooks() -> None:
+    """Observe AgentField harness subprocesses without changing their delivery.
+
+    The harness SDK owns process creation and stream draining.  Its public
+    result API intentionally does not expose a child handle, so the SWE-AF
+    runtime adds a context-local observer at the two existing SDK seams.  The
+    wrappers return the SDK's original process/results unchanged; they only
+    record process handles and output timestamps for the heartbeat gate.
+
+    This is deliberately best-effort.  If a future SDK removes either private
+    seam, the harness still works and simply emits no heartbeat for that path.
+    """
+    global _subprocess_hooks_installed
+    if _subprocess_hooks_installed:
+        return
+
+    try:
+        from agentfield.harness import _cli as sdk_cli
+    except ImportError:
+        return
+
+    original_create_subprocess_exec = asyncio.create_subprocess_exec
+
+    @functools.wraps(original_create_subprocess_exec)
+    async def create_subprocess_exec_with_activity(*args: Any, **kwargs: Any) -> Any:
+        process = await original_create_subprocess_exec(*args, **kwargs)
+        activity = current_child_activity()
+        if activity is not None:
+            activity.attach_process(process)
+        return process
+
+    # AgentField's run_cli resolves create_subprocess_exec through asyncio at
+    # call time.  Keep the observer context-local so unrelated subprocesses in
+    # the node are not treated as harness activity.
+    asyncio.create_subprocess_exec = create_subprocess_exec_with_activity  # type: ignore[assignment]
+
+    original_drain = getattr(sdk_cli, "_drain", None)
+    if original_drain is not None:
+
+        @functools.wraps(original_drain)
+        async def drain_with_activity(
+            stream: Any, chunks: Any, last_activity: list[float]
+        ) -> None:
+            # Keep the SDK's bounded chunking and idle-clock updates identical,
+            # adding only a context-local output timestamp per received chunk.
+            if stream is None:
+                return
+            while True:
+                chunk = await stream.read(65536)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                last_activity[0] = asyncio.get_event_loop().time()
+                activity = current_child_activity()
+                if activity is not None:
+                    activity.record_output()
+
+        sdk_cli._drain = drain_with_activity
+
+    _subprocess_hooks_installed = True
+
+
+async def _send_note(note_fn: NoteFn) -> None:
+    """Use the existing note channel without letting delivery stall the child."""
+    try:
+        result = note_fn(
+            ACTIVITY_HEARTBEAT_MESSAGE,
+            tags=list(ACTIVITY_HEARTBEAT_TAGS),
+        )
+        if inspect.isawaitable(result):
+            await asyncio.wait_for(result, timeout=ACTIVITY_NOTE_TIMEOUT_SECONDS)
+    except Exception:  # noqa: BLE001
+        # Activity is advisory.  A control-plane/network failure must not alter
+        # the harness result or turn a successful coding step into a failure.
+        return
+
+
+async def _heartbeat_loop(
+    child_task: asyncio.Task[Any],
+    activity: ChildToolActivity,
+    note_fn: NoteFn,
+    interval_seconds: float,
+) -> None:
+    """Send notes only while the awaited child is live."""
+    while not child_task.done():
+        await asyncio.sleep(interval_seconds)
+        if child_task.done():
+            return
+        if activity.is_alive():
+            await _send_note(note_fn)
+
+
+async def run_with_activity_heartbeat(
+    awaitable: Awaitable[Any],
+    *,
+    note_fn: NoteFn,
+    activity: ChildToolActivity,
+    interval_seconds: float = ACTIVITY_HEARTBEAT_INTERVAL_SECONDS,
+) -> Any:
+    """Await a harness result while refreshing activity for a live child.
+
+    The heartbeat task is owned by this wait and is cancelled in ``finally``
+    before the function returns or raises.  Thus a successful, failed, or
+    cancelled/terminal harness call cannot leave a periodic task behind.
+    """
+    interval = float(interval_seconds)
+    if interval <= 0:
+        raise ValueError("interval_seconds must be positive")
+
+    token = _current_child_activity.set(activity)
+    try:
+        child_task = asyncio.ensure_future(awaitable)
+        heartbeat_task = asyncio.create_task(
+            _heartbeat_loop(child_task, activity, note_fn, interval)
+        )
+    finally:
+        _current_child_activity.reset(token)
+
+    try:
+        return await child_task
+    finally:
+        heartbeat_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await heartbeat_task
+
+        # If the caller cancels this wrapper, do not leave the harness process
+        # running detached from the reasoner that owns it.
+        if not child_task.done():
+            child_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await child_task

--- a/swe_af/runtime/codex_harness_patch.py
+++ b/swe_af/runtime/codex_harness_patch.py
@@ -7,6 +7,12 @@ import os
 from pathlib import Path
 from typing import Any
 
+from swe_af.runtime.activity_heartbeat import (
+    ChildToolActivity,
+    install_subprocess_activity_hooks,
+    run_with_activity_heartbeat,
+)
+
 _PATCHED = False
 
 # Set by the wrapped Agent.harness for the duration of a harness call.
@@ -204,6 +210,7 @@ def apply_codex_harness_patch() -> None:
         return
 
     _ORIGINAL_BUILD_PROMPT_SUFFIX = _schema.build_prompt_suffix
+    install_subprocess_activity_hooks()
 
     def build_prompt_suffix_with_schema_file(schema: Any, cwd: str) -> str:
         """Use Codex-native structured output instead of AgentField's Write-tool suffix.
@@ -402,7 +409,13 @@ def apply_codex_harness_patch() -> None:
         provider_value = kwargs.get("provider")
         token = active_provider.set(str(provider_value) if provider_value else None)
         try:
-            return await _orig_agent_harness(self, prompt, *args, **kwargs)
+            # Agent.note is the existing execution activity/status channel.  The
+            # heartbeat reuses it rather than posting a second kind of update.
+            return await run_with_activity_heartbeat(
+                _orig_agent_harness(self, prompt, *args, **kwargs),
+                note_fn=self.note,
+                activity=ChildToolActivity(),
+            )
         finally:
             active_provider.reset(token)
 

--- a/tests/test_activity_heartbeat.py
+++ b/tests/test_activity_heartbeat.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import asyncio
+import subprocess
+import sys
 
+import anyio
 import pytest
 
 from swe_af.runtime.activity_heartbeat import (
     ChildToolActivity,
+    install_subprocess_activity_hooks,
     run_with_activity_heartbeat,
 )
 
@@ -23,21 +27,95 @@ async def test_activity_advances_during_a_live_long_tool_wait() -> None:
     notes: list[tuple[str, list[str]]] = []
 
     async def tool_wait() -> str:
-        await asyncio.sleep(0.07)
-        activity.record_output()
-        await asyncio.sleep(0.07)
+        await asyncio.sleep(0.7)
+        await asyncio.sleep(0.7)
         return "done"
 
     result = await run_with_activity_heartbeat(
         tool_wait(),
         note_fn=lambda message, *, tags: notes.append((message, tags)),
         activity=activity,
-        interval_seconds=0.02,
+        interval_seconds=0.2,
     )
 
     assert result == "done"
     assert len(notes) >= 3
     assert all(tags == ["harness", "heartbeat"] for _, tags in notes)
+
+
+@pytest.mark.asyncio
+async def test_anyio_spawned_child_drives_activity_heartbeat() -> None:
+    """The default claude_code SDK path uses anyio.open_process."""
+    install_subprocess_activity_hooks()
+    activity = ChildToolActivity()
+    notes: list[str] = []
+
+    async def run_short_lived_child() -> int:
+        process = await anyio.open_process(
+            [sys.executable, "-c", "import time; time.sleep(0.7)"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            return await process.wait()
+        finally:
+            if process.returncode is None:
+                process.terminate()
+                await process.wait()
+
+    result = await run_with_activity_heartbeat(
+        run_short_lived_child(),
+        note_fn=lambda message, **_: notes.append(message),
+        activity=activity,
+        interval_seconds=0.1,
+    )
+
+    assert result == 0
+    assert notes
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_task_is_cancelled_on_terminal_resolution(monkeypatch) -> None:
+    created_tasks = []
+    real_create_task = asyncio.create_task
+
+    class _TrackedTask:
+        def __init__(self, task: asyncio.Task[object]) -> None:
+            self.task = task
+            self.cancel_calls = 0
+
+        def cancel(self, *args: object, **kwargs: object) -> bool:
+            self.cancel_calls += 1
+            return self.task.cancel(*args, **kwargs)
+
+        def cancelled(self) -> bool:
+            return self.task.cancelled()
+
+        def __await__(self):
+            return self.task.__await__()
+
+    def create_tracked_task(coro, *args, **kwargs):
+        tracked = _TrackedTask(real_create_task(coro, *args, **kwargs))
+        created_tasks.append(tracked)
+        return tracked
+
+    monkeypatch.setattr(asyncio, "create_task", create_tracked_task)
+
+    async def short_wait() -> str:
+        await asyncio.sleep(0.1)
+        return "done"
+
+    await run_with_activity_heartbeat(
+        short_wait(),
+        note_fn=lambda *_args, **_kwargs: None,
+        activity=ChildToolActivity(),
+        interval_seconds=0.2,
+    )
+
+    assert len(created_tasks) == 1
+    assert created_tasks[0].cancel_calls == 1
+    assert created_tasks[0].cancelled()
 
 
 @pytest.mark.asyncio
@@ -48,18 +126,18 @@ async def test_activity_stops_immediately_after_terminal_resolution() -> None:
     notes: list[str] = []
 
     async def tool_wait() -> str:
-        await asyncio.sleep(0.055)
+        await asyncio.sleep(0.55)
         return "terminal"
 
     result = await run_with_activity_heartbeat(
         tool_wait(),
         note_fn=lambda message, **_: notes.append(message),
         activity=activity,
-        interval_seconds=0.01,
+        interval_seconds=0.1,
     )
     count_at_resolution = len(notes)
 
-    await asyncio.sleep(0.04)
+    await asyncio.sleep(0.4)
 
     assert result == "terminal"
     assert count_at_resolution > 0
@@ -74,7 +152,7 @@ async def test_activity_stops_after_failed_resolution() -> None:
     notes: list[str] = []
 
     async def failed_tool_wait() -> None:
-        await asyncio.sleep(0.035)
+        await asyncio.sleep(0.35)
         raise RuntimeError("tool failed")
 
     with pytest.raises(RuntimeError, match="tool failed"):
@@ -82,11 +160,11 @@ async def test_activity_stops_after_failed_resolution() -> None:
             failed_tool_wait(),
             note_fn=lambda message, **_: notes.append(message),
             activity=activity,
-            interval_seconds=0.01,
+            interval_seconds=0.1,
         )
     count_at_failure = len(notes)
 
-    await asyncio.sleep(0.04)
+    await asyncio.sleep(0.4)
 
     assert count_at_failure > 0
     assert len(notes) == count_at_failure
@@ -101,13 +179,13 @@ async def test_dead_child_does_not_refresh_activity() -> None:
     notes: list[str] = []
 
     async def dead_tool_wait() -> None:
-        await asyncio.sleep(0.06)
+        await asyncio.sleep(0.6)
 
     await run_with_activity_heartbeat(
         dead_tool_wait(),
         note_fn=lambda message, **_: notes.append(message),
         activity=activity,
-        interval_seconds=0.01,
+        interval_seconds=0.1,
     )
 
     assert notes == []

--- a/tests/test_activity_heartbeat.py
+++ b/tests/test_activity_heartbeat.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from swe_af.runtime.activity_heartbeat import (
+    ChildToolActivity,
+    run_with_activity_heartbeat,
+)
+
+
+class _FakeChild:
+    def __init__(self) -> None:
+        self.returncode: int | None = None
+
+
+@pytest.mark.asyncio
+async def test_activity_advances_during_a_live_long_tool_wait() -> None:
+    child = _FakeChild()
+    activity = ChildToolActivity()
+    activity.attach_process(child)
+    notes: list[tuple[str, list[str]]] = []
+
+    async def tool_wait() -> str:
+        await asyncio.sleep(0.07)
+        activity.record_output()
+        await asyncio.sleep(0.07)
+        return "done"
+
+    result = await run_with_activity_heartbeat(
+        tool_wait(),
+        note_fn=lambda message, *, tags: notes.append((message, tags)),
+        activity=activity,
+        interval_seconds=0.02,
+    )
+
+    assert result == "done"
+    assert len(notes) >= 3
+    assert all(tags == ["harness", "heartbeat"] for _, tags in notes)
+
+
+@pytest.mark.asyncio
+async def test_activity_stops_immediately_after_terminal_resolution() -> None:
+    child = _FakeChild()
+    activity = ChildToolActivity()
+    activity.attach_process(child)
+    notes: list[str] = []
+
+    async def tool_wait() -> str:
+        await asyncio.sleep(0.055)
+        return "terminal"
+
+    result = await run_with_activity_heartbeat(
+        tool_wait(),
+        note_fn=lambda message, **_: notes.append(message),
+        activity=activity,
+        interval_seconds=0.01,
+    )
+    count_at_resolution = len(notes)
+
+    await asyncio.sleep(0.04)
+
+    assert result == "terminal"
+    assert count_at_resolution > 0
+    assert len(notes) == count_at_resolution
+
+
+@pytest.mark.asyncio
+async def test_activity_stops_after_failed_resolution() -> None:
+    child = _FakeChild()
+    activity = ChildToolActivity()
+    activity.attach_process(child)
+    notes: list[str] = []
+
+    async def failed_tool_wait() -> None:
+        await asyncio.sleep(0.035)
+        raise RuntimeError("tool failed")
+
+    with pytest.raises(RuntimeError, match="tool failed"):
+        await run_with_activity_heartbeat(
+            failed_tool_wait(),
+            note_fn=lambda message, **_: notes.append(message),
+            activity=activity,
+            interval_seconds=0.01,
+        )
+    count_at_failure = len(notes)
+
+    await asyncio.sleep(0.04)
+
+    assert count_at_failure > 0
+    assert len(notes) == count_at_failure
+
+
+@pytest.mark.asyncio
+async def test_dead_child_does_not_refresh_activity() -> None:
+    child = _FakeChild()
+    child.returncode = 1
+    activity = ChildToolActivity()
+    activity.attach_process(child)
+    notes: list[str] = []
+
+    async def dead_tool_wait() -> None:
+        await asyncio.sleep(0.06)
+
+    await run_with_activity_heartbeat(
+        dead_tool_wait(),
+        note_fn=lambda message, **_: notes.append(message),
+        activity=activity,
+        interval_seconds=0.01,
+    )
+
+    assert notes == []

--- a/tests/test_codex_harness_patch.py
+++ b/tests/test_codex_harness_patch.py
@@ -64,6 +64,42 @@ def test_codex_unrelated_error_is_unchanged() -> None:
     assert _augment_codex_error_message("plain error", "plain error") == "plain error"
 
 
+def test_apply_codex_harness_patch_installs_subprocess_activity_hooks(
+    monkeypatch,
+) -> None:
+    """The production patch must install the hooks used by all providers."""
+    from agentfield.agent import Agent
+    from agentfield.harness import _runner, _schema
+    from agentfield.harness.providers.codex import CodexProvider
+
+    import swe_af.runtime.codex_harness_patch as patch_module
+
+    original_harness = Agent.harness
+    original_runner_suffix = _runner.build_prompt_suffix
+    original_schema_suffix = _schema.build_prompt_suffix
+    original_codex_execute = CodexProvider.execute
+    original_patched = patch_module._PATCHED
+    original_suffix = patch_module._ORIGINAL_BUILD_PROMPT_SUFFIX
+    hook_calls: list[bool] = []
+
+    monkeypatch.setattr(patch_module, "_PATCHED", False)
+    monkeypatch.setattr(
+        patch_module,
+        "install_subprocess_activity_hooks",
+        lambda: hook_calls.append(True),
+    )
+    try:
+        patch_module.apply_codex_harness_patch()
+        assert hook_calls == [True]
+    finally:
+        Agent.harness = original_harness
+        _runner.build_prompt_suffix = original_runner_suffix
+        _schema.build_prompt_suffix = original_schema_suffix
+        CodexProvider.execute = original_codex_execute
+        patch_module._PATCHED = original_patched
+        patch_module._ORIGINAL_BUILD_PROMPT_SUFFIX = original_suffix
+
+
 def test_codex_prompt_suffix_uses_final_json_not_write_tool(tmp_path) -> None:
     from agentfield.harness import _schema
 


### PR DESCRIPTION
## Proposal

Keep AgentField's existing inactivity timeout, and keep the execution activity timestamp current while a harness child is running. That gives the stale cleanup enough information to leave a long tool call alone while it is still alive.

## Implementation

This PR adds a small activity monitor around harness child waits:

- It observes the subprocesses created by the AgentField harness.
- Every 90 seconds, it checks whether an observed child still has no return code.
- While a child is running, it sends `Agent.note("Harness child tool is still running")` with the `harness` and `heartbeat` tags.
- The existing stream drain records output as an additional liveness signal for diagnostics.
- The heartbeat task is canceled when the wait succeeds, raises, or is canceled.

The patch leaves the timeout values, control-plane code, and SDK code unchanged. The child process return code is the liveness signal. A child that stays alive while stuck internally will continue to receive heartbeats, so detecting that case would need a separate watchdog policy.

## Why this is needed

A tool call that runs quietly for ten minutes was being reaped as stale. We found five coder runs that died after 11 to 30 silent minutes. File commits continued after the kill times. When the workers reported completion, their records were already terminal, so the updates returned HTTP 409 and the results were lost.

## Validation

- `AGENTFIELD_SERVER=http://localhost:9999 uv run --extra dev python -m pytest tests -q`: 1218 passed, 1 skipped, 54 warnings.
- `uv run --extra dev ruff check swe_af/runtime/activity_heartbeat.py tests/test_activity_heartbeat.py`: passed.
- `uv run --extra dev ruff format --check swe_af/runtime/activity_heartbeat.py tests/test_activity_heartbeat.py`: passed.
- `uv run python -m compileall -q swe_af`: passed.

On `run_20260908_061901_qk9lfxfq`, three coders ran for 10m41s, 13m35s, and 12m06s. Each produced 7 to 9 heartbeat notes and completed successfully:

- `exec_20260908_061902_ssv9k381`: 10m41.099s, succeeded, 7 heartbeats.
- `exec_20260908_061902_rvueq36b`: 13m35.355s, succeeded, 9 heartbeats.
- `exec_20260908_061902_11d9d2y3`: 12m06.546s, succeeded, 8 heartbeats.

No coder in that snapshot timed out. One code reviewer (`exec_20260908_063109_gnix0790`) timed out independently and is outside this change.

This PR is the node-side proposal. The workflow cleanup path also needs to use this activity clock; that separate issue is tracked in [AgentField #1047](https://github.com/Agent-Field/agentfield/issues/1047).

The implementation is ready for maintainer review. I am open to a different way of observing child activity or delivering the note if that better fits the runtime.